### PR TITLE
Clear iterators before putting them back into pools

### DIFF
--- a/policy/policy.go
+++ b/policy/policy.go
@@ -34,8 +34,10 @@ const (
 	DefaultPolicyVersion = 0
 )
 
-// DefaultVersionedPolicies are the default versioned policies
 var (
+	emptyVersionedPolicies VersionedPolicies
+
+	// DefaultVersionedPolicies are the default versioned policies
 	DefaultVersionedPolicies = VersionedPolicies{
 		Version: DefaultPolicyVersion,
 		Policies: []Policy{
@@ -50,3 +52,8 @@ var (
 		},
 	}
 )
+
+// Reset resets the versioned policies
+func (vp *VersionedPolicies) Reset() {
+	*vp = emptyVersionedPolicies
+}

--- a/protocol/msgpack/aggregated_iterator.go
+++ b/protocol/msgpack/aggregated_iterator.go
@@ -75,6 +75,8 @@ func (it *aggregatedIterator) Close() {
 		return
 	}
 	it.closed = true
+	it.reset(emptyReader)
+	it.metric.Reset(nil)
 	if it.iteratorPool != nil {
 		it.iteratorPool.Put(it)
 	}

--- a/protocol/msgpack/base_iterator.go
+++ b/protocol/msgpack/base_iterator.go
@@ -21,6 +21,7 @@
 package msgpack
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"time"
@@ -30,6 +31,10 @@ import (
 	"github.com/m3db/m3x/time"
 
 	msgpack "gopkg.in/vmihailenco/msgpack.v2"
+)
+
+var (
+	emptyReader *bytes.Buffer
 )
 
 // baseIterator is the base iterator that provides common decoding APIs

--- a/protocol/msgpack/unaggregated_iterator.go
+++ b/protocol/msgpack/unaggregated_iterator.go
@@ -86,6 +86,9 @@ func (it *unaggregatedIterator) Close() {
 		return
 	}
 	it.closed = true
+	it.reset(emptyReader)
+	it.metric.Reset()
+	it.versionedPolicies.Reset()
 	if it.iteratorPool != nil {
 		it.iteratorPool.Put(it)
 	}


### PR DESCRIPTION
cc @kobolog @cw9 @robskillington 

This PR clears the iterator fields before putting them back into pools to avoid pooled objects holding references to large amount of memory, causing a memory leak