### PR TITLE
Decoded raw metric ID should be part of raw data slice

### DIFF
--- a/protocol/msgpack/aggregated_roundtrip_test.go
+++ b/protocol/msgpack/aggregated_roundtrip_test.go
@@ -41,6 +41,11 @@ var (
 		Timestamp: time.Now(),
 		Value:     123.45,
 	}
+	testMetric2 = aggregated.Metric{
+		ID:        metric.ID("bar"),
+		Timestamp: time.Now(),
+		Value:     678.90,
+	}
 
 	testPolicy = policy.Policy{
 		Resolution: policy.Resolution{Window: time.Second, Precision: xtime.Second},
@@ -175,7 +180,7 @@ func TestAggregatedEncodeDecodeStress(t *testing.T) {
 				})
 			} else {
 				inputs = append(inputs, metricWithPolicy{
-					metric: toRawMetric(t, testMetric),
+					metric: toRawMetric(t, testMetric2),
 					policy: testPolicy,
 				})
 			}

--- a/protocol/msgpack/raw_metric_test.go
+++ b/protocol/msgpack/raw_metric_test.go
@@ -87,8 +87,6 @@ func testRawMetric() *rawMetric {
 
 	m := NewRawMetric(testRawMetricData).(*rawMetric)
 	m.it = mockIt
-	m.readBytesFn = func(n int) []byte { return testRawMetricData[:n] }
-
 	return m
 }
 


### PR DESCRIPTION
cc @kobolog @cw9 @robskillington 

This PR fixes a bug where the ID for the raw metric used to point to the internal buffer instead of the raw data slice, which causes issues when the same iterator is reused to decode multiple metrics.