### PR TITLE
Support encoding metrics with chunked IDs efficiently

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: d8de5319d9d2b69ac7538271d44105f6007d92f0815d936b0551c4a7e3721f6f
-updated: 2016-12-13T22:42:28.879149226-05:00
+hash: 22996bdfd992015c6b999771d64996343958df212db5c82b032b8142caaa30ff
+updated: 2017-01-07T22:32:44.56183669-05:00
 imports:
 - name: github.com/facebookgo/clock
   version: 600d898af40aa09a7a93ecb9265d87b0504b6f03
@@ -21,7 +21,7 @@ imports:
   subpackages:
   - context
 - name: google.golang.org/appengine
-  version: ca59ef35f409df61fa4a5f8290ff289b37eccfb8
+  version: 8758a385849434ba5eac8aeedcf5192c5a0f5f10
   subpackages:
   - datastore
   - internal
@@ -32,7 +32,7 @@ imports:
   - internal/modules
   - internal/remote_api
 - name: gopkg.in/vmihailenco/msgpack.v2
-  version: 94af6ea04d2da6a09d6914ca79b8fb94f3acbba4
+  version: a1382b1ce0c749733b814157c245e02cc1f41076
   subpackages:
   - codes
 testImports:

--- a/glide.yaml
+++ b/glide.yaml
@@ -6,7 +6,7 @@ import:
   - pool
   - time
 - package: gopkg.in/vmihailenco/msgpack.v2
-  version: 94af6ea04d2da6a09d6914ca79b8fb94f3acbba4
+  version: a1382b1ce0c749733b814157c245e02cc1f41076
 testImport:
 - package: github.com/stretchr/testify
   version: d77da356e56a7428ad25149ca77381849a6a5232

