### PR TITLE
Encode cutover time for versioned policies

### DIFF
--- a/policy/policy.go
+++ b/policy/policy.go
@@ -26,8 +26,11 @@ import (
 	"github.com/m3db/m3x/time"
 )
 
-// DefaultPolicyVersion is the version for the default policy
 const (
+	// InitPolicyVersion is the version of an uninitialized policy
+	InitPolicyVersion = -1
+
+	// DefaultPolicyVersion is the version for the default policy
 	DefaultPolicyVersion = 0
 )
 

--- a/policy/types.go
+++ b/policy/types.go
@@ -53,6 +53,9 @@ type VersionedPolicies struct {
 	// Version is the version of the policies
 	Version int
 
+	// Cutover is when the policies take effect
+	Cutover time.Time
+
 	// Policies represent the list of policies
 	Policies []Policy
 }

--- a/protocol/msgpack/aggregated_encoder_test.go
+++ b/protocol/msgpack/aggregated_encoder_test.go
@@ -29,26 +29,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func testCapturingBaseEncoder(encoder encoderBase) *[]interface{} {
-	baseEncoder := encoder.(*baseEncoder)
-
-	var result []interface{}
-	baseEncoder.encodeVarintFn = func(value int64) {
-		result = append(result, value)
-	}
-	baseEncoder.encodeFloat64Fn = func(value float64) {
-		result = append(result, value)
-	}
-	baseEncoder.encodeBytesFn = func(value []byte) {
-		result = append(result, value)
-	}
-	baseEncoder.encodeArrayLenFn = func(value int) {
-		result = append(result, value)
-	}
-
-	return &result
-}
-
 func testCapturingAggregatedEncoder(t *testing.T) (AggregatedEncoder, *[]interface{}) {
 	encoder := testAggregatedEncoder(t).(*aggregatedEncoder)
 	result := testCapturingBaseEncoder(encoder.encoderBase)
@@ -90,7 +70,7 @@ func TestAggregatedEncodeMetric(t *testing.T) {
 		int64(metricVersion),
 		int(numFieldsForType(metricType)),
 		[]byte(testMetric.ID),
-		int64(testMetric.Timestamp.UnixNano()),
+		testMetric.Timestamp,
 		testMetric.Value,
 	}
 	require.Equal(t, expected, *result)

--- a/protocol/msgpack/aggregated_encoder_test.go
+++ b/protocol/msgpack/aggregated_encoder_test.go
@@ -105,3 +105,13 @@ func TestAggregatedEncodeError(t *testing.T) {
 	// Assert re-encoding doesn't change the error
 	require.Equal(t, errTestVarint, testAggregatedEncode(t, encoder, testMetric, testPolicy))
 }
+
+func TestAggregatedEncoderReset(t *testing.T) {
+	encoder := testAggregatedEncoder(t).(*aggregatedEncoder)
+	baseEncoder := encoder.encoderBase.(*baseEncoder)
+	baseEncoder.encodeErr = errTestVarint
+	require.Equal(t, errTestVarint, testAggregatedEncode(t, encoder, testMetric, testPolicy))
+
+	encoder.Reset(newBufferedEncoder())
+	require.NoError(t, testAggregatedEncode(t, encoder, testMetric, testPolicy))
+}

--- a/protocol/msgpack/base_encoder.go
+++ b/protocol/msgpack/base_encoder.go
@@ -61,7 +61,6 @@ func newBaseEncoder(encoder BufferedEncoder) encoderBase {
 
 func (enc *baseEncoder) encoder() BufferedEncoder            { return enc.bufEncoder }
 func (enc *baseEncoder) err() error                          { return enc.encodeErr }
-func (enc *baseEncoder) reset(encoder BufferedEncoder)       { enc.bufEncoder = encoder }
 func (enc *baseEncoder) resetData()                          { enc.bufEncoder.Reset() }
 func (enc *baseEncoder) encodePolicy(p policy.Policy)        { enc.encodePolicyFn(p) }
 func (enc *baseEncoder) encodeVersion(version int)           { enc.encodeVarint(int64(version)) }
@@ -73,6 +72,11 @@ func (enc *baseEncoder) encodeVarint(value int64)            { enc.encodeVarintF
 func (enc *baseEncoder) encodeFloat64(value float64)         { enc.encodeFloat64Fn(value) }
 func (enc *baseEncoder) encodeBytes(value []byte)            { enc.encodeBytesFn(value) }
 func (enc *baseEncoder) encodeArrayLen(value int)            { enc.encodeArrayLenFn(value) }
+
+func (enc *baseEncoder) reset(encoder BufferedEncoder) {
+	enc.bufEncoder = encoder
+	enc.encodeErr = nil
+}
 
 func (enc *baseEncoder) encodePolicyInternal(p policy.Policy) {
 	enc.encodeNumObjectFields(numFieldsForType(policyType))

--- a/protocol/msgpack/base_iterator.go
+++ b/protocol/msgpack/base_iterator.go
@@ -160,7 +160,12 @@ func (it *baseIterator) decodeID() metric.ID {
 }
 
 func (it *baseIterator) decodeTime() time.Time {
-	return time.Unix(0, it.decodeVarint())
+	if it.decodeErr != nil {
+		return time.Time{}
+	}
+	value, err := it.decoder.DecodeTime()
+	it.decodeErr = err
+	return value
 }
 
 // NB(xichen): the underlying msgpack decoder implementation

--- a/protocol/msgpack/schema.go
+++ b/protocol/msgpack/schema.go
@@ -78,7 +78,7 @@ const (
 	numKnownRetentionFields         = 2
 	numUnknownRetentionFields       = 2
 	numDefaultVersionedPolicyFields = 1
-	numCustomVersionedPolicyFields  = 3
+	numCustomVersionedPolicyFields  = 4
 )
 
 // NB(xichen): use a slice instead of a map to avoid lookup overhead

--- a/protocol/msgpack/unaggregated_encoder.go
+++ b/protocol/msgpack/unaggregated_encoder.go
@@ -154,6 +154,7 @@ func (enc *unaggregatedEncoder) encodeVersionedPolicies(vp policy.VersionedPolic
 	enc.encodeNumObjectFields(numFieldsForType(customVersionedPoliciesType))
 	enc.encodeObjectType(customVersionedPoliciesType)
 	enc.encodeVersion(vp.Version)
+	enc.encodeTime(vp.Cutover)
 	enc.encodeArrayLen(len(vp.Policies))
 	for _, policy := range vp.Policies {
 		enc.encodePolicy(policy)

--- a/protocol/msgpack/unaggregated_encoder_test.go
+++ b/protocol/msgpack/unaggregated_encoder_test.go
@@ -131,6 +131,7 @@ func expectedResultsForUnaggregatedMetricWithPolicies(t *testing.T, m unaggregat
 			numFieldsForType(customVersionedPoliciesType),
 			int64(customVersionedPoliciesType),
 			int64(p.Version),
+			p.Cutover,
 			len(p.Policies),
 		}...)
 		for _, p := range p.Policies {
@@ -245,6 +246,7 @@ func TestUnaggregatedEncodeArrayLenError(t *testing.T) {
 	gauge := testGauge
 	policies := policy.VersionedPolicies{
 		Version: 1,
+		Cutover: time.Now(),
 		Policies: []policy.Policy{
 			{
 				Resolution: policy.Resolution{Window: time.Second, Precision: xtime.Second},

--- a/protocol/msgpack/unaggregated_encoder_test.go
+++ b/protocol/msgpack/unaggregated_encoder_test.go
@@ -268,3 +268,16 @@ func TestUnaggregatedEncodeArrayLenError(t *testing.T) {
 	// Assert re-encoding doesn't change the error
 	require.Equal(t, errTestArrayLen, testUnaggregatedEncode(t, encoder, gauge, policies))
 }
+
+func TestUnaggregatedEncoderReset(t *testing.T) {
+	metric := testCounter
+	policies := policy.DefaultVersionedPolicies
+
+	encoder := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
+	baseEncoder := encoder.encoderBase.(*baseEncoder)
+	baseEncoder.encodeErr = errTestVarint
+	require.Equal(t, errTestVarint, testUnaggregatedEncode(t, encoder, metric, policies))
+
+	encoder.Reset(newBufferedEncoder())
+	require.NoError(t, testUnaggregatedEncode(t, encoder, metric, policies))
+}

--- a/protocol/msgpack/unaggregated_iterator.go
+++ b/protocol/msgpack/unaggregated_iterator.go
@@ -200,12 +200,17 @@ func (it *unaggregatedIterator) decodeVersionedPolicies() {
 		it.skip(numActualFields - numExpectedFields)
 	case customVersionedPoliciesType:
 		version := int(it.decodeVarint())
+		cutover := it.decodeTime()
 		numPolicies := it.decodeArrayLen()
 		policies := it.policiesPool.Get(numPolicies)
 		for i := 0; i < numPolicies; i++ {
 			policies = append(policies, it.decodePolicy())
 		}
-		it.versionedPolicies = policy.VersionedPolicies{Version: version, Policies: policies}
+		it.versionedPolicies = policy.VersionedPolicies{
+			Version:  version,
+			Cutover:  cutover,
+			Policies: policies,
+		}
 		it.skip(numActualFields - numExpectedFields)
 	default:
 		it.setErr(fmt.Errorf("unrecognized versioned policies type: %v", versionedPoliciesType))

--- a/protocol/msgpack/unaggregated_iterator_test.go
+++ b/protocol/msgpack/unaggregated_iterator_test.go
@@ -201,6 +201,7 @@ func TestUnaggregatedIteratorDecodePolicyWithCustomResolution(t *testing.T) {
 		metric: testGauge,
 		versionedPolicies: policy.VersionedPolicies{
 			Version: 1,
+			Cutover: time.Now(),
 			Policies: []policy.Policy{
 				{
 					Resolution: policy.Resolution{Window: 3 * time.Second, Precision: xtime.Second},
@@ -223,6 +224,7 @@ func TestUnaggregatedIteratorDecodePolicyWithCustomRetention(t *testing.T) {
 		metric: testGauge,
 		versionedPolicies: policy.VersionedPolicies{
 			Version: 1,
+			Cutover: time.Now(),
 			Policies: []policy.Policy{
 				{
 					Resolution: policy.Resolution{Window: time.Second, Precision: xtime.Second},
@@ -245,6 +247,7 @@ func TestUnaggregatedIteratorDecodePolicyMoreFieldsThanExpected(t *testing.T) {
 		metric: testGauge,
 		versionedPolicies: policy.VersionedPolicies{
 			Version: 1,
+			Cutover: time.Now(),
 			Policies: []policy.Policy{
 				{
 					Resolution: policy.Resolution{Window: time.Second, Precision: xtime.Second},
@@ -276,6 +279,7 @@ func TestUnaggregatedIteratorDecodeVersionedPoliciesMoreFieldsThanExpected(t *te
 		metric: testGauge,
 		versionedPolicies: policy.VersionedPolicies{
 			Version: 1,
+			Cutover: time.Now(),
 			Policies: []policy.Policy{
 				{
 					Resolution: policy.Resolution{Window: time.Second, Precision: xtime.Second},
@@ -291,6 +295,7 @@ func TestUnaggregatedIteratorDecodeVersionedPoliciesMoreFieldsThanExpected(t *te
 		enc.encodeNumObjectFields(numFieldsForType(customVersionedPoliciesType) + 1)
 		enc.encodeObjectType(customVersionedPoliciesType)
 		enc.encodeVersion(vp.Version)
+		enc.encodeTime(vp.Cutover)
 		enc.encodeArrayLen(len(vp.Policies))
 		for _, policy := range vp.Policies {
 			enc.encodePolicy(policy)

--- a/protocol/msgpack/wire_format.md
+++ b/protocol/msgpack/wire_format.md
@@ -41,11 +41,13 @@
 
 * VersionedPolicies object
   * Number of VersionedPolicies fields
-  * Versioned Policies type
   * Versioned Policies (can be one of the following)
     * DefaultVersionedPolicies
+      * Versioned Policies type
     * CustomVersionedPolicies
+      * Versioned Policies type
       * Version
+      * Cutover
       * List of Policy objects
 
 * Policy object
@@ -55,21 +57,23 @@
 
 * Resolution object
   * Number of Resolution fields
-  * Resolution type
   * Resolution (can be one of the following)
     * KnownResolution
+      * Resolution type
       * ResolutionValue
     * UnknownResolution
+      * Resolution type
       * Resolution window in nanoseconds
       * Resolution precision
 
 * Retention object
   * Number of Retention fields
-  * Retention type
   * Retention (can be one of the following)
     * KnownRetention
+      * Retention type
       * RetentionValue
     * UnknownRetention
+      * Retention type
       * Retention duration in nanoseconds
 
 ## Wire format for aggregated metrics


### PR DESCRIPTION
cc @robskillington @kobolog @cw9 @martin-mao 

Also use the `EncodeTime` API provided by msgpack to encode time for space savings.