### PR TITLE
MessagePack encoder and decoder for aggregated metrics

### DIFF
--- a/metric/aggregated/types.go
+++ b/metric/aggregated/types.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/m3db/m3metrics/metric"
+	"github.com/m3db/m3metrics/policy"
 )
 
 // Metric is a metric, which is essentially a named value at certain time.
@@ -53,4 +54,16 @@ type RawMetric interface {
 
 	// Reset resets the raw data
 	Reset(data []byte)
+}
+
+// MetricWithPolicy is a metric with applicable policy
+type MetricWithPolicy struct {
+	Metric
+	policy.Policy
+}
+
+// RawMetricWithPolicy is a raw metric with applicable policy
+type RawMetricWithPolicy struct {
+	RawMetric
+	policy.Policy
 }

--- a/metric/aggregated/types.go
+++ b/metric/aggregated/types.go
@@ -18,39 +18,39 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package msgpack
+package aggregated
 
 import (
-	"bytes"
+	"time"
 
-	msgpack "gopkg.in/vmihailenco/msgpack.v2"
+	"github.com/m3db/m3metrics/metric"
 )
 
-// newBufferedEncoder creates a new buffered encoder
-func newBufferedEncoder() BufferedEncoder {
-	return NewPooledBufferedEncoder(nil)
+// Metric is a metric, which is essentially a named value at certain time.
+type Metric struct {
+	ID        metric.ID
+	Timestamp time.Time
+	Value     float64
 }
 
-// NewPooledBufferedEncoder creates a new pooled buffered encoder
-func NewPooledBufferedEncoder(p BufferedEncoderPool) BufferedEncoder {
-	buffer := bytes.NewBuffer(nil)
+// RawMetric is a metric in its raw form (e.g., encoded bytes associated with
+// a metric object)
+type RawMetric interface {
+	// ID is the metric identifier
+	ID() (metric.ID, error)
 
-	return BufferedEncoder{
-		Encoder: msgpack.NewEncoder(buffer),
-		Buffer:  buffer,
-		pool:    p,
-	}
-}
+	// Timestamp is the metric timestamp
+	Timestamp() (time.Time, error)
 
-// Bytes returns the buffer data
-func (enc BufferedEncoder) Bytes() []byte { return enc.Buffer.Bytes() }
+	// Value is the metric value
+	Value() (float64, error)
 
-// Reset resets the buffered encoder
-func (enc BufferedEncoder) Reset() { enc.Buffer.Truncate(0) }
+	// Metric is the metric object represented by the raw metric
+	Metric() (Metric, error)
 
-// Close returns the buffered encoder to the pool if possible
-func (enc BufferedEncoder) Close() {
-	if enc.pool != nil {
-		enc.pool.Put(enc)
-	}
+	// Bytes are the bytes backing this raw metric
+	Bytes() []byte
+
+	// Reset resets the raw data
+	Reset(data []byte)
 }

--- a/metric/unaggregated/types.go
+++ b/metric/unaggregated/types.go
@@ -20,7 +20,10 @@
 
 package unaggregated
 
-import "github.com/m3db/m3metrics/metric"
+import (
+	"github.com/m3db/m3metrics/metric"
+	"github.com/m3db/m3metrics/policy"
+)
 
 // Type is a metric type
 type Type int8
@@ -49,6 +52,24 @@ type BatchTimer struct {
 type Gauge struct {
 	ID    metric.ID
 	Value float64
+}
+
+// CounterWithPolicies is a counter with applicable policies
+type CounterWithPolicies struct {
+	Counter
+	policy.VersionedPolicies
+}
+
+// BatchTimerWithPolicies is a batch timer with applicable policies
+type BatchTimerWithPolicies struct {
+	BatchTimer
+	policy.VersionedPolicies
+}
+
+// GaugeWithPolicies is a gauge with applicable policies
+type GaugeWithPolicies struct {
+	Gauge
+	policy.VersionedPolicies
 }
 
 // MetricUnion is a union of different types of metrics, only one of which is valid

--- a/protocol/msgpack/aggregated_encoder.go
+++ b/protocol/msgpack/aggregated_encoder.go
@@ -1,0 +1,111 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package msgpack
+
+import (
+	"github.com/m3db/m3metrics/metric/aggregated"
+	"github.com/m3db/m3metrics/policy"
+)
+
+type encodeRawMetricWithPolicyFn func(data []byte, p policy.Policy)
+type encodeRawMetricFn func(data []byte)
+type encodeMetricAsRawFn func(m aggregated.Metric) []byte
+
+// aggregatedEncoder uses MessagePack for encoding aggregated metrics.
+// It is not thread-safe.
+type aggregatedEncoder struct {
+	encoderBase
+
+	buf                         encoderBase                 // buffer for encoding metrics
+	encodeRootObjectFn          encodeRootObjectFn          // root object encoding function
+	encodeRawMetricWithPolicyFn encodeRawMetricWithPolicyFn // raw metric with policy encoding function
+	encodeRawMetricFn           encodeRawMetricFn           // raw metric encoding function
+	encodeMetricAsRawFn         encodeMetricAsRawFn         // metric to raw metric conversion function
+}
+
+// NewAggregatedEncoder creates an aggregated encoder
+func NewAggregatedEncoder(encoder BufferedEncoder) AggregatedEncoder {
+	enc := &aggregatedEncoder{
+		encoderBase: newBaseEncoder(encoder),
+		buf:         newBaseEncoder(newBufferedEncoder()),
+	}
+
+	enc.encodeRootObjectFn = enc.encodeRootObject
+	enc.encodeRawMetricWithPolicyFn = enc.encodeRawMetricWithPolicy
+	enc.encodeRawMetricFn = enc.encodeRawMetric
+	enc.encodeMetricAsRawFn = enc.encodeMetricAsRaw
+
+	return enc
+}
+
+func (enc *aggregatedEncoder) Encoder() BufferedEncoder      { return enc.encoder() }
+func (enc *aggregatedEncoder) Reset(encoder BufferedEncoder) { enc.reset(encoder) }
+
+// NB(xichen): we encode metric as a raw metric so the decoder can inspect the encoded byte stream
+// and apply filters to the encode bytes as needed without fully decoding the entire payload
+func (enc *aggregatedEncoder) EncodeMetricWithPolicy(m aggregated.Metric, p policy.Policy) error {
+	if err := enc.err(); err != nil {
+		return err
+	}
+	enc.encodeRootObjectFn(rawMetricWithPolicyType)
+	data := enc.encodeMetricAsRawFn(m)
+	enc.encodeRawMetricWithPolicyFn(data, p)
+	return enc.err()
+}
+
+func (enc *aggregatedEncoder) EncodeRawMetricWithPolicy(m aggregated.RawMetric, p policy.Policy) error {
+	if err := enc.err(); err != nil {
+		return err
+	}
+	enc.encodeRootObjectFn(rawMetricWithPolicyType)
+	enc.encodeRawMetricWithPolicyFn(m.Bytes(), p)
+	return enc.err()
+}
+
+func (enc *aggregatedEncoder) encodeRootObject(objType objectType) {
+	enc.encodeVersion(aggregatedVersion)
+	enc.encodeNumObjectFields(numFieldsForType(rootObjectType))
+	enc.encodeObjectType(objType)
+}
+
+// NB(xichen): we do not encode the number of object fields here because the metric
+// is encoded as raw bytes in the payload, which means each metric is decoded individually
+// rather than in a streaming fashion. As a result we can safely make backward-compatible
+// changes (e.g., encode one more field at the end) without needing the number of object
+// fields.
+func (enc *aggregatedEncoder) encodeMetricAsRaw(m aggregated.Metric) []byte {
+	enc.buf.resetData()
+	enc.buf.encodeVersion(metricVersion)
+	enc.buf.encodeID(m.ID)
+	enc.buf.encodeTime(m.Timestamp)
+	enc.buf.encodeFloat64(m.Value)
+	return enc.buf.encoder().Bytes()
+}
+
+func (enc *aggregatedEncoder) encodeRawMetricWithPolicy(data []byte, p policy.Policy) {
+	enc.encodeNumObjectFields(numFieldsForType(rawMetricWithPolicyType))
+	enc.encodeRawMetricFn(data)
+	enc.encodePolicy(p)
+}
+
+func (enc *aggregatedEncoder) encodeRawMetric(data []byte) {
+	enc.encodeBytes(data)
+}

--- a/protocol/msgpack/aggregated_encoder.go
+++ b/protocol/msgpack/aggregated_encoder.go
@@ -86,14 +86,10 @@ func (enc *aggregatedEncoder) encodeRootObject(objType objectType) {
 	enc.encodeObjectType(objType)
 }
 
-// NB(xichen): we do not encode the number of object fields here because the metric
-// is encoded as raw bytes in the payload, which means each metric is decoded individually
-// rather than in a streaming fashion. As a result we can safely make backward-compatible
-// changes (e.g., encode one more field at the end) without needing the number of object
-// fields.
 func (enc *aggregatedEncoder) encodeMetricAsRaw(m aggregated.Metric) []byte {
 	enc.buf.resetData()
 	enc.buf.encodeVersion(metricVersion)
+	enc.buf.encodeNumObjectFields(numFieldsForType(metricType))
 	enc.buf.encodeID(m.ID)
 	enc.buf.encodeTime(m.Timestamp)
 	enc.buf.encodeFloat64(m.Value)

--- a/protocol/msgpack/aggregated_encoder.go
+++ b/protocol/msgpack/aggregated_encoder.go
@@ -61,22 +61,22 @@ func (enc *aggregatedEncoder) Reset(encoder BufferedEncoder) { enc.reset(encoder
 
 // NB(xichen): we encode metric as a raw metric so the decoder can inspect the encoded byte stream
 // and apply filters to the encode bytes as needed without fully decoding the entire payload
-func (enc *aggregatedEncoder) EncodeMetricWithPolicy(m aggregated.Metric, p policy.Policy) error {
+func (enc *aggregatedEncoder) EncodeMetricWithPolicy(mp aggregated.MetricWithPolicy) error {
 	if err := enc.err(); err != nil {
 		return err
 	}
 	enc.encodeRootObjectFn(rawMetricWithPolicyType)
-	data := enc.encodeMetricAsRawFn(m)
-	enc.encodeRawMetricWithPolicyFn(data, p)
+	data := enc.encodeMetricAsRawFn(mp.Metric)
+	enc.encodeRawMetricWithPolicyFn(data, mp.Policy)
 	return enc.err()
 }
 
-func (enc *aggregatedEncoder) EncodeRawMetricWithPolicy(m aggregated.RawMetric, p policy.Policy) error {
+func (enc *aggregatedEncoder) EncodeRawMetricWithPolicy(rp aggregated.RawMetricWithPolicy) error {
 	if err := enc.err(); err != nil {
 		return err
 	}
 	enc.encodeRootObjectFn(rawMetricWithPolicyType)
-	enc.encodeRawMetricWithPolicyFn(m.Bytes(), p)
+	enc.encodeRawMetricWithPolicyFn(rp.RawMetric.Bytes(), rp.Policy)
 	return enc.err()
 }
 

--- a/protocol/msgpack/aggregated_encoder_test.go
+++ b/protocol/msgpack/aggregated_encoder_test.go
@@ -97,7 +97,7 @@ func TestAggregatedEncodeMetric(t *testing.T) {
 
 func TestAggregatedEncodeMetricWithPolicy(t *testing.T) {
 	encoder, results := testCapturingAggregatedEncoder(t)
-	require.NoError(t, encoder.EncodeMetricWithPolicy(testMetric, testPolicy))
+	require.NoError(t, testAggregatedEncode(t, encoder, testMetric, testPolicy))
 	expected := expectedResultsForAggregatedMetricWithPolicy(t, testMetric, testPolicy)
 	require.Equal(t, expected, *results)
 }
@@ -105,7 +105,7 @@ func TestAggregatedEncodeMetricWithPolicy(t *testing.T) {
 func TestAggregatedEncodeRawMetricWithPolicy(t *testing.T) {
 	encoder, results := testCapturingAggregatedEncoder(t)
 	rawMetric := toRawMetric(t, testMetric)
-	require.NoError(t, encoder.EncodeRawMetricWithPolicy(rawMetric, testPolicy))
+	require.NoError(t, testAggregatedEncode(t, encoder, rawMetric, testPolicy))
 	expected := expectedResultsForAggregatedMetricWithPolicy(t, rawMetric, testPolicy)
 	require.Equal(t, expected, *results)
 }
@@ -119,8 +119,8 @@ func TestAggregatedEncodeError(t *testing.T) {
 	}
 
 	// Assert the error is expected
-	require.Equal(t, errTestVarint, encoder.EncodeMetricWithPolicy(testMetric, testPolicy))
+	require.Equal(t, errTestVarint, testAggregatedEncode(t, encoder, testMetric, testPolicy))
 
 	// Assert re-encoding doesn't change the error
-	require.Equal(t, errTestVarint, encoder.EncodeMetricWithPolicy(testMetric, testPolicy))
+	require.Equal(t, errTestVarint, testAggregatedEncode(t, encoder, testMetric, testPolicy))
 }

--- a/protocol/msgpack/aggregated_encoder_test.go
+++ b/protocol/msgpack/aggregated_encoder_test.go
@@ -1,0 +1,126 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package msgpack
+
+import (
+	"testing"
+
+	"github.com/m3db/m3metrics/metric/aggregated"
+	"github.com/m3db/m3metrics/policy"
+
+	"github.com/stretchr/testify/require"
+)
+
+func testCapturingBaseEncoder(encoder encoderBase) *[]interface{} {
+	baseEncoder := encoder.(*baseEncoder)
+
+	var result []interface{}
+	baseEncoder.encodeVarintFn = func(value int64) {
+		result = append(result, value)
+	}
+	baseEncoder.encodeFloat64Fn = func(value float64) {
+		result = append(result, value)
+	}
+	baseEncoder.encodeBytesFn = func(value []byte) {
+		result = append(result, value)
+	}
+	baseEncoder.encodeArrayLenFn = func(value int) {
+		result = append(result, value)
+	}
+
+	return &result
+}
+
+func testCapturingAggregatedEncoder(t *testing.T) (AggregatedEncoder, *[]interface{}) {
+	encoder := testAggregatedEncoder(t).(*aggregatedEncoder)
+	result := testCapturingBaseEncoder(encoder.encoderBase)
+	return encoder, result
+}
+
+func expectedResultsForRawMetricWithPolicy(t *testing.T, m aggregated.RawMetric, p policy.Policy) []interface{} {
+	results := []interface{}{
+		numFieldsForType(rawMetricWithPolicyType),
+		m.Bytes(),
+	}
+	results = append(results, expectedResultsForPolicy(t, p)...)
+	return results
+}
+
+func expectedResultsForAggregatedMetricWithPolicy(t *testing.T, m interface{}, p policy.Policy) []interface{} {
+	results := []interface{}{
+		int64(aggregatedVersion),
+		numFieldsForType(rootObjectType),
+		int64(rawMetricWithPolicyType),
+	}
+	switch m := m.(type) {
+	case aggregated.Metric:
+		rm := toRawMetric(t, m)
+		results = append(results, expectedResultsForRawMetricWithPolicy(t, rm, p)...)
+	case aggregated.RawMetric:
+		results = append(results, expectedResultsForRawMetricWithPolicy(t, m, p)...)
+	default:
+		require.Fail(t, "unrecognized input type %T", m)
+	}
+	return results
+}
+
+func TestAggregatedEncodeMetric(t *testing.T) {
+	encoder := testAggregatedEncoder(t).(*aggregatedEncoder)
+	result := testCapturingBaseEncoder(encoder.buf)
+	encoder.encodeMetricAsRaw(testMetric)
+	expected := []interface{}{
+		int64(metricVersion),
+		[]byte(testMetric.ID),
+		int64(testMetric.Timestamp.UnixNano()),
+		testMetric.Value,
+	}
+	require.Equal(t, expected, *result)
+}
+
+func TestAggregatedEncodeMetricWithPolicy(t *testing.T) {
+	encoder, results := testCapturingAggregatedEncoder(t)
+	require.NoError(t, encoder.EncodeMetricWithPolicy(testMetric, testPolicy))
+	expected := expectedResultsForAggregatedMetricWithPolicy(t, testMetric, testPolicy)
+	require.Equal(t, expected, *results)
+}
+
+func TestAggregatedEncodeRawMetricWithPolicy(t *testing.T) {
+	encoder, results := testCapturingAggregatedEncoder(t)
+	rawMetric := toRawMetric(t, testMetric)
+	require.NoError(t, encoder.EncodeRawMetricWithPolicy(rawMetric, testPolicy))
+	expected := expectedResultsForAggregatedMetricWithPolicy(t, rawMetric, testPolicy)
+	require.Equal(t, expected, *results)
+}
+
+func TestAggregatedEncodeError(t *testing.T) {
+	// Intentionally return an error when encoding varint
+	encoder := testAggregatedEncoder(t).(*aggregatedEncoder)
+	baseEncoder := encoder.encoderBase.(*baseEncoder)
+	baseEncoder.encodeVarintFn = func(value int64) {
+		baseEncoder.encodeErr = errTestVarint
+	}
+
+	// Assert the error is expected
+	require.Equal(t, errTestVarint, encoder.EncodeMetricWithPolicy(testMetric, testPolicy))
+
+	// Assert re-encoding doesn't change the error
+	require.Equal(t, errTestVarint, encoder.EncodeMetricWithPolicy(testMetric, testPolicy))
+}

--- a/protocol/msgpack/aggregated_encoder_test.go
+++ b/protocol/msgpack/aggregated_encoder_test.go
@@ -88,6 +88,7 @@ func TestAggregatedEncodeMetric(t *testing.T) {
 	encoder.encodeMetricAsRaw(testMetric)
 	expected := []interface{}{
 		int64(metricVersion),
+		int(numFieldsForType(metricType)),
 		[]byte(testMetric.ID),
 		int64(testMetric.Timestamp.UnixNano()),
 		testMetric.Value,

--- a/protocol/msgpack/aggregated_iterator.go
+++ b/protocol/msgpack/aggregated_iterator.go
@@ -1,0 +1,113 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package msgpack
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/m3db/m3metrics/metric/aggregated"
+	"github.com/m3db/m3metrics/policy"
+)
+
+// aggregatedIterator is an iterator for decoding aggregated metrics
+type aggregatedIterator struct {
+	iteratorBase
+
+	ignoreHigherVersion bool // whether we ignore messages with a higher-than-supported version
+	metric              aggregated.RawMetric
+	policy              policy.Policy
+}
+
+// NewAggregatedIterator creates a new aggregated iterator
+func NewAggregatedIterator(reader io.Reader, opts AggregatedIteratorOptions) AggregatedIterator {
+	if opts == nil {
+		opts = NewAggregatedIteratorOptions()
+	}
+	return &aggregatedIterator{
+		ignoreHigherVersion: opts.IgnoreHigherVersion(),
+		iteratorBase:        newBaseIterator(reader),
+		metric:              NewRawMetric(nil),
+	}
+}
+
+func (it *aggregatedIterator) Reset(reader io.Reader) { it.reset(reader) }
+func (it *aggregatedIterator) Err() error             { return it.err() }
+
+func (it *aggregatedIterator) Value() (aggregated.RawMetric, policy.Policy) {
+	return it.metric, it.policy
+}
+
+func (it *aggregatedIterator) Next() bool {
+	if it.err() != nil {
+		return false
+	}
+	return it.decodeRootObject()
+}
+
+func (it *aggregatedIterator) decodeRootObject() bool {
+	version := it.decodeVersion()
+	if it.err() != nil {
+		return false
+	}
+	// If the actual version is higher than supported version, we skip
+	// the data for this metric and continue to the next
+	if version > aggregatedVersion {
+		if it.ignoreHigherVersion {
+			it.skip(it.decodeNumObjectFields())
+			return it.Next()
+		}
+		it.setErr(fmt.Errorf("received version %d is higher than supported version %d", version, aggregatedVersion))
+		return false
+	}
+	// Otherwise we proceed to decoding normally
+	numExpectedFields, numActualFields, ok := it.checkNumFieldsForType(rootObjectType)
+	if !ok {
+		return false
+	}
+	objType := it.decodeObjectType()
+	if it.err() != nil {
+		return false
+	}
+	switch objType {
+	case rawMetricWithPolicyType:
+		it.decodeRawMetricWithPolicy()
+	default:
+		it.setErr(fmt.Errorf("unrecognized object type %v", objType))
+	}
+	it.skip(numActualFields - numExpectedFields)
+
+	return it.err() == nil
+}
+
+func (it *aggregatedIterator) decodeRawMetricWithPolicy() {
+	numExpectedFields, numActualFields, ok := it.checkNumFieldsForType(rawMetricWithPolicyType)
+	if !ok {
+		return
+	}
+	it.metric.Reset(it.decodeRawMetric())
+	it.policy = it.decodePolicy()
+	it.skip(numActualFields - numExpectedFields)
+}
+
+func (it *aggregatedIterator) decodeRawMetric() []byte {
+	return it.decodeBytes()
+}

--- a/protocol/msgpack/aggregated_iterator_pool.go
+++ b/protocol/msgpack/aggregated_iterator_pool.go
@@ -22,25 +22,25 @@ package msgpack
 
 import "github.com/m3db/m3x/pool"
 
-type bufferedEncoderPool struct {
+type aggregatedIteratorPool struct {
 	pool pool.ObjectPool
 }
 
-// NewBufferedEncoderPool creates a new pool for buffered encoders
-func NewBufferedEncoderPool(opts pool.ObjectPoolOptions) BufferedEncoderPool {
-	return &bufferedEncoderPool{pool: pool.NewObjectPool(opts)}
+// NewAggregatedIteratorPool creates a new pool for aggregated iterators
+func NewAggregatedIteratorPool(opts pool.ObjectPoolOptions) AggregatedIteratorPool {
+	return &aggregatedIteratorPool{pool: pool.NewObjectPool(opts)}
 }
 
-func (p *bufferedEncoderPool) Init(alloc BufferedEncoderAlloc) {
+func (p *aggregatedIteratorPool) Init(alloc AggregatedIteratorAlloc) {
 	p.pool.Init(func() interface{} {
 		return alloc()
 	})
 }
 
-func (p *bufferedEncoderPool) Get() BufferedEncoder {
-	return p.pool.Get().(BufferedEncoder)
+func (p *aggregatedIteratorPool) Get() AggregatedIterator {
+	return p.pool.Get().(AggregatedIterator)
 }
 
-func (p *bufferedEncoderPool) Put(encoder BufferedEncoder) {
-	p.pool.Put(encoder)
+func (p *aggregatedIteratorPool) Put(it AggregatedIterator) {
+	p.pool.Put(it)
 }

--- a/protocol/msgpack/aggregated_iterator_test.go
+++ b/protocol/msgpack/aggregated_iterator_test.go
@@ -1,0 +1,167 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package msgpack
+
+import (
+	"io"
+	"testing"
+
+	"github.com/m3db/m3metrics/metric/aggregated"
+	"github.com/m3db/m3metrics/policy"
+
+	"github.com/stretchr/testify/require"
+)
+
+func validateAggregatedDecodeResults(
+	t *testing.T,
+	it AggregatedIterator,
+	expectedResults []metricWithPolicy,
+	expectedErr error,
+) {
+	var results []metricWithPolicy
+	for it.Next() {
+		value, policy := it.Value()
+		m, err := value.Metric()
+		require.NoError(t, err)
+		results = append(results, metricWithPolicy{
+			metric: m,
+			policy: policy,
+		})
+	}
+	require.Equal(t, expectedErr, it.Err())
+	require.Equal(t, expectedResults, results)
+}
+
+func TestAggregatedIteratorDecodeNewerVersionThanSupported(t *testing.T) {
+	input := metricWithPolicy{
+		metric: testMetric,
+		policy: testPolicy,
+	}
+	enc := testAggregatedEncoder(t).(*aggregatedEncoder)
+
+	// Version encoded is higher than supported version
+	enc.encodeRootObjectFn = func(objType objectType) {
+		enc.encodeVersion(aggregatedVersion + 1)
+		enc.encodeNumObjectFields(numFieldsForType(rootObjectType))
+		enc.encodeObjectType(objType)
+	}
+	require.NoError(t, enc.EncodeMetricWithPolicy(input.metric.(aggregated.Metric), input.policy))
+
+	// Now restore the encode top-level function and encode another metric
+	enc.encodeRootObjectFn = enc.encodeRootObject
+	require.NoError(t, enc.EncodeMetricWithPolicy(input.metric.(aggregated.Metric), input.policy))
+
+	it := testAggregatedIterator(t, enc.Encoder().Buffer)
+
+	// Check that we skipped the first metric and successfully decoded the second metric
+	validateAggregatedDecodeResults(t, it, []metricWithPolicy{input}, io.EOF)
+}
+
+func TestAggregatedIteratorDecodeRootObjectMoreFieldsThanExpected(t *testing.T) {
+	input := metricWithPolicy{
+		metric: testMetric,
+		policy: testPolicy,
+	}
+	enc := testAggregatedEncoder(t).(*aggregatedEncoder)
+
+	// Pretend we added an extra int field to the root object
+	enc.encodeRootObjectFn = func(objType objectType) {
+		enc.encodeVersion(unaggregatedVersion)
+		enc.encodeNumObjectFields(numFieldsForType(rootObjectType) + 1)
+		enc.encodeObjectType(objType)
+	}
+	enc.EncodeMetricWithPolicy(input.metric.(aggregated.Metric), input.policy)
+	enc.encodeVarint(0)
+	require.NoError(t, enc.err())
+
+	it := testAggregatedIterator(t, enc.Encoder().Buffer)
+
+	// Check that we successfully decoded the metric
+	validateAggregatedDecodeResults(t, it, []metricWithPolicy{input}, io.EOF)
+}
+
+func TestAggregatedIteratorDecodeRawMetricMoreFieldsThanExpected(t *testing.T) {
+	input := metricWithPolicy{
+		metric: testMetric,
+		policy: testPolicy,
+	}
+	enc := testAggregatedEncoder(t).(*aggregatedEncoder)
+
+	// Pretend we added an extra int field to the raw metric with policy object
+	enc.encodeRawMetricWithPolicyFn = func(data []byte, p policy.Policy) {
+		enc.encodeNumObjectFields(numFieldsForType(rawMetricWithPolicyType) + 1)
+		enc.encodeRawMetricFn(data)
+		enc.encodePolicy(p)
+	}
+	enc.EncodeMetricWithPolicy(input.metric.(aggregated.Metric), input.policy)
+	enc.encodeVarint(0)
+	require.NoError(t, enc.err())
+
+	it := testAggregatedIterator(t, enc.Encoder().Buffer)
+
+	// Check that we successfully decoded the metric
+	validateAggregatedDecodeResults(t, it, []metricWithPolicy{input}, io.EOF)
+}
+
+func TestAggregatedIteratorDecodeMetricHigherVersionThanSupported(t *testing.T) {
+	input := metricWithPolicy{
+		metric: testMetric,
+		policy: testPolicy,
+	}
+	enc := testAggregatedEncoder(t).(*aggregatedEncoder)
+
+	// Pretend we added an extra int field to the raw metric object
+	enc.encodeMetricAsRawFn = func(m aggregated.Metric) []byte {
+		enc.buf.resetData()
+		enc.buf.encodeVersion(metricVersion + 1)
+		return enc.buf.encoder().Bytes()
+	}
+	enc.EncodeMetricWithPolicy(input.metric.(aggregated.Metric), input.policy)
+	require.NoError(t, enc.err())
+
+	it := testAggregatedIterator(t, enc.Encoder().Buffer)
+	require.True(t, it.Next())
+	rawMetric, _ := it.Value()
+	_, err := rawMetric.Value()
+	require.Error(t, err)
+}
+
+func TestAggregatedIteratorDecodeMetricMoreFieldsThanExpected(t *testing.T) {
+	input := metricWithPolicy{
+		metric: testMetric,
+		policy: testPolicy,
+	}
+	enc := testAggregatedEncoder(t).(*aggregatedEncoder)
+
+	// Pretend we added an extra int field to the raw metric object
+	enc.encodeMetricAsRawFn = func(m aggregated.Metric) []byte {
+		enc.encodeMetricAsRaw(m)
+		enc.buf.encodeVarint(0)
+		return enc.buf.encoder().Bytes()
+	}
+	enc.EncodeMetricWithPolicy(input.metric.(aggregated.Metric), input.policy)
+	require.NoError(t, enc.err())
+
+	it := testAggregatedIterator(t, enc.Encoder().Buffer)
+
+	// Check that we successfully decoded the metric
+	validateAggregatedDecodeResults(t, it, []metricWithPolicy{input}, io.EOF)
+}

--- a/protocol/msgpack/aggregated_iterator_test.go
+++ b/protocol/msgpack/aggregated_iterator_test.go
@@ -70,6 +70,7 @@ func TestAggregatedIteratorDecodeNewerVersionThanSupported(t *testing.T) {
 	require.NoError(t, testAggregatedEncode(t, enc, input.metric.(aggregated.Metric), input.policy))
 
 	it := testAggregatedIterator(t, enc.Encoder().Buffer)
+	it.(*aggregatedIterator).ignoreHigherVersion = true
 
 	// Check that we skipped the first metric and successfully decoded the second metric
 	validateAggregatedDecodeResults(t, it, []metricWithPolicy{input}, io.EOF)

--- a/protocol/msgpack/aggregated_iterator_test.go
+++ b/protocol/msgpack/aggregated_iterator_test.go
@@ -63,11 +63,11 @@ func TestAggregatedIteratorDecodeNewerVersionThanSupported(t *testing.T) {
 		enc.encodeNumObjectFields(numFieldsForType(rootObjectType))
 		enc.encodeObjectType(objType)
 	}
-	require.NoError(t, enc.EncodeMetricWithPolicy(input.metric.(aggregated.Metric), input.policy))
+	require.NoError(t, testAggregatedEncode(t, enc, input.metric.(aggregated.Metric), input.policy))
 
 	// Now restore the encode top-level function and encode another metric
 	enc.encodeRootObjectFn = enc.encodeRootObject
-	require.NoError(t, enc.EncodeMetricWithPolicy(input.metric.(aggregated.Metric), input.policy))
+	require.NoError(t, testAggregatedEncode(t, enc, input.metric.(aggregated.Metric), input.policy))
 
 	it := testAggregatedIterator(t, enc.Encoder().Buffer)
 
@@ -88,7 +88,7 @@ func TestAggregatedIteratorDecodeRootObjectMoreFieldsThanExpected(t *testing.T) 
 		enc.encodeNumObjectFields(numFieldsForType(rootObjectType) + 1)
 		enc.encodeObjectType(objType)
 	}
-	enc.EncodeMetricWithPolicy(input.metric.(aggregated.Metric), input.policy)
+	testAggregatedEncode(t, enc, input.metric.(aggregated.Metric), input.policy)
 	enc.encodeVarint(0)
 	require.NoError(t, enc.err())
 
@@ -111,7 +111,7 @@ func TestAggregatedIteratorDecodeRawMetricMoreFieldsThanExpected(t *testing.T) {
 		enc.encodeRawMetricFn(data)
 		enc.encodePolicy(p)
 	}
-	enc.EncodeMetricWithPolicy(input.metric.(aggregated.Metric), input.policy)
+	testAggregatedEncode(t, enc, input.metric.(aggregated.Metric), input.policy)
 	enc.encodeVarint(0)
 	require.NoError(t, enc.err())
 
@@ -134,7 +134,7 @@ func TestAggregatedIteratorDecodeMetricHigherVersionThanSupported(t *testing.T) 
 		enc.buf.encodeVersion(metricVersion + 1)
 		return enc.buf.encoder().Bytes()
 	}
-	enc.EncodeMetricWithPolicy(input.metric.(aggregated.Metric), input.policy)
+	testAggregatedEncode(t, enc, input.metric.(aggregated.Metric), input.policy)
 	require.NoError(t, enc.err())
 
 	it := testAggregatedIterator(t, enc.Encoder().Buffer)
@@ -157,7 +157,7 @@ func TestAggregatedIteratorDecodeMetricMoreFieldsThanExpected(t *testing.T) {
 		enc.buf.encodeVarint(0)
 		return enc.buf.encoder().Bytes()
 	}
-	enc.EncodeMetricWithPolicy(input.metric.(aggregated.Metric), input.policy)
+	testAggregatedEncode(t, enc, input.metric.(aggregated.Metric), input.policy)
 	require.NoError(t, enc.err())
 
 	it := testAggregatedIterator(t, enc.Encoder().Buffer)

--- a/protocol/msgpack/aggregated_iterator_test.go
+++ b/protocol/msgpack/aggregated_iterator_test.go
@@ -165,3 +165,11 @@ func TestAggregatedIteratorDecodeMetricMoreFieldsThanExpected(t *testing.T) {
 	// Check that we successfully decoded the metric
 	validateAggregatedDecodeResults(t, it, []metricWithPolicy{input}, io.EOF)
 }
+
+func TestAggregatedIteratorClose(t *testing.T) {
+	it := NewAggregatedIterator(nil, nil)
+	it.Close()
+	require.False(t, it.Next())
+	require.NoError(t, it.Err())
+	require.True(t, it.(*aggregatedIterator).closed)
+}

--- a/protocol/msgpack/aggregated_roundtrip_test.go
+++ b/protocol/msgpack/aggregated_roundtrip_test.go
@@ -1,0 +1,167 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package msgpack
+
+import (
+	"bytes"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/m3db/m3metrics/metric"
+	"github.com/m3db/m3metrics/metric/aggregated"
+	"github.com/m3db/m3metrics/policy"
+	"github.com/m3db/m3x/time"
+
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	testMetric = aggregated.Metric{
+		ID:        metric.ID("foo"),
+		Timestamp: time.Now(),
+		Value:     123.45,
+	}
+
+	testPolicy = policy.Policy{
+		Resolution: policy.Resolution{Window: time.Duration(1), Precision: xtime.Second},
+		Retention:  policy.Retention(time.Hour),
+	}
+)
+
+type metricWithPolicy struct {
+	metric interface{}
+	policy policy.Policy
+}
+
+func testAggregatedEncoder(t *testing.T) AggregatedEncoder {
+	return NewAggregatedEncoder(newBufferedEncoder())
+}
+
+func testAggregatedIterator(t *testing.T, reader io.Reader) AggregatedIterator {
+	return NewAggregatedIterator(reader, NewAggregatedIteratorOptions())
+}
+
+func toRawMetric(t *testing.T, m aggregated.Metric) aggregated.RawMetric {
+	encoder := NewAggregatedEncoder(newBufferedEncoder()).(*aggregatedEncoder)
+	data := encoder.encodeMetricAsRaw(m)
+	require.NoError(t, encoder.err())
+	return NewRawMetric(data)
+}
+
+func validateAggregatedRoundtrip(t *testing.T, inputs ...metricWithPolicy) {
+	encoder := testAggregatedEncoder(t)
+	it := testAggregatedIterator(t, nil)
+	validateAggregatedRoundtripWithEncoderAndIterator(t, encoder, it, inputs...)
+}
+
+func validateAggregatedRoundtripWithEncoderAndIterator(
+	t *testing.T,
+	encoder AggregatedEncoder,
+	it AggregatedIterator,
+	inputs ...metricWithPolicy,
+) {
+	var (
+		expected []metricWithPolicy
+		results  []metricWithPolicy
+	)
+
+	// Encode the batch of metrics
+	encoder.Reset(newBufferedEncoder())
+	for _, input := range inputs {
+		switch inputMetric := input.metric.(type) {
+		case aggregated.Metric:
+			expected = append(expected, metricWithPolicy{
+				metric: inputMetric,
+				policy: input.policy,
+			})
+			require.NoError(t, encoder.EncodeMetricWithPolicy(inputMetric, input.policy))
+		case aggregated.RawMetric:
+			m, err := inputMetric.Metric()
+			require.NoError(t, err)
+			expected = append(expected, metricWithPolicy{
+				metric: m,
+				policy: input.policy,
+			})
+			require.NoError(t, encoder.EncodeRawMetricWithPolicy(inputMetric, input.policy))
+		default:
+			require.Fail(t, "unrecognized input type %T", inputMetric)
+		}
+	}
+
+	// Decode the batch of metrics
+	encodedBytes := bytes.NewBuffer(encoder.Encoder().Bytes())
+	it.Reset(encodedBytes)
+	for it.Next() {
+		metric, p := it.Value()
+		m, err := metric.Metric()
+		require.NoError(t, err)
+		results = append(results, metricWithPolicy{
+			metric: m,
+			policy: p,
+		})
+	}
+
+	// Assert the results match expectations
+	require.Equal(t, io.EOF, it.Err())
+	require.Equal(t, expected, results)
+}
+
+func TestAggregatedEncodeDecodeMetricWithPolicy(t *testing.T) {
+	validateAggregatedRoundtrip(t, metricWithPolicy{
+		metric: testMetric,
+		policy: testPolicy,
+	})
+}
+
+func TestAggregatedEncodeDecodeRawMetricWithPolicy(t *testing.T) {
+	validateAggregatedRoundtrip(t, metricWithPolicy{
+		metric: toRawMetric(t, testMetric),
+		policy: testPolicy,
+	})
+}
+
+func TestAggregatedEncodeDecodeStress(t *testing.T) {
+	var (
+		numIter    = 10
+		numMetrics = 10000
+		encoder    = testAggregatedEncoder(t)
+		iterator   = testAggregatedIterator(t, nil)
+	)
+
+	for i := 0; i < numIter; i++ {
+		var inputs []metricWithPolicy
+		for j := 0; j < numMetrics; j++ {
+			if j%2 == 0 {
+				inputs = append(inputs, metricWithPolicy{
+					metric: testMetric,
+					policy: testPolicy,
+				})
+			} else {
+				inputs = append(inputs, metricWithPolicy{
+					metric: toRawMetric(t, testMetric),
+					policy: testPolicy,
+				})
+			}
+		}
+		validateAggregatedRoundtripWithEncoderAndIterator(t, encoder, iterator, inputs...)
+	}
+}

--- a/protocol/msgpack/base_encoder.go
+++ b/protocol/msgpack/base_encoder.go
@@ -1,0 +1,146 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package msgpack
+
+import (
+	"time"
+
+	"github.com/m3db/m3metrics/metric"
+	"github.com/m3db/m3metrics/policy"
+)
+
+type encodePolicyFn func(p policy.Policy)
+type encodeVarintFn func(value int64)
+type encodeFloat64Fn func(value float64)
+type encodeBytesFn func(value []byte)
+type encodeArrayLenFn func(value int)
+
+// baseEncoder is the base encoder that provides common encoding APIs
+type baseEncoder struct {
+	bufEncoder       BufferedEncoder  // internal encoder that performs the actual encoding
+	encodeErr        error            // error encountered during encoding
+	encodePolicyFn   encodePolicyFn   // policy encoding function
+	encodeVarintFn   encodeVarintFn   // varint encoding function
+	encodeFloat64Fn  encodeFloat64Fn  // float64 encoding function
+	encodeBytesFn    encodeBytesFn    // byte slice encoding function
+	encodeArrayLenFn encodeArrayLenFn // array length encoding function
+}
+
+func newBaseEncoder(encoder BufferedEncoder) encoderBase {
+	enc := &baseEncoder{bufEncoder: encoder}
+
+	enc.encodePolicyFn = enc.encodePolicyInternal
+	enc.encodeVarintFn = enc.encodeVarintInternal
+	enc.encodeFloat64Fn = enc.encodeFloat64Internal
+	enc.encodeBytesFn = enc.encodeBytesInternal
+	enc.encodeArrayLenFn = enc.encodeArrayLenInternal
+
+	return enc
+}
+
+func (enc *baseEncoder) encoder() BufferedEncoder            { return enc.bufEncoder }
+func (enc *baseEncoder) err() error                          { return enc.encodeErr }
+func (enc *baseEncoder) reset(encoder BufferedEncoder)       { enc.bufEncoder = encoder }
+func (enc *baseEncoder) resetData()                          { enc.bufEncoder.Reset() }
+func (enc *baseEncoder) encodePolicy(p policy.Policy)        { enc.encodePolicyFn(p) }
+func (enc *baseEncoder) encodeVersion(version int)           { enc.encodeVarint(int64(version)) }
+func (enc *baseEncoder) encodeObjectType(objType objectType) { enc.encodeVarint(int64(objType)) }
+func (enc *baseEncoder) encodeNumObjectFields(numFields int) { enc.encodeArrayLen(numFields) }
+func (enc *baseEncoder) encodeID(id metric.ID)               { enc.encodeBytes([]byte(id)) }
+func (enc *baseEncoder) encodeTime(t time.Time)              { enc.encodeVarint(t.UnixNano()) }
+func (enc *baseEncoder) encodeVarint(value int64)            { enc.encodeVarintFn(value) }
+func (enc *baseEncoder) encodeFloat64(value float64)         { enc.encodeFloat64Fn(value) }
+func (enc *baseEncoder) encodeBytes(value []byte)            { enc.encodeBytesFn(value) }
+func (enc *baseEncoder) encodeArrayLen(value int)            { enc.encodeArrayLenFn(value) }
+
+func (enc *baseEncoder) encodePolicyInternal(p policy.Policy) {
+	enc.encodeNumObjectFields(numFieldsForType(policyType))
+	enc.encodeResolution(p.Resolution)
+	enc.encodeRetention(p.Retention)
+}
+
+func (enc *baseEncoder) encodeResolution(resolution policy.Resolution) {
+	if enc.encodeErr != nil {
+		return
+	}
+	// If this is a known resolution, only encode its corresponding value
+	if resolutionValue, err := policy.ValueFromResolution(resolution); err == nil {
+		enc.encodeNumObjectFields(numFieldsForType(knownResolutionType))
+		enc.encodeObjectType(knownResolutionType)
+		enc.encodeVarintFn(int64(resolutionValue))
+		return
+	}
+	// Otherwise encode the entire resolution object
+	// TODO(xichen): validate the resolution before putting it on the wire
+	enc.encodeNumObjectFields(numFieldsForType(unknownResolutionType))
+	enc.encodeObjectType(unknownResolutionType)
+	enc.encodeVarintFn(int64(resolution.Window))
+	enc.encodeVarintFn(int64(resolution.Precision))
+}
+
+func (enc *baseEncoder) encodeRetention(retention policy.Retention) {
+	if enc.encodeErr != nil {
+		return
+	}
+	// If this is a known retention, only encode its corresponding value
+	if retentionValue, err := policy.ValueFromRetention(retention); err == nil {
+		enc.encodeNumObjectFields(numFieldsForType(knownRetentionType))
+		enc.encodeObjectType(knownRetentionType)
+		enc.encodeVarintFn(int64(retentionValue))
+		return
+	}
+	// Otherwise encode the entire retention object
+	// TODO(xichen): validate the retention before putting it on the wire
+	enc.encodeNumObjectFields(numFieldsForType(unknownRetentionType))
+	enc.encodeObjectType(unknownRetentionType)
+	enc.encodeVarintFn(int64(retention))
+}
+
+// NB(xichen): the underlying msgpack encoder implementation
+// always cast an integer value to an int64 and encodes integer
+// values as varints, regardless of the actual integer type
+func (enc *baseEncoder) encodeVarintInternal(value int64) {
+	if enc.encodeErr != nil {
+		return
+	}
+	enc.encodeErr = enc.bufEncoder.EncodeInt64(value)
+}
+
+func (enc *baseEncoder) encodeFloat64Internal(value float64) {
+	if enc.encodeErr != nil {
+		return
+	}
+	enc.encodeErr = enc.bufEncoder.EncodeFloat64(value)
+}
+
+func (enc *baseEncoder) encodeBytesInternal(value []byte) {
+	if enc.encodeErr != nil {
+		return
+	}
+	enc.encodeErr = enc.bufEncoder.EncodeBytes(value)
+}
+
+func (enc *baseEncoder) encodeArrayLenInternal(value int) {
+	if enc.encodeErr != nil {
+		return
+	}
+	enc.encodeErr = enc.bufEncoder.EncodeArrayLen(value)
+}

--- a/protocol/msgpack/base_iterator.go
+++ b/protocol/msgpack/base_iterator.go
@@ -1,0 +1,250 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package msgpack
+
+import (
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/m3db/m3metrics/metric"
+	"github.com/m3db/m3metrics/policy"
+	"github.com/m3db/m3x/time"
+
+	msgpack "gopkg.in/vmihailenco/msgpack.v2"
+)
+
+// baseIterator is the base iterator that provides common decoding APIs
+type baseIterator struct {
+	decoder   *msgpack.Decoder // internal decoder that does the actual decoding
+	decodeErr error            // error encountered during decoding
+}
+
+func newBaseIterator(reader io.Reader) iteratorBase {
+	return &baseIterator{
+		decoder: msgpack.NewDecoder(reader),
+	}
+}
+
+// NB(xichen): if reader is not a bufio.Reader or a bytes.Buffer,
+// the underlying msgpack decoder creates a bufio.Reader wrapping
+// the reader every time Reset() is called
+func (it *baseIterator) reset(reader io.Reader) {
+	it.decoder.Reset(reader)
+	it.decodeErr = nil
+}
+
+func (it *baseIterator) err() error       { return it.decodeErr }
+func (it *baseIterator) setErr(err error) { it.decodeErr = err }
+
+func (it *baseIterator) decodePolicy() policy.Policy {
+	numExpectedFields, numActualFields, ok := it.checkNumFieldsForType(policyType)
+	if !ok {
+		return policy.Policy{}
+	}
+	resolution := it.decodeResolution()
+	retention := it.decodeRetention()
+	p := policy.Policy{Resolution: resolution, Retention: retention}
+	it.skip(numActualFields - numExpectedFields)
+	return p
+}
+
+func (it *baseIterator) decodeResolution() policy.Resolution {
+	numActualFields := it.decodeNumObjectFields()
+	resolutionType := it.decodeObjectType()
+	numExpectedFields, numActualFields, ok := it.checkNumFieldsForTypeWithActual(
+		resolutionType,
+		numActualFields,
+	)
+	if !ok {
+		return policy.EmptyResolution
+	}
+	switch resolutionType {
+	case knownResolutionType:
+		resolutionValue := policy.ResolutionValue(it.decodeVarint())
+		if !resolutionValue.IsValid() {
+			it.decodeErr = fmt.Errorf("invalid resolution value %v", resolutionValue)
+			return policy.EmptyResolution
+		}
+		it.skip(numActualFields - numExpectedFields)
+		if it.decodeErr != nil {
+			return policy.EmptyResolution
+		}
+		resolution, err := resolutionValue.Resolution()
+		it.decodeErr = err
+		return resolution
+	case unknownResolutionType:
+		window := time.Duration(it.decodeVarint())
+		precision := xtime.Unit(it.decodeVarint())
+		if it.decodeErr != nil {
+			return policy.EmptyResolution
+		}
+		if !precision.IsValid() {
+			it.decodeErr = fmt.Errorf("invalid precision %v", precision)
+			return policy.EmptyResolution
+		}
+		it.skip(numActualFields - numExpectedFields)
+		return policy.Resolution{Window: window, Precision: precision}
+	default:
+		it.decodeErr = fmt.Errorf("unrecognized resolution type %v", resolutionType)
+		return policy.EmptyResolution
+	}
+}
+
+func (it *baseIterator) decodeRetention() policy.Retention {
+	numActualFields := it.decodeNumObjectFields()
+	retentionType := it.decodeObjectType()
+	numExpectedFields, numActualFields, ok := it.checkNumFieldsForTypeWithActual(
+		retentionType,
+		numActualFields,
+	)
+	if !ok {
+		return policy.EmptyRetention
+	}
+	switch retentionType {
+	case knownRetentionType:
+		retentionValue := policy.RetentionValue(it.decodeVarint())
+		if !retentionValue.IsValid() {
+			it.decodeErr = fmt.Errorf("invalid retention value %v", retentionValue)
+			return policy.EmptyRetention
+		}
+		it.skip(numActualFields - numExpectedFields)
+		if it.decodeErr != nil {
+			return policy.EmptyRetention
+		}
+		retention, err := retentionValue.Retention()
+		it.decodeErr = err
+		return retention
+	case unknownRetentionType:
+		retention := policy.Retention(it.decodeVarint())
+		it.skip(numActualFields - numExpectedFields)
+		return retention
+	default:
+		it.decodeErr = fmt.Errorf("unrecognized retention type %v", retentionType)
+		return policy.EmptyRetention
+	}
+}
+
+func (it *baseIterator) decodeVersion() int {
+	return int(it.decodeVarint())
+}
+
+func (it *baseIterator) decodeObjectType() objectType {
+	return objectType(it.decodeVarint())
+}
+
+func (it *baseIterator) decodeNumObjectFields() int {
+	return int(it.decodeArrayLen())
+}
+
+func (it *baseIterator) decodeID() metric.ID {
+	return metric.ID(it.decodeBytes())
+}
+
+func (it *baseIterator) decodeTime() time.Time {
+	return time.Unix(0, it.decodeVarint())
+}
+
+// NB(xichen): the underlying msgpack decoder implementation
+// always decodes an int64 and looks at the actual decoded
+// value to determine the width of the integer (a.k.a. varint
+// decoding)
+func (it *baseIterator) decodeVarint() int64 {
+	if it.decodeErr != nil {
+		return 0
+	}
+	value, err := it.decoder.DecodeInt64()
+	it.decodeErr = err
+	return value
+}
+
+func (it *baseIterator) decodeFloat64() float64 {
+	if it.decodeErr != nil {
+		return 0.0
+	}
+	value, err := it.decoder.DecodeFloat64()
+	it.decodeErr = err
+	return value
+}
+
+func (it *baseIterator) decodeBytes() []byte {
+	if it.decodeErr != nil {
+		return nil
+	}
+	value, err := it.decoder.DecodeBytes()
+	it.decodeErr = err
+	return value
+}
+
+func (it *baseIterator) decodeBytesLen() int {
+	if it.decodeErr != nil {
+		return 0
+	}
+	bytesLen, err := it.decoder.DecodeBytesLen()
+	it.decodeErr = err
+	return bytesLen
+}
+
+func (it *baseIterator) decodeArrayLen() int {
+	if it.decodeErr != nil {
+		return 0
+	}
+	value, err := it.decoder.DecodeArrayLen()
+	it.decodeErr = err
+	return value
+}
+
+func (it *baseIterator) skip(numFields int) {
+	if it.decodeErr != nil {
+		return
+	}
+	if numFields < 0 {
+		it.decodeErr = fmt.Errorf("number of fields to skip is %d", numFields)
+		return
+	}
+	// Otherwise we skip any unexpected extra fields
+	for i := 0; i < numFields; i++ {
+		if err := it.decoder.Skip(); err != nil {
+			it.decodeErr = err
+			return
+		}
+	}
+}
+
+func (it *baseIterator) checkNumFieldsForType(objType objectType) (int, int, bool) {
+	numActualFields := it.decodeNumObjectFields()
+	return it.checkNumFieldsForTypeWithActual(objType, numActualFields)
+}
+
+func (it *baseIterator) checkNumFieldsForTypeWithActual(
+	objType objectType,
+	numActualFields int,
+) (int, int, bool) {
+	if it.decodeErr != nil {
+		return 0, 0, false
+	}
+	numExpectedFields := numFieldsForType(objType)
+	if numExpectedFields > numActualFields {
+		it.decodeErr = fmt.Errorf("number of fields mismatch: expected %d actual %d", numExpectedFields, numActualFields)
+		return 0, 0, false
+	}
+	return numExpectedFields, numActualFields, true
+}

--- a/protocol/msgpack/buffered_encoder.go
+++ b/protocol/msgpack/buffered_encoder.go
@@ -46,11 +46,18 @@ func NewPooledBufferedEncoder(p BufferedEncoderPool) BufferedEncoder {
 func (enc BufferedEncoder) Bytes() []byte { return enc.Buffer.Bytes() }
 
 // Reset resets the buffered encoder
-func (enc BufferedEncoder) Reset() { enc.Buffer.Truncate(0) }
+func (enc *BufferedEncoder) Reset() {
+	enc.closed = false
+	enc.Buffer.Truncate(0)
+}
 
 // Close returns the buffered encoder to the pool if possible
-func (enc BufferedEncoder) Close() {
+func (enc *BufferedEncoder) Close() {
+	if enc.closed {
+		return
+	}
+	enc.closed = true
 	if enc.pool != nil {
-		enc.pool.Put(enc)
+		enc.pool.Put(*enc)
 	}
 }

--- a/protocol/msgpack/buffered_encoder_pool_test.go
+++ b/protocol/msgpack/buffered_encoder_pool_test.go
@@ -42,7 +42,11 @@ func TestBufferedEncoderPool(t *testing.T) {
 	// Closing the encoder should put it back to the pool
 	encoder.Close()
 
-	// Retrieve the encoder and assert it's been reset
+	// Retrieve the encoder and assert it's the same encoder
 	encoder = p.Get()
+	require.Equal(t, 3, encoder.Buffer.Len())
+
+	// Reset the encoder and assert it's been reset
+	encoder.Reset()
 	require.Equal(t, 0, encoder.Buffer.Len())
 }

--- a/protocol/msgpack/buffered_encoder_test.go
+++ b/protocol/msgpack/buffered_encoder_test.go
@@ -40,7 +40,7 @@ func TestBufferedEncoderReset(t *testing.T) {
 	for _, input := range inputs {
 		encoder.Encode(input)
 	}
-	encoded := encoder.Buffer.Bytes()
+	encoded := encoder.Bytes()
 	results := make([]byte, len(encoded))
 	copy(results, encoded)
 
@@ -51,7 +51,7 @@ func TestBufferedEncoderReset(t *testing.T) {
 	for _, input := range inputs {
 		encoder.Encode(input)
 	}
-	encoded = encoder.Buffer.Bytes()
+	encoded = encoder.Bytes()
 	results2 := make([]byte, len(encoded))
 	copy(results2, encoded)
 

--- a/protocol/msgpack/buffered_encoder_test.go
+++ b/protocol/msgpack/buffered_encoder_test.go
@@ -32,8 +32,6 @@ func testBufferedEncoder() BufferedEncoder {
 
 func TestBufferedEncoderReset(t *testing.T) {
 	encoder := testBufferedEncoder()
-	defer encoder.Close()
-
 	inputs := []interface{}{1, 2.0, "foo", byte(8)}
 
 	// Encode for the first time
@@ -56,4 +54,17 @@ func TestBufferedEncoderReset(t *testing.T) {
 	copy(results2, encoded)
 
 	require.Equal(t, results, results2)
+}
+
+func TestBufferedEncoderClose(t *testing.T) {
+	encoder := testBufferedEncoder()
+	require.False(t, encoder.closed)
+
+	// Close the encoder should set the flag
+	encoder.Close()
+	require.True(t, encoder.closed)
+
+	// Close the encoder again should be a no-op
+	encoder.Close()
+	require.True(t, encoder.closed)
 }

--- a/protocol/msgpack/options.go
+++ b/protocol/msgpack/options.go
@@ -21,8 +21,6 @@
 package msgpack
 
 import (
-	"errors"
-
 	"github.com/m3db/m3metrics/pool"
 	xpool "github.com/m3db/m3x/pool"
 )
@@ -37,15 +35,11 @@ const (
 	defaultAggregatedIgnoreHigherVersion = true
 )
 
-var (
-	errNoFloatsPool   = errors.New("no floats pool")
-	errNoPoliciesPool = errors.New("no policies pool")
-)
-
 type unaggregatedIteratorOptions struct {
 	ignoreHigherVersion bool
 	floatsPool          xpool.FloatsPool
 	policiesPool        pool.PoliciesPool
+	iteratorPool        UnaggregatedIteratorPool
 }
 
 // NewUnaggregatedIteratorOptions creates a new set of unaggregated iterator options
@@ -93,18 +87,19 @@ func (o unaggregatedIteratorOptions) PoliciesPool() pool.PoliciesPool {
 	return o.policiesPool
 }
 
-func (o unaggregatedIteratorOptions) Validate() error {
-	if o.floatsPool == nil {
-		return errNoFloatsPool
-	}
-	if o.policiesPool == nil {
-		return errNoPoliciesPool
-	}
-	return nil
+func (o unaggregatedIteratorOptions) SetIteratorPool(value UnaggregatedIteratorPool) UnaggregatedIteratorOptions {
+	opts := o
+	opts.iteratorPool = value
+	return opts
+}
+
+func (o unaggregatedIteratorOptions) IteratorPool() UnaggregatedIteratorPool {
+	return o.iteratorPool
 }
 
 type aggregatedIteratorOptions struct {
 	ignoreHigherVersion bool
+	iteratorPool        AggregatedIteratorPool
 }
 
 // NewAggregatedIteratorOptions creates a new set of aggregated iterator options
@@ -122,4 +117,14 @@ func (o aggregatedIteratorOptions) SetIgnoreHigherVersion(value bool) Aggregated
 
 func (o aggregatedIteratorOptions) IgnoreHigherVersion() bool {
 	return o.ignoreHigherVersion
+}
+
+func (o aggregatedIteratorOptions) SetIteratorPool(value AggregatedIteratorPool) AggregatedIteratorOptions {
+	opts := o
+	opts.iteratorPool = value
+	return opts
+}
+
+func (o aggregatedIteratorOptions) IteratorPool() AggregatedIteratorPool {
+	return o.iteratorPool
 }

--- a/protocol/msgpack/options.go
+++ b/protocol/msgpack/options.go
@@ -28,11 +28,11 @@ import (
 const (
 	// Whether the iterator should ignore higher-than-supported version
 	// by default for unaggregated metrics
-	defaultUnaggregatedIgnoreHigherVersion = true
+	defaultUnaggregatedIgnoreHigherVersion = false
 
 	// Whether the iterator should ignore higher-than-supported version
 	// by default for aggregated metrics
-	defaultAggregatedIgnoreHigherVersion = true
+	defaultAggregatedIgnoreHigherVersion = false
 )
 
 type unaggregatedIteratorOptions struct {

--- a/protocol/msgpack/options.go
+++ b/protocol/msgpack/options.go
@@ -28,7 +28,13 @@ import (
 )
 
 const (
-	defaultIgnoreHigherVersion = true
+	// Whether the iterator should ignore higher-than-supported version
+	// by default for unaggregated metrics
+	defaultUnaggregatedIgnoreHigherVersion = true
+
+	// Whether the iterator should ignore higher-than-supported version
+	// by default for aggregated metrics
+	defaultAggregatedIgnoreHigherVersion = true
 )
 
 var (
@@ -51,7 +57,7 @@ func NewUnaggregatedIteratorOptions() UnaggregatedIteratorOptions {
 	policiesPool.Init()
 
 	return unaggregatedIteratorOptions{
-		ignoreHigherVersion: defaultIgnoreHigherVersion,
+		ignoreHigherVersion: defaultUnaggregatedIgnoreHigherVersion,
 		floatsPool:          floatsPool,
 		policiesPool:        policiesPool,
 	}
@@ -95,4 +101,25 @@ func (o unaggregatedIteratorOptions) Validate() error {
 		return errNoPoliciesPool
 	}
 	return nil
+}
+
+type aggregatedIteratorOptions struct {
+	ignoreHigherVersion bool
+}
+
+// NewAggregatedIteratorOptions creates a new set of aggregated iterator options
+func NewAggregatedIteratorOptions() AggregatedIteratorOptions {
+	return aggregatedIteratorOptions{
+		ignoreHigherVersion: defaultAggregatedIgnoreHigherVersion,
+	}
+}
+
+func (o aggregatedIteratorOptions) SetIgnoreHigherVersion(value bool) AggregatedIteratorOptions {
+	opts := o
+	opts.ignoreHigherVersion = value
+	return opts
+}
+
+func (o aggregatedIteratorOptions) IgnoreHigherVersion() bool {
+	return o.ignoreHigherVersion
 }

--- a/protocol/msgpack/raw_metric.go
+++ b/protocol/msgpack/raw_metric.go
@@ -1,0 +1,177 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package msgpack
+
+import (
+	"bytes"
+	"fmt"
+	"time"
+
+	"github.com/m3db/m3metrics/metric"
+	"github.com/m3db/m3metrics/metric/aggregated"
+)
+
+var (
+	emptyMetric aggregated.Metric
+)
+
+type decodeVersionFn func() int
+type decodeBytesLenFn func() int
+type decodeTimeFn func() time.Time
+type decodeFloat64Fn func() float64
+type readBytesFn func(n int) []byte
+
+// rawMetric is a raw metric
+type rawMetric struct {
+	data             []byte            // raw data containing encoded metric
+	buf              *bytes.Buffer     // intermediate buffer
+	it               iteratorBase      // base iterator for lazily decoding metric fields
+	metric           aggregated.Metric // current metric
+	idDecoded        bool              // whether id has been decoded
+	timestampDecoded bool              // whether timestamp has been decoded
+	valueDecoded     bool              // whether value has been decoded
+	decodeVersionFn  decodeVersionFn   // decoding version function
+	decodeBytesLenFn decodeBytesLenFn  // decoding the byte slice length function
+	decodeTimeFn     decodeTimeFn      // decoding time function
+	decodeFloat64Fn  decodeFloat64Fn   // decoding float64 value function
+	readBytesFn      readBytesFn       // reading bytes function
+}
+
+// NewRawMetric creates a new raw metric
+func NewRawMetric(data []byte) aggregated.RawMetric {
+	buf := bytes.NewBuffer(data)
+	m := &rawMetric{
+		data: data,
+		buf:  buf,
+		it:   newBaseIterator(buf),
+	}
+
+	m.decodeVersionFn = m.it.decodeVersion
+	m.decodeBytesLenFn = m.it.decodeBytesLen
+	m.decodeTimeFn = m.it.decodeTime
+	m.decodeFloat64Fn = m.it.decodeFloat64
+	m.readBytesFn = m.buf.Next
+
+	return m
+}
+
+func (m *rawMetric) ID() (metric.ID, error) {
+	m.decodeID()
+	if err := m.it.err(); err != nil {
+		return nil, err
+	}
+	return m.metric.ID, nil
+}
+
+func (m *rawMetric) Timestamp() (time.Time, error) {
+	m.decodeTimestamp()
+	if err := m.it.err(); err != nil {
+		return time.Time{}, err
+	}
+	return m.metric.Timestamp, nil
+}
+
+func (m *rawMetric) Value() (float64, error) {
+	m.decodeValue()
+	if err := m.it.err(); err != nil {
+		return 0.0, err
+	}
+	return m.metric.Value, nil
+}
+
+func (m *rawMetric) Metric() (aggregated.Metric, error) {
+	m.decodeID()
+	m.decodeTimestamp()
+	m.decodeValue()
+	if err := m.it.err(); err != nil {
+		return emptyMetric, err
+	}
+	return m.metric, nil
+}
+
+func (m *rawMetric) Bytes() []byte {
+	return m.data
+}
+
+func (m *rawMetric) Reset(data []byte) {
+	m.data = data
+	m.metric = emptyMetric
+	m.idDecoded = false
+	m.timestampDecoded = false
+	m.valueDecoded = false
+	m.buf.Reset()
+	_, err := m.buf.Write(data)
+	m.it.setErr(err)
+}
+
+// NB(xichen): decodeID decodes the ID without making a copy
+// of the bytes stored in the buffer. The decoded ID is a slice
+// of the internal buffer, which remains valid until the buffered
+// data become invalid (e.g. when Reset() is called).
+func (m *rawMetric) decodeID() {
+	if m.it.err() != nil || m.idDecoded {
+		return
+	}
+	version := m.decodeVersionFn()
+	if m.it.err() != nil {
+		return
+	}
+	if version > metricVersion {
+		err := fmt.Errorf("metric version received %d is higher than supported version %d", version, metricVersion)
+		m.it.setErr(err)
+		return
+	}
+	idLen := m.decodeBytesLenFn()
+	if m.it.err() != nil {
+		return
+	}
+	if idLen < 0 || idLen > m.buf.Len() {
+		err := fmt.Errorf("invalid id length %d", idLen)
+		m.it.setErr(err)
+		return
+	}
+	m.metric.ID = m.readBytesFn(idLen)
+	m.idDecoded = true
+}
+
+func (m *rawMetric) decodeTimestamp() {
+	if m.it.err() != nil || m.timestampDecoded {
+		return
+	}
+	t := m.decodeTimeFn()
+	if m.it.err() != nil {
+		return
+	}
+	m.metric.Timestamp = t
+	m.timestampDecoded = true
+}
+
+func (m *rawMetric) decodeValue() {
+	if m.it.err() != nil || m.valueDecoded {
+		return
+	}
+	v := m.decodeFloat64Fn()
+	if m.it.err() != nil {
+		return
+	}
+	m.metric.Value = v
+	m.valueDecoded = true
+}

--- a/protocol/msgpack/raw_metric_test.go
+++ b/protocol/msgpack/raw_metric_test.go
@@ -1,0 +1,219 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package msgpack
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/m3db/m3metrics/metric"
+	"github.com/m3db/m3metrics/metric/aggregated"
+
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	testRawMetricData      = []byte("foodg")
+	errTestDecodeRawMetric = errors.New("foo")
+)
+
+func testRawMetric() *rawMetric {
+	m := NewRawMetric(testRawMetricData).(*rawMetric)
+
+	m.decodeVersionFn = func() int { return metricVersion }
+	m.decodeBytesLenFn = func() int { return len(testMetric.ID) }
+	m.decodeTimeFn = func() time.Time { return testMetric.Timestamp }
+	m.decodeFloat64Fn = func() float64 { return testMetric.Value }
+	m.readBytesFn = func(n int) []byte { return testRawMetricData[:n] }
+
+	return m
+}
+
+func TestRawMetricDecodeIDExistingError(t *testing.T) {
+	m := testRawMetric()
+	m.it.setErr(errTestDecodeRawMetric)
+	_, err := m.ID()
+	require.Equal(t, errTestDecodeRawMetric, err)
+}
+
+func TestRawMetricDecodeIDVersionError(t *testing.T) {
+	m := testRawMetric()
+	m.decodeVersionFn = func() int { return metricVersion + 1 }
+	_, err := m.ID()
+	require.Error(t, err)
+}
+
+func TestRawMetricDecodeIDBytesLenDecodeError(t *testing.T) {
+	m := testRawMetric()
+	m.decodeBytesLenFn = func() int {
+		m.it.setErr(errTestDecodeRawMetric)
+		return 0
+	}
+	_, err := m.ID()
+	require.Equal(t, errTestDecodeRawMetric, err)
+}
+
+func TestRawMetricDecodeIDBytesLenOutOfRange(t *testing.T) {
+	m := testRawMetric()
+	m.decodeBytesLenFn = func() int { return -1 }
+	_, err := m.ID()
+	require.Error(t, err)
+
+	m = testRawMetric()
+	m.decodeBytesLenFn = func() int { return len(testRawMetricData) + 1 }
+	_, err = m.ID()
+	require.Error(t, err)
+}
+
+func TestRawMetricDecodeIDSuccess(t *testing.T) {
+	m := testRawMetric()
+	id, err := m.ID()
+	require.NoError(t, err)
+	require.Equal(t, testMetric.ID, id)
+	require.True(t, m.idDecoded)
+
+	// Get ID again to make sure we don't re-decode the ID
+	id, err = m.ID()
+	require.NoError(t, err)
+	require.Equal(t, testMetric.ID, id)
+}
+
+func TestRawMetricDecodeTimestampExistingError(t *testing.T) {
+	m := testRawMetric()
+	m.it.setErr(errTestDecodeRawMetric)
+	_, err := m.Timestamp()
+	require.Equal(t, errTestDecodeRawMetric, err)
+}
+
+func TestRawMetricDecodeTimestampDecodeError(t *testing.T) {
+	m := testRawMetric()
+	m.decodeTimeFn = func() time.Time {
+		m.it.setErr(errTestDecodeRawMetric)
+		return time.Time{}
+	}
+	_, err := m.Timestamp()
+	require.Equal(t, errTestDecodeRawMetric, err)
+}
+
+func TestRawMetricDecodeTimestampSuccess(t *testing.T) {
+	m := testRawMetric()
+	timestamp, err := m.Timestamp()
+	require.NoError(t, err)
+	require.Equal(t, testMetric.Timestamp, timestamp)
+	require.True(t, m.timestampDecoded)
+
+	// Get timestamp again to make sure we don't re-decode the timestamp
+	require.NoError(t, err)
+	require.Equal(t, testMetric.Timestamp, timestamp)
+}
+
+func TestRawMetricDecodeValueExistingError(t *testing.T) {
+	m := testRawMetric()
+	m.it.setErr(errTestDecodeRawMetric)
+	_, err := m.Value()
+	require.Equal(t, errTestDecodeRawMetric, err)
+}
+
+func TestRawMetricDecodeValueDecodeError(t *testing.T) {
+	m := testRawMetric()
+	m.decodeFloat64Fn = func() float64 {
+		m.it.setErr(errTestDecodeRawMetric)
+		return 0
+	}
+	_, err := m.Value()
+	require.Equal(t, errTestDecodeRawMetric, err)
+}
+
+func TestRawMetricDecodeValueSuccess(t *testing.T) {
+	m := testRawMetric()
+	value, err := m.Value()
+	require.NoError(t, err)
+	require.Equal(t, testMetric.Value, value)
+	require.True(t, m.valueDecoded)
+
+	value, err = m.Value()
+	require.NoError(t, err)
+	require.Equal(t, testMetric.Value, value)
+}
+
+func TestRawMetricDecodeMetricExistingError(t *testing.T) {
+	m := testRawMetric()
+	m.it.setErr(errTestDecodeRawMetric)
+	_, err := m.Metric()
+	require.Equal(t, errTestDecodeRawMetric, err)
+}
+
+func TestRawMetricDecodeMetricSuccess(t *testing.T) {
+	m := testRawMetric()
+	metric, err := m.Metric()
+	require.NoError(t, err)
+	require.Equal(t, testMetric, metric)
+	require.True(t, m.idDecoded)
+	require.True(t, m.timestampDecoded)
+	require.True(t, m.valueDecoded)
+
+	// Get metric again to make sure we don't re-decode the metric
+	require.NoError(t, err)
+	require.Equal(t, testMetric, metric)
+}
+
+func TestRawMetricBytes(t *testing.T) {
+	m := testRawMetric()
+	require.Equal(t, m.data, m.Bytes())
+}
+
+func TestRawMetricReset(t *testing.T) {
+	metrics := []aggregated.Metric{
+		{ID: metric.ID("foo"), Timestamp: testMetric.Timestamp, Value: 1.0},
+		{ID: metric.ID("bar"), Timestamp: testMetric.Timestamp, Value: 2.3},
+		{ID: metric.ID("baz"), Timestamp: testMetric.Timestamp, Value: 4234.234},
+	}
+	rawMetric := NewRawMetric(nil)
+	for i := 0; i < len(metrics); i++ {
+		rawMetric.Reset(toRawMetric(t, metrics[i]).Bytes())
+		decoded, err := rawMetric.Metric()
+		require.NoError(t, err)
+		require.Equal(t, metrics[i], decoded)
+	}
+}
+
+func TestRawMetricRoundtripStress(t *testing.T) {
+	metrics := []aggregated.Metric{
+		{ID: metric.ID("foo"), Timestamp: testMetric.Timestamp, Value: 1.0},
+		{ID: metric.ID("bar"), Timestamp: testMetric.Timestamp, Value: 2.3},
+		{ID: metric.ID("baz"), Timestamp: testMetric.Timestamp, Value: 4234.234},
+	}
+	var (
+		inputs  []aggregated.Metric
+		results []aggregated.Metric
+		numIter = 2
+	)
+	for i := 0; i < numIter; i++ {
+		input := metrics[i%len(metrics)]
+		inputs = append(inputs, input)
+		rawMetric := toRawMetric(t, input)
+		decoded, err := rawMetric.Metric()
+		require.NoError(t, err)
+		results = append(results, decoded)
+	}
+	require.Equal(t, inputs, results)
+}

--- a/protocol/msgpack/schema.go
+++ b/protocol/msgpack/schema.go
@@ -34,7 +34,7 @@ const (
 )
 
 const (
-	unknownType = iota
+	unknownType objectType = iota
 
 	// Root object type
 	rootObjectType
@@ -49,6 +49,7 @@ const (
 	counterType
 	batchTimerType
 	gaugeType
+	metricType
 	policyType
 	knownResolutionType
 	unknownResolutionType
@@ -70,6 +71,7 @@ const (
 	numCounterFields                = 2
 	numBatchTimerFields             = 2
 	numGaugeFields                  = 2
+	numMetricFields                 = 3
 	numPolicyFields                 = 2
 	numKnownResolutionFields        = 2
 	numUnknownResolutionFields      = 3
@@ -101,6 +103,7 @@ func init() {
 	setNumFieldsForType(counterType, numCounterFields)
 	setNumFieldsForType(batchTimerType, numBatchTimerFields)
 	setNumFieldsForType(gaugeType, numGaugeFields)
+	setNumFieldsForType(metricType, numMetricFields)
 	setNumFieldsForType(policyType, numPolicyFields)
 	setNumFieldsForType(knownResolutionType, numKnownResolutionFields)
 	setNumFieldsForType(unknownResolutionType, numUnknownResolutionFields)

--- a/protocol/msgpack/schema.go
+++ b/protocol/msgpack/schema.go
@@ -25,6 +25,12 @@ type objectType int
 const (
 	// Current version for encoding unaggregated metrics
 	unaggregatedVersion int = 1
+
+	// Current version for encoding aggregated metrics
+	aggregatedVersion int = 1
+
+	// Current metric version
+	metricVersion int = 1
 )
 
 const (
@@ -37,6 +43,7 @@ const (
 	counterWithPoliciesType
 	batchTimerWithPoliciesType
 	gaugeWithPoliciesType
+	rawMetricWithPolicyType
 
 	// Object types not exposed to the encoder interface
 	counterType
@@ -59,6 +66,7 @@ const (
 	numCounterWithPoliciesFields    = 2
 	numBatchTimerWithPoliciesFields = 2
 	numGaugeWithPoliciesFields      = 2
+	numRawMetricWithPolicyFields    = 2
 	numCounterFields                = 2
 	numBatchTimerFields             = 2
 	numGaugeFields                  = 2
@@ -71,6 +79,7 @@ const (
 	numCustomVersionedPolicyFields  = 3
 )
 
+// NB(xichen): use a slice instead of a map to avoid lookup overhead
 var numObjectFields []int
 
 func numFieldsForType(objType objectType) int {
@@ -83,10 +92,12 @@ func setNumFieldsForType(objType objectType, numFields int) {
 
 func init() {
 	numObjectFields = make([]int, int(numObjectTypes))
+
 	setNumFieldsForType(rootObjectType, numRootObjectFields)
 	setNumFieldsForType(counterWithPoliciesType, numCounterWithPoliciesFields)
 	setNumFieldsForType(batchTimerWithPoliciesType, numBatchTimerWithPoliciesFields)
 	setNumFieldsForType(gaugeWithPoliciesType, numGaugeWithPoliciesFields)
+	setNumFieldsForType(rawMetricWithPolicyType, numRawMetricWithPolicyFields)
 	setNumFieldsForType(counterType, numCounterFields)
 	setNumFieldsForType(batchTimerType, numBatchTimerFields)
 	setNumFieldsForType(gaugeType, numGaugeFields)
@@ -97,5 +108,4 @@ func init() {
 	setNumFieldsForType(unknownRetentionType, numKnownRetentionFields)
 	setNumFieldsForType(defaultVersionedPoliciesType, numDefaultVersionedPolicyFields)
 	setNumFieldsForType(customVersionedPoliciesType, numCustomVersionedPolicyFields)
-
 }

--- a/protocol/msgpack/types.go
+++ b/protocol/msgpack/types.go
@@ -40,6 +40,7 @@ type BufferedEncoder struct {
 	*msgpack.Encoder
 
 	Buffer *bytes.Buffer
+	closed bool
 	pool   BufferedEncoderPool
 }
 
@@ -190,6 +191,9 @@ type UnaggregatedIterator interface {
 
 	// Reset resets the iterator
 	Reset(reader io.Reader)
+
+	// Close closes the iterator
+	Close()
 }
 
 // UnaggregatedIteratorOptions provide options for unaggregated iterators
@@ -214,8 +218,26 @@ type UnaggregatedIteratorOptions interface {
 	// PoliciesPool returns the policies pool
 	PoliciesPool() pool.PoliciesPool
 
-	// Validate validates the options
-	Validate() error
+	// SetIteratorPool sets the unaggregated iterator pool
+	SetIteratorPool(value UnaggregatedIteratorPool) UnaggregatedIteratorOptions
+
+	// IteratorPool returns the unaggregated iterator pool
+	IteratorPool() UnaggregatedIteratorPool
+}
+
+// UnaggregatedIteratorAlloc allocates an unaggregated iterator
+type UnaggregatedIteratorAlloc func() UnaggregatedIterator
+
+// UnaggregatedIteratorPool is a pool of unaggregated iterators
+type UnaggregatedIteratorPool interface {
+	// Init initializes the unaggregated iterator pool
+	Init(alloc UnaggregatedIteratorAlloc)
+
+	// Get returns an unaggregated iterator from the pool
+	Get() UnaggregatedIterator
+
+	// Put puts an unaggregated iterator into the pool
+	Put(it UnaggregatedIterator)
 }
 
 // AggregatedEncoder is an encoder for encoding aggregated metrics
@@ -246,6 +268,9 @@ type AggregatedIterator interface {
 
 	// Reset resets the iterator
 	Reset(reader io.Reader)
+
+	// Close closes the iterator
+	Close()
 }
 
 // AggregatedIteratorOptions provide options for aggregated iterators
@@ -257,4 +282,25 @@ type AggregatedIteratorOptions interface {
 	// IgnoreHigherVersion returns whether the iterator ignores messages with
 	// higher-than-supported version
 	IgnoreHigherVersion() bool
+
+	// SetIteratorPool sets the aggregated iterator pool
+	SetIteratorPool(value AggregatedIteratorPool) AggregatedIteratorOptions
+
+	// IteratorPool returns the aggregated iterator pool
+	IteratorPool() AggregatedIteratorPool
+}
+
+// AggregatedIteratorAlloc allocates an aggregated iterator
+type AggregatedIteratorAlloc func() AggregatedIterator
+
+// AggregatedIteratorPool is a pool of aggregated iterators
+type AggregatedIteratorPool interface {
+	// Init initializes the aggregated iterator pool
+	Init(alloc AggregatedIteratorAlloc)
+
+	// Get returns an aggregated iterator from the pool
+	Get() AggregatedIterator
+
+	// Put puts an aggregated iterator into the pool
+	Put(it AggregatedIterator)
 }

--- a/protocol/msgpack/types.go
+++ b/protocol/msgpack/types.go
@@ -23,7 +23,10 @@ package msgpack
 import (
 	"bytes"
 	"io"
+	"time"
 
+	"github.com/m3db/m3metrics/metric"
+	"github.com/m3db/m3metrics/metric/aggregated"
 	"github.com/m3db/m3metrics/metric/unaggregated"
 	"github.com/m3db/m3metrics/policy"
 	"github.com/m3db/m3metrics/pool"
@@ -55,6 +58,107 @@ type BufferedEncoderPool interface {
 	Put(enc BufferedEncoder)
 }
 
+// encoderBase is the base encoder interface
+type encoderBase interface {
+	// Encoder returns the encoder
+	encoder() BufferedEncoder
+
+	// err returns the error encountered during encoding, if any
+	err() error
+
+	// reset resets the encoder
+	reset(encoder BufferedEncoder)
+
+	// resetData resets the encoder data
+	resetData()
+
+	// encodePolicy encodes a policy
+	encodePolicy(p policy.Policy)
+
+	// encodeVersion encodes a version
+	encodeVersion(version int)
+
+	// encodeObjectType encodes an object type
+	encodeObjectType(objType objectType)
+
+	// encodeNumObjectFields encodes the number of object fields
+	encodeNumObjectFields(numFields int)
+
+	// encodeID encodes an ID
+	encodeID(id metric.ID)
+
+	// encodeTime encodes a time
+	encodeTime(t time.Time)
+
+	// encodeVarint encodes an integer value as varint
+	encodeVarint(value int64)
+
+	// encodeFloat64 encodes a float64 value
+	encodeFloat64(value float64)
+
+	// encodeBytes encodes a byte slice
+	encodeBytes(value []byte)
+
+	// encodeArrayLen encodes the length of an array
+	encodeArrayLen(value int)
+}
+
+// iteratorBase is the base iterator interface
+type iteratorBase interface {
+	// Reset resets the iterator
+	reset(reader io.Reader)
+
+	// err returns the error encountered during decoding, if any
+	err() error
+
+	// setErr sets the iterator error
+	setErr(err error)
+
+	// decodePolicy decodes a policy
+	decodePolicy() policy.Policy
+
+	// decodeVersion decodes a version
+	decodeVersion() int
+
+	// decodeObjectType decodes an object type
+	decodeObjectType() objectType
+
+	// decodeNumObjectFields decodes the number of object fields
+	decodeNumObjectFields() int
+
+	// decodeID decodes an ID
+	decodeID() metric.ID
+
+	// decodeTime decodes a time
+	decodeTime() time.Time
+
+	// decodeVarint decodes a variable-width integer value
+	decodeVarint() int64
+
+	// decodeFloat64 decodes a float64 value
+	decodeFloat64() float64
+
+	// decodeBytes decodes a byte slice
+	decodeBytes() []byte
+
+	// decodeBytesLen decodes the length of a byte slice
+	decodeBytesLen() int
+
+	// decodeArrayLen decodes the length of an array
+	decodeArrayLen() int
+
+	// skip skips given number of fields if applicable
+	skip(numFields int)
+
+	// checkNumFieldsForType decodes and compares the number of actual fields with
+	// the number of expected fields for a given object type
+	checkNumFieldsForType(objType objectType) (int, int, bool)
+
+	// checkNumFieldsForTypeWithActual compares the given number of actual fields with
+	// the number of expected fields for a given object type
+	checkNumFieldsForTypeWithActual(objType objectType, numActualFields int) (int, int, bool)
+}
+
 // UnaggregatedEncoder is an encoder for encoding different types of unaggregated metrics
 type UnaggregatedEncoder interface {
 	// EncodeCounterWithPolicies encodes a counter with applicable policies
@@ -73,7 +177,7 @@ type UnaggregatedEncoder interface {
 	Reset(encoder BufferedEncoder)
 }
 
-// UnaggregatedIterator decodes different types of unaggregated metrics iteratively
+// UnaggregatedIterator is an iterator for decoding different types of unaggregated metrics
 type UnaggregatedIterator interface {
 	// Next returns true if there are more items to decode
 	Next() bool
@@ -81,7 +185,7 @@ type UnaggregatedIterator interface {
 	// Value returns the current metric and applicable policies
 	Value() (unaggregated.MetricUnion, policy.VersionedPolicies)
 
-	// Err returns the error encountered during decoding if any
+	// Err returns the error encountered during decoding, if any
 	Err() error
 
 	// Reset resets the iterator
@@ -112,4 +216,45 @@ type UnaggregatedIteratorOptions interface {
 
 	// Validate validates the options
 	Validate() error
+}
+
+// AggregatedEncoder is an encoder for encoding aggregated metrics
+type AggregatedEncoder interface {
+	// EncodeMetricWithPolicy encodes a metric with an applicable policy
+	EncodeMetricWithPolicy(m aggregated.Metric, p policy.Policy) error
+
+	// EncodeRawMetricWithPolicy encodes a raw metric with an applicable policy
+	EncodeRawMetricWithPolicy(m aggregated.RawMetric, p policy.Policy) error
+
+	// Encoder returns the encoder
+	Encoder() BufferedEncoder
+
+	// Reset resets the encoder
+	Reset(encoder BufferedEncoder)
+}
+
+// AggregatedIterator is an iterator for decoding aggregated metrics
+type AggregatedIterator interface {
+	// Next returns true if there are more metrics to decode
+	Next() bool
+
+	// Value returns the current raw metric and the applicable policy
+	Value() (aggregated.RawMetric, policy.Policy)
+
+	// Err returns the error encountered during decoding, if any
+	Err() error
+
+	// Reset resets the iterator
+	Reset(reader io.Reader)
+}
+
+// AggregatedIteratorOptions provide options for aggregated iterators
+type AggregatedIteratorOptions interface {
+	// SetIgnoreHigherVersion determines whether the iterator ignores messages
+	// with higher-than-supported version
+	SetIgnoreHigherVersion(value bool) AggregatedIteratorOptions
+
+	// IgnoreHigherVersion returns whether the iterator ignores messages with
+	// higher-than-supported version
+	IgnoreHigherVersion() bool
 }

--- a/protocol/msgpack/types.go
+++ b/protocol/msgpack/types.go
@@ -163,13 +163,13 @@ type iteratorBase interface {
 // UnaggregatedEncoder is an encoder for encoding different types of unaggregated metrics
 type UnaggregatedEncoder interface {
 	// EncodeCounterWithPolicies encodes a counter with applicable policies
-	EncodeCounterWithPolicies(c unaggregated.Counter, vp policy.VersionedPolicies) error
+	EncodeCounterWithPolicies(cp unaggregated.CounterWithPolicies) error
 
 	// EncodeBatchTimerWithPolicies encodes a batched timer with applicable policies
-	EncodeBatchTimerWithPolicies(bt unaggregated.BatchTimer, vp policy.VersionedPolicies) error
+	EncodeBatchTimerWithPolicies(btp unaggregated.BatchTimerWithPolicies) error
 
 	// EncodeGaugeWithPolicies encodes a gauge with applicable policies
-	EncodeGaugeWithPolicies(g unaggregated.Gauge, vp policy.VersionedPolicies) error
+	EncodeGaugeWithPolicies(gp unaggregated.GaugeWithPolicies) error
 
 	// Encoder returns the encoder
 	Encoder() BufferedEncoder
@@ -243,10 +243,10 @@ type UnaggregatedIteratorPool interface {
 // AggregatedEncoder is an encoder for encoding aggregated metrics
 type AggregatedEncoder interface {
 	// EncodeMetricWithPolicy encodes a metric with an applicable policy
-	EncodeMetricWithPolicy(m aggregated.Metric, p policy.Policy) error
+	EncodeMetricWithPolicy(mp aggregated.MetricWithPolicy) error
 
 	// EncodeRawMetricWithPolicy encodes a raw metric with an applicable policy
-	EncodeRawMetricWithPolicy(m aggregated.RawMetric, p policy.Policy) error
+	EncodeRawMetricWithPolicy(rp aggregated.RawMetricWithPolicy) error
 
 	// Encoder returns the encoder
 	Encoder() BufferedEncoder

--- a/protocol/msgpack/unaggregated_encoder.go
+++ b/protocol/msgpack/unaggregated_encoder.go
@@ -27,9 +27,9 @@ import (
 
 // Various object-level encoding functions to facilitate testing
 type encodeRootObjectFn func(objType objectType)
-type encodeCounterWithPoliciesFn func(c unaggregated.Counter, vp policy.VersionedPolicies)
-type encodeBatchTimerWithPoliciesFn func(bt unaggregated.BatchTimer, vp policy.VersionedPolicies)
-type encodeGaugeWithPoliciesFn func(g unaggregated.Gauge, vp policy.VersionedPolicies)
+type encodeCounterWithPoliciesFn func(cp unaggregated.CounterWithPolicies)
+type encodeBatchTimerWithPoliciesFn func(btp unaggregated.BatchTimerWithPolicies)
+type encodeGaugeWithPoliciesFn func(gp unaggregated.GaugeWithPolicies)
 type encodeCounterFn func(c unaggregated.Counter)
 type encodeBatchTimerFn func(bt unaggregated.BatchTimer)
 type encodeGaugeFn func(g unaggregated.Gauge)
@@ -69,39 +69,30 @@ func NewUnaggregatedEncoder(encoder BufferedEncoder) UnaggregatedEncoder {
 func (enc *unaggregatedEncoder) Encoder() BufferedEncoder      { return enc.encoder() }
 func (enc *unaggregatedEncoder) Reset(encoder BufferedEncoder) { enc.reset(encoder) }
 
-func (enc *unaggregatedEncoder) EncodeCounterWithPolicies(
-	c unaggregated.Counter,
-	vp policy.VersionedPolicies,
-) error {
+func (enc *unaggregatedEncoder) EncodeCounterWithPolicies(cp unaggregated.CounterWithPolicies) error {
 	if err := enc.err(); err != nil {
 		return err
 	}
 	enc.encodeRootObjectFn(counterWithPoliciesType)
-	enc.encodeCounterWithPoliciesFn(c, vp)
+	enc.encodeCounterWithPoliciesFn(cp)
 	return enc.err()
 }
 
-func (enc *unaggregatedEncoder) EncodeBatchTimerWithPolicies(
-	bt unaggregated.BatchTimer,
-	vp policy.VersionedPolicies,
-) error {
+func (enc *unaggregatedEncoder) EncodeBatchTimerWithPolicies(btp unaggregated.BatchTimerWithPolicies) error {
 	if err := enc.err(); err != nil {
 		return err
 	}
 	enc.encodeRootObjectFn(batchTimerWithPoliciesType)
-	enc.encodeBatchTimerWithPoliciesFn(bt, vp)
+	enc.encodeBatchTimerWithPoliciesFn(btp)
 	return enc.err()
 }
 
-func (enc *unaggregatedEncoder) EncodeGaugeWithPolicies(
-	g unaggregated.Gauge,
-	vp policy.VersionedPolicies,
-) error {
+func (enc *unaggregatedEncoder) EncodeGaugeWithPolicies(gp unaggregated.GaugeWithPolicies) error {
 	if err := enc.err(); err != nil {
 		return err
 	}
 	enc.encodeRootObjectFn(gaugeWithPoliciesType)
-	enc.encodeGaugeWithPoliciesFn(g, vp)
+	enc.encodeGaugeWithPoliciesFn(gp)
 	return enc.err()
 }
 
@@ -111,31 +102,22 @@ func (enc *unaggregatedEncoder) encodeRootObject(objType objectType) {
 	enc.encodeObjectType(objType)
 }
 
-func (enc *unaggregatedEncoder) encodeCounterWithPolicies(
-	c unaggregated.Counter,
-	vp policy.VersionedPolicies,
-) {
+func (enc *unaggregatedEncoder) encodeCounterWithPolicies(cp unaggregated.CounterWithPolicies) {
 	enc.encodeNumObjectFields(numFieldsForType(counterWithPoliciesType))
-	enc.encodeCounterFn(c)
-	enc.encodeVersionedPoliciesFn(vp)
+	enc.encodeCounterFn(cp.Counter)
+	enc.encodeVersionedPoliciesFn(cp.VersionedPolicies)
 }
 
-func (enc *unaggregatedEncoder) encodeBatchTimerWithPolicies(
-	bt unaggregated.BatchTimer,
-	vp policy.VersionedPolicies,
-) {
+func (enc *unaggregatedEncoder) encodeBatchTimerWithPolicies(btp unaggregated.BatchTimerWithPolicies) {
 	enc.encodeNumObjectFields(numFieldsForType(batchTimerWithPoliciesType))
-	enc.encodeBatchTimerFn(bt)
-	enc.encodeVersionedPoliciesFn(vp)
+	enc.encodeBatchTimerFn(btp.BatchTimer)
+	enc.encodeVersionedPoliciesFn(btp.VersionedPolicies)
 }
 
-func (enc *unaggregatedEncoder) encodeGaugeWithPolicies(
-	g unaggregated.Gauge,
-	vp policy.VersionedPolicies,
-) {
+func (enc *unaggregatedEncoder) encodeGaugeWithPolicies(gp unaggregated.GaugeWithPolicies) {
 	enc.encodeNumObjectFields(numFieldsForType(gaugeWithPoliciesType))
-	enc.encodeGaugeFn(g)
-	enc.encodeVersionedPoliciesFn(vp)
+	enc.encodeGaugeFn(gp.Gauge)
+	enc.encodeVersionedPoliciesFn(gp.VersionedPolicies)
 }
 
 func (enc *unaggregatedEncoder) encodeCounter(c unaggregated.Counter) {

--- a/protocol/msgpack/unaggregated_encoder.go
+++ b/protocol/msgpack/unaggregated_encoder.go
@@ -21,7 +21,6 @@
 package msgpack
 
 import (
-	"github.com/m3db/m3metrics/metric"
 	"github.com/m3db/m3metrics/metric/unaggregated"
 	"github.com/m3db/m3metrics/policy"
 )
@@ -34,39 +33,26 @@ type encodeGaugeWithPoliciesFn func(g unaggregated.Gauge, vp policy.VersionedPol
 type encodeCounterFn func(c unaggregated.Counter)
 type encodeBatchTimerFn func(bt unaggregated.BatchTimer)
 type encodeGaugeFn func(g unaggregated.Gauge)
-type encodePolicyFn func(p policy.Policy)
 type encodeVersionedPoliciesFn func(vp policy.VersionedPolicies)
-
-// Various low-level encoding functions
-type encodeVarintFn func(value int64)
-type encodeFloat64Fn func(value float64)
-type encodeBytesFn func(value []byte)
-type encodeArrayLenFn func(value int)
 
 // unaggregatedEncoder uses MessagePack for encoding different types of unaggregated metrics.
 // It is not thread-safe.
 type unaggregatedEncoder struct {
-	encoderPool                    BufferedEncoderPool            // pool for internal encoders
-	encoder                        BufferedEncoder                // internal encoder that does the actual encoding
-	err                            error                          // error encountered during encoding
-	encodeRootObjectFn             encodeRootObjectFn             // top-level encoding function
+	encoderBase
+
+	encodeRootObjectFn             encodeRootObjectFn             // root object encoding function
 	encodeCounterWithPoliciesFn    encodeCounterWithPoliciesFn    // counter with policies encoding function
 	encodeBatchTimerWithPoliciesFn encodeBatchTimerWithPoliciesFn // batch timer with policies encoding function
 	encodeGaugeWithPoliciesFn      encodeGaugeWithPoliciesFn      // gauge with policies encoding function
 	encodeCounterFn                encodeCounterFn                // counter encoding function
 	encodeBatchTimerFn             encodeBatchTimerFn             // batch timer encoding function
 	encodeGaugeFn                  encodeGaugeFn                  // gauge encoding function
-	encodePolicyFn                 encodePolicyFn                 // policy encoding function
 	encodeVersionedPoliciesFn      encodeVersionedPoliciesFn      // versioned policies encoding function
-	encodeVarintFn                 encodeVarintFn                 // varint encoding function
-	encodeFloat64Fn                encodeFloat64Fn                // float64 encoding function
-	encodeBytesFn                  encodeBytesFn                  // byte slice encoding function
-	encodeArrayLenFn               encodeArrayLenFn               // array length encoding function
 }
 
 // NewUnaggregatedEncoder creates a new unaggregated encoder
-func NewUnaggregatedEncoder(encoder BufferedEncoder) (UnaggregatedEncoder, error) {
-	enc := &unaggregatedEncoder{encoder: encoder}
+func NewUnaggregatedEncoder(encoder BufferedEncoder) UnaggregatedEncoder {
+	enc := &unaggregatedEncoder{encoderBase: newBaseEncoder(encoder)}
 
 	enc.encodeRootObjectFn = enc.encodeRootObject
 	enc.encodeCounterWithPoliciesFn = enc.encodeCounterWithPolicies
@@ -75,58 +61,48 @@ func NewUnaggregatedEncoder(encoder BufferedEncoder) (UnaggregatedEncoder, error
 	enc.encodeCounterFn = enc.encodeCounter
 	enc.encodeBatchTimerFn = enc.encodeBatchTimer
 	enc.encodeGaugeFn = enc.encodeGauge
-	enc.encodePolicyFn = enc.encodePolicy
 	enc.encodeVersionedPoliciesFn = enc.encodeVersionedPolicies
-	enc.encodeVarintFn = enc.encodeVarint
-	enc.encodeFloat64Fn = enc.encodeFloat64
-	enc.encodeBytesFn = enc.encodeBytes
-	enc.encodeArrayLenFn = enc.encodeArrayLen
 
-	return enc, nil
+	return enc
 }
 
-func (enc *unaggregatedEncoder) Encoder() BufferedEncoder {
-	return enc.encoder
-}
-
-func (enc *unaggregatedEncoder) Reset(encoder BufferedEncoder) {
-	enc.encoder = encoder
-}
+func (enc *unaggregatedEncoder) Encoder() BufferedEncoder      { return enc.encoder() }
+func (enc *unaggregatedEncoder) Reset(encoder BufferedEncoder) { enc.reset(encoder) }
 
 func (enc *unaggregatedEncoder) EncodeCounterWithPolicies(
 	c unaggregated.Counter,
 	vp policy.VersionedPolicies,
 ) error {
-	if enc.err != nil {
-		return enc.err
+	if err := enc.err(); err != nil {
+		return err
 	}
 	enc.encodeRootObjectFn(counterWithPoliciesType)
 	enc.encodeCounterWithPoliciesFn(c, vp)
-	return enc.err
+	return enc.err()
 }
 
 func (enc *unaggregatedEncoder) EncodeBatchTimerWithPolicies(
 	bt unaggregated.BatchTimer,
 	vp policy.VersionedPolicies,
 ) error {
-	if enc.err != nil {
-		return enc.err
+	if err := enc.err(); err != nil {
+		return err
 	}
 	enc.encodeRootObjectFn(batchTimerWithPoliciesType)
 	enc.encodeBatchTimerWithPoliciesFn(bt, vp)
-	return enc.err
+	return enc.err()
 }
 
 func (enc *unaggregatedEncoder) EncodeGaugeWithPolicies(
 	g unaggregated.Gauge,
 	vp policy.VersionedPolicies,
 ) error {
-	if enc.err != nil {
-		return enc.err
+	if err := enc.err(); err != nil {
+		return err
 	}
 	enc.encodeRootObjectFn(gaugeWithPoliciesType)
 	enc.encodeGaugeWithPoliciesFn(g, vp)
-	return enc.err
+	return enc.err()
 }
 
 func (enc *unaggregatedEncoder) encodeRootObject(objType objectType) {
@@ -165,65 +141,22 @@ func (enc *unaggregatedEncoder) encodeGaugeWithPolicies(
 func (enc *unaggregatedEncoder) encodeCounter(c unaggregated.Counter) {
 	enc.encodeNumObjectFields(numFieldsForType(counterType))
 	enc.encodeID(c.ID)
-	enc.encodeVarintFn(int64(c.Value))
+	enc.encodeVarint(int64(c.Value))
 }
 
 func (enc *unaggregatedEncoder) encodeBatchTimer(bt unaggregated.BatchTimer) {
 	enc.encodeNumObjectFields(numFieldsForType(batchTimerType))
 	enc.encodeID(bt.ID)
-	enc.encodeArrayLenFn(len(bt.Values))
+	enc.encodeArrayLen(len(bt.Values))
 	for _, v := range bt.Values {
-		enc.encodeFloat64Fn(v)
+		enc.encodeFloat64(v)
 	}
 }
 
 func (enc *unaggregatedEncoder) encodeGauge(g unaggregated.Gauge) {
 	enc.encodeNumObjectFields(numFieldsForType(gaugeType))
 	enc.encodeID(g.ID)
-	enc.encodeFloat64Fn(g.Value)
-}
-
-func (enc *unaggregatedEncoder) encodePolicy(p policy.Policy) {
-	enc.encodeNumObjectFields(numFieldsForType(policyType))
-	enc.encodeResolution(p.Resolution)
-	enc.encodeRetention(p.Retention)
-}
-
-func (enc *unaggregatedEncoder) encodeResolution(resolution policy.Resolution) {
-	if enc.err != nil {
-		return
-	}
-	// If this is a known resolution, only encode its corresponding value
-	if resolutionValue, err := policy.ValueFromResolution(resolution); err == nil {
-		enc.encodeNumObjectFields(numFieldsForType(knownResolutionType))
-		enc.encodeObjectType(knownResolutionType)
-		enc.encodeVarintFn(int64(resolutionValue))
-		return
-	}
-	// Otherwise encode the entire resolution object
-	// TODO(xichen): validate the resolution before putting it on the wire
-	enc.encodeNumObjectFields(numFieldsForType(unknownResolutionType))
-	enc.encodeObjectType(unknownResolutionType)
-	enc.encodeVarintFn(int64(resolution.Window))
-	enc.encodeVarintFn(int64(resolution.Precision))
-}
-
-func (enc *unaggregatedEncoder) encodeRetention(retention policy.Retention) {
-	if enc.err != nil {
-		return
-	}
-	// If this is a known retention, only encode its corresponding value
-	if retentionValue, err := policy.ValueFromRetention(retention); err == nil {
-		enc.encodeNumObjectFields(numFieldsForType(knownRetentionType))
-		enc.encodeObjectType(knownRetentionType)
-		enc.encodeVarintFn(int64(retentionValue))
-		return
-	}
-	// Otherwise encode the entire retention object
-	// TODO(xichen): validate the retention before putting it on the wire
-	enc.encodeNumObjectFields(numFieldsForType(unknownRetentionType))
-	enc.encodeObjectType(unknownRetentionType)
-	enc.encodeVarintFn(int64(retention))
+	enc.encodeFloat64(g.Value)
 }
 
 func (enc *unaggregatedEncoder) encodeVersionedPolicies(vp policy.VersionedPolicies) {
@@ -239,55 +172,8 @@ func (enc *unaggregatedEncoder) encodeVersionedPolicies(vp policy.VersionedPolic
 	enc.encodeNumObjectFields(numFieldsForType(customVersionedPoliciesType))
 	enc.encodeObjectType(customVersionedPoliciesType)
 	enc.encodeVersion(vp.Version)
-	enc.encodeArrayLenFn(len(vp.Policies))
+	enc.encodeArrayLen(len(vp.Policies))
 	for _, policy := range vp.Policies {
-		enc.encodePolicyFn(policy)
+		enc.encodePolicy(policy)
 	}
-}
-
-func (enc *unaggregatedEncoder) encodeVersion(version int) {
-	enc.encodeVarintFn(int64(version))
-}
-
-func (enc *unaggregatedEncoder) encodeObjectType(objType objectType) {
-	enc.encodeVarintFn(int64(objType))
-}
-
-func (enc *unaggregatedEncoder) encodeNumObjectFields(numFields int) {
-	enc.encodeArrayLenFn(numFields)
-}
-
-func (enc *unaggregatedEncoder) encodeID(id metric.ID) {
-	enc.encodeBytesFn([]byte(id))
-}
-
-// NB(xichen): the underlying msgpack encoder implementation
-// always cast an integer value to an int64 and encodes integer
-// values as varints, regardless of the actual integer type
-func (enc *unaggregatedEncoder) encodeVarint(value int64) {
-	if enc.err != nil {
-		return
-	}
-	enc.err = enc.encoder.EncodeInt64(value)
-}
-
-func (enc *unaggregatedEncoder) encodeFloat64(value float64) {
-	if enc.err != nil {
-		return
-	}
-	enc.err = enc.encoder.EncodeFloat64(value)
-}
-
-func (enc *unaggregatedEncoder) encodeBytes(value []byte) {
-	if enc.err != nil {
-		return
-	}
-	enc.err = enc.encoder.EncodeBytes(value)
-}
-
-func (enc *unaggregatedEncoder) encodeArrayLen(value int) {
-	if enc.err != nil {
-		return
-	}
-	enc.err = enc.encoder.EncodeArrayLen(value)
 }

--- a/protocol/msgpack/unaggregated_encoder_test.go
+++ b/protocol/msgpack/unaggregated_encoder_test.go
@@ -83,7 +83,7 @@ func expectedResultsForPolicy(t *testing.T, p policy.Policy) []interface{} {
 	return results
 }
 
-func expectedResultsForUnaggregatedMetricWithPolicies(t *testing.T, m *unaggregated.MetricUnion, p policy.VersionedPolicies) []interface{} {
+func expectedResultsForUnaggregatedMetricWithPolicies(t *testing.T, m unaggregated.MetricUnion, p policy.VersionedPolicies) []interface{} {
 	results := []interface{}{
 		int64(unaggregatedVersion),
 		numFieldsForType(rootObjectType),
@@ -144,24 +144,24 @@ func expectedResultsForUnaggregatedMetricWithPolicies(t *testing.T, m *unaggrega
 func TestUnaggregatedEncodeCounterWithDefaultPolicies(t *testing.T) {
 	policies := policy.DefaultVersionedPolicies
 	encoder, results := testCapturingUnaggregatedEncoder(t)
-	require.NoError(t, testUnaggregatedEncode(t, encoder, &testCounter, policies))
-	expected := expectedResultsForUnaggregatedMetricWithPolicies(t, &testCounter, policies)
+	require.NoError(t, testUnaggregatedEncode(t, encoder, testCounter, policies))
+	expected := expectedResultsForUnaggregatedMetricWithPolicies(t, testCounter, policies)
 	require.Equal(t, expected, *results)
 }
 
 func TestUnaggregatedEncodeBatchTimerWithDefaultPolicies(t *testing.T) {
 	policies := policy.DefaultVersionedPolicies
 	encoder, results := testCapturingUnaggregatedEncoder(t)
-	require.NoError(t, testUnaggregatedEncode(t, encoder, &testBatchTimer, policies))
-	expected := expectedResultsForUnaggregatedMetricWithPolicies(t, &testBatchTimer, policies)
+	require.NoError(t, testUnaggregatedEncode(t, encoder, testBatchTimer, policies))
+	expected := expectedResultsForUnaggregatedMetricWithPolicies(t, testBatchTimer, policies)
 	require.Equal(t, expected, *results)
 }
 
 func TestUnaggregatedEncodeGaugeWithDefaultPolicies(t *testing.T) {
 	policies := policy.DefaultVersionedPolicies
 	encoder, results := testCapturingUnaggregatedEncoder(t)
-	require.NoError(t, testUnaggregatedEncode(t, encoder, &testGauge, policies))
-	expected := expectedResultsForUnaggregatedMetricWithPolicies(t, &testGauge, policies)
+	require.NoError(t, testUnaggregatedEncode(t, encoder, testGauge, policies))
+	expected := expectedResultsForUnaggregatedMetricWithPolicies(t, testGauge, policies)
 	require.Equal(t, expected, *results)
 }
 
@@ -169,8 +169,8 @@ func TestUnaggregatedEncodeAllTypesWithDefaultPolicies(t *testing.T) {
 	var expected []interface{}
 	encoder, results := testCapturingUnaggregatedEncoder(t)
 	for _, input := range testInputWithAllTypesAndDefaultPolicies {
-		require.NoError(t, testUnaggregatedEncode(t, encoder, &input.metric, input.versionedPolicies))
-		expected = append(expected, expectedResultsForUnaggregatedMetricWithPolicies(t, &input.metric, input.versionedPolicies)...)
+		require.NoError(t, testUnaggregatedEncode(t, encoder, input.metric, input.versionedPolicies))
+		expected = append(expected, expectedResultsForUnaggregatedMetricWithPolicies(t, input.metric, input.versionedPolicies)...)
 	}
 
 	require.Equal(t, expected, *results)
@@ -180,8 +180,8 @@ func TestUnaggregatedEncodeAllTypesWithCustomPolicies(t *testing.T) {
 	var expected []interface{}
 	encoder, results := testCapturingUnaggregatedEncoder(t)
 	for _, input := range testInputWithAllTypesAndCustomPolicies {
-		require.NoError(t, testUnaggregatedEncode(t, encoder, &input.metric, input.versionedPolicies))
-		expected = append(expected, expectedResultsForUnaggregatedMetricWithPolicies(t, &input.metric, input.versionedPolicies)...)
+		require.NoError(t, testUnaggregatedEncode(t, encoder, input.metric, input.versionedPolicies))
+		expected = append(expected, expectedResultsForUnaggregatedMetricWithPolicies(t, input.metric, input.versionedPolicies)...)
 	}
 
 	require.Equal(t, expected, *results)
@@ -199,10 +199,10 @@ func TestUnaggregatedEncodeVarintError(t *testing.T) {
 	}
 
 	// Assert the error is expected
-	require.Equal(t, errTestVarint, testUnaggregatedEncode(t, encoder, &counter, policies))
+	require.Equal(t, errTestVarint, testUnaggregatedEncode(t, encoder, counter, policies))
 
 	// Assert re-encoding doesn't change the error
-	require.Equal(t, errTestVarint, testUnaggregatedEncode(t, encoder, &counter, policies))
+	require.Equal(t, errTestVarint, testUnaggregatedEncode(t, encoder, counter, policies))
 }
 
 func TestUnaggregatedEncodeFloat64Error(t *testing.T) {
@@ -217,10 +217,10 @@ func TestUnaggregatedEncodeFloat64Error(t *testing.T) {
 	}
 
 	// Assert the error is expected
-	require.Equal(t, errTestFloat64, testUnaggregatedEncode(t, encoder, &gauge, policies))
+	require.Equal(t, errTestFloat64, testUnaggregatedEncode(t, encoder, gauge, policies))
 
 	// Assert re-encoding doesn't change the error
-	require.Equal(t, errTestFloat64, testUnaggregatedEncode(t, encoder, &gauge, policies))
+	require.Equal(t, errTestFloat64, testUnaggregatedEncode(t, encoder, gauge, policies))
 }
 
 func TestUnaggregatedEncodeBytesError(t *testing.T) {
@@ -235,10 +235,10 @@ func TestUnaggregatedEncodeBytesError(t *testing.T) {
 	}
 
 	// Assert the error is expected
-	require.Equal(t, errTestBytes, testUnaggregatedEncode(t, encoder, &timer, policies))
+	require.Equal(t, errTestBytes, testUnaggregatedEncode(t, encoder, timer, policies))
 
 	// Assert re-encoding doesn't change the error
-	require.Equal(t, errTestBytes, testUnaggregatedEncode(t, encoder, &timer, policies))
+	require.Equal(t, errTestBytes, testUnaggregatedEncode(t, encoder, timer, policies))
 }
 
 func TestUnaggregatedEncodeArrayLenError(t *testing.T) {
@@ -261,8 +261,8 @@ func TestUnaggregatedEncodeArrayLenError(t *testing.T) {
 	}
 
 	// Assert the error is expected
-	require.Equal(t, errTestArrayLen, testUnaggregatedEncode(t, encoder, &gauge, policies))
+	require.Equal(t, errTestArrayLen, testUnaggregatedEncode(t, encoder, gauge, policies))
 
 	// Assert re-encoding doesn't change the error
-	require.Equal(t, errTestArrayLen, testUnaggregatedEncode(t, encoder, &gauge, policies))
+	require.Equal(t, errTestArrayLen, testUnaggregatedEncode(t, encoder, gauge, policies))
 }

--- a/protocol/msgpack/unaggregated_iterator_pool.go
+++ b/protocol/msgpack/unaggregated_iterator_pool.go
@@ -20,22 +20,27 @@
 
 package msgpack
 
-import (
-	"testing"
+import "github.com/m3db/m3x/pool"
 
-	"github.com/stretchr/testify/require"
-)
-
-var (
-	testUnaggregatedIteratorOpts = NewUnaggregatedIteratorOptions()
-)
-
-func TestUnaggregatedIteratorOptionsValidateNoFloatsPool(t *testing.T) {
-	opts := testUnaggregatedIteratorOpts.SetFloatsPool(nil)
-	require.Equal(t, errNoFloatsPool, opts.Validate())
+type unaggregatedIteratorPool struct {
+	pool pool.ObjectPool
 }
 
-func TestUnaggregatedIteratorOptionsValidateNoPoliciesPool(t *testing.T) {
-	opts := testUnaggregatedIteratorOpts.SetPoliciesPool(nil)
-	require.Equal(t, errNoPoliciesPool, opts.Validate())
+// NewUnaggregatedIteratorPool creates a new pool for unaggregated iterators
+func NewUnaggregatedIteratorPool(opts pool.ObjectPoolOptions) UnaggregatedIteratorPool {
+	return &unaggregatedIteratorPool{pool: pool.NewObjectPool(opts)}
+}
+
+func (p *unaggregatedIteratorPool) Init(alloc UnaggregatedIteratorAlloc) {
+	p.pool.Init(func() interface{} {
+		return alloc()
+	})
+}
+
+func (p *unaggregatedIteratorPool) Get() UnaggregatedIterator {
+	return p.pool.Get().(UnaggregatedIterator)
+}
+
+func (p *unaggregatedIteratorPool) Put(it UnaggregatedIterator) {
+	p.pool.Put(it)
 }

--- a/protocol/msgpack/unaggregated_iterator_pool_test.go
+++ b/protocol/msgpack/unaggregated_iterator_pool_test.go
@@ -20,27 +20,35 @@
 
 package msgpack
 
-import "github.com/m3db/m3x/pool"
+import (
+	"bytes"
+	"testing"
 
-type bufferedEncoderPool struct {
-	pool pool.ObjectPool
-}
+	"github.com/m3db/m3x/pool"
 
-// NewBufferedEncoderPool creates a new pool for buffered encoders
-func NewBufferedEncoderPool(opts pool.ObjectPoolOptions) BufferedEncoderPool {
-	return &bufferedEncoderPool{pool: pool.NewObjectPool(opts)}
-}
+	"github.com/stretchr/testify/require"
+)
 
-func (p *bufferedEncoderPool) Init(alloc BufferedEncoderAlloc) {
-	p.pool.Init(func() interface{} {
-		return alloc()
+func TestUnaggregatedIteratorPool(t *testing.T) {
+	p := NewUnaggregatedIteratorPool(pool.NewObjectPoolOptions().SetSize(1))
+	itOpts := NewUnaggregatedIteratorOptions().SetIteratorPool(p)
+	p.Init(func() UnaggregatedIterator {
+		return NewUnaggregatedIterator(nil, itOpts)
 	})
-}
 
-func (p *bufferedEncoderPool) Get() BufferedEncoder {
-	return p.pool.Get().(BufferedEncoder)
-}
+	// Retrieve an iterator from the pool
+	it := p.Get()
+	it.Reset(bytes.NewBuffer([]byte{0x1, 0x2}))
 
-func (p *bufferedEncoderPool) Put(encoder BufferedEncoder) {
-	p.pool.Put(encoder)
+	// Closing the iterator should put it back to the pool
+	it.Close()
+	require.True(t, it.(*unaggregatedIterator).closed)
+
+	// Retrieve the iterator and assert it's the same iterator
+	it = p.Get()
+	require.True(t, it.(*unaggregatedIterator).closed)
+
+	// Reset the iterator and assert it's been reset
+	it.Reset(nil)
+	require.False(t, it.(*unaggregatedIterator).closed)
 }

--- a/protocol/msgpack/unaggregated_iterator_test.go
+++ b/protocol/msgpack/unaggregated_iterator_test.go
@@ -328,9 +328,8 @@ func TestUnaggregatedIteratorDecodeCounterFewerFieldsThanExpected(t *testing.T) 
 }
 
 func TestUnaggregatedIteratorDecodeError(t *testing.T) {
-	it, err := NewUnaggregatedIterator(nil, nil)
-	require.NoError(t, err)
-	err = errors.New("foo")
+	it := NewUnaggregatedIterator(nil, nil)
+	err := errors.New("foo")
 	it.(*unaggregatedIterator).setErr(err)
 
 	require.False(t, it.Next())
@@ -338,13 +337,21 @@ func TestUnaggregatedIteratorDecodeError(t *testing.T) {
 }
 
 func TestUnaggregatedIteratorReset(t *testing.T) {
-	it, err := NewUnaggregatedIterator(nil, nil)
-	require.NoError(t, err)
-	err = errors.New("foo")
+	it := NewUnaggregatedIterator(nil, nil)
+	err := errors.New("foo")
 	it.(*unaggregatedIterator).setErr(err)
 
 	it.Reset(nil)
 	require.NoError(t, it.(*unaggregatedIterator).Err())
+	require.False(t, it.(*unaggregatedIterator).closed)
+}
+
+func TestUnaggregatedIteratorClose(t *testing.T) {
+	it := NewUnaggregatedIterator(nil, nil)
+	it.Close()
+	require.False(t, it.Next())
+	require.NoError(t, it.Err())
+	require.True(t, it.(*unaggregatedIterator).closed)
 }
 
 func TestUnaggregatedIteratorDecodeInvalidTimeUnit(t *testing.T) {

--- a/protocol/msgpack/unaggregated_iterator_test.go
+++ b/protocol/msgpack/unaggregated_iterator_test.go
@@ -73,6 +73,7 @@ func TestUnaggregatedIteratorDecodeNewerVersionThanSupported(t *testing.T) {
 
 	// Check that we skipped the first counter and successfully decoded the second counter
 	it := testUnaggregatedIterator(t, bytes.NewBuffer(enc.Encoder().Buffer.Bytes()))
+	it.(*unaggregatedIterator).ignoreHigherVersion = true
 	validateUnaggregatedDecodeResults(t, it, []metricWithPolicies{input}, io.EOF)
 
 	it.Reset(bytes.NewBuffer(enc.Encoder().Buffer.Bytes()))

--- a/protocol/msgpack/unaggregated_roundtrip_test.go
+++ b/protocol/msgpack/unaggregated_roundtrip_test.go
@@ -145,14 +145,23 @@ func testUnaggregatedIterator(t *testing.T, reader io.Reader) UnaggregatedIterat
 	return NewUnaggregatedIterator(reader, opts)
 }
 
-func testUnaggregatedEncode(t *testing.T, encoder UnaggregatedEncoder, m *unaggregated.MetricUnion, p policy.VersionedPolicies) error {
+func testUnaggregatedEncode(t *testing.T, encoder UnaggregatedEncoder, m unaggregated.MetricUnion, p policy.VersionedPolicies) error {
 	switch m.Type {
 	case unaggregated.CounterType:
-		return encoder.EncodeCounterWithPolicies(m.Counter(), p)
+		return encoder.EncodeCounterWithPolicies(unaggregated.CounterWithPolicies{
+			Counter:           m.Counter(),
+			VersionedPolicies: p,
+		})
 	case unaggregated.BatchTimerType:
-		return encoder.EncodeBatchTimerWithPolicies(m.BatchTimer(), p)
+		return encoder.EncodeBatchTimerWithPolicies(unaggregated.BatchTimerWithPolicies{
+			BatchTimer:        m.BatchTimer(),
+			VersionedPolicies: p,
+		})
 	case unaggregated.GaugeType:
-		return encoder.EncodeGaugeWithPolicies(m.Gauge(), p)
+		return encoder.EncodeGaugeWithPolicies(unaggregated.GaugeWithPolicies{
+			Gauge:             m.Gauge(),
+			VersionedPolicies: p,
+		})
 	default:
 		return fmt.Errorf("unrecognized metric type %v", m.Type)
 	}
@@ -189,7 +198,7 @@ func validateUnaggregatedRoundtripWithEncoderAndIterator(
 	// Encode the batch of metrics
 	encoder.Reset(newBufferedEncoder())
 	for _, input := range inputs {
-		testUnaggregatedEncode(t, encoder, &input.metric, input.versionedPolicies)
+		testUnaggregatedEncode(t, encoder, input.metric, input.versionedPolicies)
 	}
 
 	// Decode the batch of metrics

--- a/protocol/msgpack/unaggregated_roundtrip_test.go
+++ b/protocol/msgpack/unaggregated_roundtrip_test.go
@@ -142,9 +142,7 @@ func testUnaggregatedEncoder(t *testing.T) UnaggregatedEncoder {
 
 func testUnaggregatedIterator(t *testing.T, reader io.Reader) UnaggregatedIterator {
 	opts := NewUnaggregatedIteratorOptions()
-	iterator, err := NewUnaggregatedIterator(reader, opts)
-	require.NoError(t, err)
-	return iterator
+	return NewUnaggregatedIterator(reader, opts)
 }
 
 func testUnaggregatedEncode(t *testing.T, encoder UnaggregatedEncoder, m *unaggregated.MetricUnion, p policy.VersionedPolicies) error {

--- a/protocol/msgpack/wire_format.md
+++ b/protocol/msgpack/wire_format.md
@@ -1,4 +1,4 @@
-## Wire format
+## Wire format for unaggregated metrics
 
 * Message format
   * Version
@@ -9,17 +9,17 @@
     * BatchTimerWithPolicies
     * GaugeWithPolicies
 
-* CounterWithPolicies format
+* CounterWithPolicies object
   * Number of CounterWithPolicies fields
   * Counter object
   * VersionedPolicies object
 
-* BatchTimerWithPolicies format
+* BatchTimerWithPolicies object
   * Number of BatchTimerWithPolicies fields
   * BatchTimer object
   * VersionedPolicies object
 
-* GaugeWithPolicies format
+* GaugeWithPolicies object
   * Number of GaugeWithPolicies fields
   * Gauge object
   * VersionedPolicies object
@@ -71,6 +71,28 @@
       * RetentionValue
     * UnknownRetention
       * Retention duration in nanoseconds
+
+## Wire format for aggregated metrics
+
+* Message format
+  * Version
+  * Number of root object fields
+  * Root object type
+  * Root object (can be one of the following):
+    * RawMetricWithPolicy
+
+* RawMetricWithPolicy object
+  * Number of RawMetricWithPolicy fields
+  * Raw metric object
+  * Policy object
+
+* Raw metric object
+  * Version
+  * Metric ID
+  * Metric timestamp
+  * Metric value
+
+* Policy object (same format as in unaggregated metrics)
 
 ## Schema changes
 

--- a/protocol/msgpack/wire_format.md
+++ b/protocol/msgpack/wire_format.md
@@ -88,6 +88,7 @@
 
 * Raw metric object
   * Version
+  * Number of metric fields
   * Metric ID
   * Metric timestamp
   * Metric value


### PR DESCRIPTION
cc @robskillington @kobolog @martin-mao @cw9 

This PR adds the message-backed encoder and decoder for aggregated metrics. 

Since the encoders / iterators for unaggregated metrics and aggregated metrics share a lot of common low-level encoding/decoding functions, I factored them out into base interfaces shared by both encoders / iterators.