--- a/metric/aggregated/types.go
+++ b/metric/aggregated/types.go
@@ -29,7 +29,14 @@ import (
 
 // Metric is a metric, which is essentially a named value at certain time.
 type Metric struct {
-	ID        metric.ID
+	metric.ID
+	Timestamp time.Time
+	Value     float64
+}
+
+// ChunkedMetric is a metric with a chunked ID
+type ChunkedMetric struct {
+	metric.ChunkedID
 	Timestamp time.Time
 	Value     float64
 }
@@ -59,6 +66,12 @@ type RawMetric interface {
 // MetricWithPolicy is a metric with applicable policy
 type MetricWithPolicy struct {
 	Metric
+	policy.Policy
+}
+
+// ChunkedMetricWithPolicy is a chunked metric with applicable policy
+type ChunkedMetricWithPolicy struct {
+	ChunkedMetric
 	policy.Policy
 }
 

--- a/metric/common.go
+++ b/metric/common.go
@@ -20,6 +20,8 @@
 
 package metric
 
+import "fmt"
+
 // ID is the metric id
 // TODO(xichen): make ID a union of numeric ID and bytes-backed IDs
 // so we can compress IDs on a per-connection basis
@@ -27,3 +29,15 @@ type ID []byte
 
 // String is the string representation of an id
 func (id ID) String() string { return string(id) }
+
+// ChunkedID is a three-part id
+type ChunkedID struct {
+	Prefix []byte
+	Data   []byte
+	Suffix []byte
+}
+
+// String is the string representation of the chunked id
+func (cid ChunkedID) String() string {
+	return fmt.Sprintf("%s%s%s", cid.Prefix, cid.Data, cid.Suffix)
+}

--- a/protocol/msgpack/aggregated_encoder_test.go
+++ b/protocol/msgpack/aggregated_encoder_test.go
@@ -54,6 +54,9 @@ func expectedResultsForAggregatedMetricWithPolicy(t *testing.T, m interface{}, p
 	case aggregated.Metric:
 		rm := toRawMetric(t, m)
 		results = append(results, expectedResultsForRawMetricWithPolicy(t, rm, p)...)
+	case aggregated.ChunkedMetric:
+		rm := toRawMetric(t, m)
+		results = append(results, expectedResultsForRawMetricWithPolicy(t, rm, p)...)
 	case aggregated.RawMetric:
 		results = append(results, expectedResultsForRawMetricWithPolicy(t, m, p)...)
 	default:
@@ -80,6 +83,13 @@ func TestAggregatedEncodeMetricWithPolicy(t *testing.T) {
 	encoder, results := testCapturingAggregatedEncoder(t)
 	require.NoError(t, testAggregatedEncode(t, encoder, testMetric, testPolicy))
 	expected := expectedResultsForAggregatedMetricWithPolicy(t, testMetric, testPolicy)
+	require.Equal(t, expected, *results)
+}
+
+func TestAggregatedEncodeChunkedMetricWithPolicy(t *testing.T) {
+	encoder, results := testCapturingAggregatedEncoder(t)
+	require.NoError(t, testAggregatedEncode(t, encoder, testChunkedMetric, testPolicy))
+	expected := expectedResultsForAggregatedMetricWithPolicy(t, testChunkedMetric, testPolicy)
 	require.Equal(t, expected, *results)
 }
 

--- a/protocol/msgpack/types.go
+++ b/protocol/msgpack/types.go
@@ -88,6 +88,9 @@ type encoderBase interface {
 	// encodeID encodes an ID
 	encodeID(id metric.ID)
 
+	// encodeChunkedID encodes a chunked ID
+	encodeChunkedID(id metric.ChunkedID)
+
 	// encodeTime encodes a time
 	encodeTime(t time.Time)
 
@@ -99,6 +102,9 @@ type encoderBase interface {
 
 	// encodeBytes encodes a byte slice
 	encodeBytes(value []byte)
+
+	// encodeBytesLen encodes the length of a byte slice
+	encodeBytesLen(value int)
 
 	// encodeArrayLen encodes the length of an array
 	encodeArrayLen(value int)
@@ -244,6 +250,9 @@ type UnaggregatedIteratorPool interface {
 type AggregatedEncoder interface {
 	// EncodeMetricWithPolicy encodes a metric with an applicable policy
 	EncodeMetricWithPolicy(mp aggregated.MetricWithPolicy) error
+
+	// EncodeChunkedMetricWithPolicy encodes a chunked metric with an applicable policy
+	EncodeChunkedMetricWithPolicy(cmp aggregated.ChunkedMetricWithPolicy) error
 
 	// EncodeRawMetricWithPolicy encodes a raw metric with an applicable policy
 	EncodeRawMetricWithPolicy(rp aggregated.RawMetricWithPolicy) error

--- a/protocol/msgpack/unaggregated_roundtrip_test.go
+++ b/protocol/msgpack/unaggregated_roundtrip_test.go
@@ -156,6 +156,9 @@ func testCapturingBaseEncoder(encoder encoderBase) *[]interface{} {
 	baseEncoder.encodeBytesFn = func(value []byte) {
 		result = append(result, value)
 	}
+	baseEncoder.encodeBytesLenFn = func(value int) {
+		result = append(result, value)
+	}
 	baseEncoder.encodeArrayLenFn = func(value int) {
 		result = append(result, value)
 	}


### PR DESCRIPTION
cc @kobolog @cw9 @robskillington 

This PR adds support for encoding metrics with chunked ids efficiently.

The main use case this PR addresses is to encode metrics in the aggregation tier before they are flushed downstream. Each metric id usually has a prefix (e.g., stats.blah), a body (i.e., the main id), and a suffix (e.g., .p99). Since the current encoder API only handles single-byte-slice ids, this requires either merging the prefix/body/suffix before encoding each id, which costs extra time due to extra byte copies, or storing the precomputed full ids for each metric, which costs extra space (e.g., each timer id would need to be stored as 10+ different ids due to different suffixes). Neither of which is optimal due to the large number of encoding operations in the aggregation tier.

This PR adds a `ChunkedMetric` struct (i.e., a metric with a chunked id) along with the corresponding encoding API so it makes zero copies when encoding such chunked IDs, therefore saving time and memory significantly. 