### PR TITLE
Expose support for encoding and decoding metrics without policies

### DIFF
--- a/policy/policy.go
+++ b/policy/policy.go
@@ -41,6 +41,11 @@ var (
 	emptyPolicy            Policy
 	emptyVersionedPolicies VersionedPolicies
 
+	// UninitializedVersionedPolicies ia an uninitialized VersionedPolicies struct
+	UninitializedVersionedPolicies = VersionedPolicies{
+		Version: InitPolicyVersion,
+	}
+
 	// DefaultVersionedPolicies are the default versioned policies
 	DefaultVersionedPolicies = VersionedPolicies{
 		Version: DefaultPolicyVersion,

--- a/protocol/msgpack/types.go
+++ b/protocol/msgpack/types.go
@@ -198,6 +198,9 @@ type UnaggregatedIterator interface {
 	// Next returns true if there are more items to decode
 	Next() bool
 
+	// Metric returns the current metric
+	Metric() unaggregated.MetricUnion
+
 	// Value returns the current metric and applicable policies
 	Value() (unaggregated.MetricUnion, policy.VersionedPolicies)
 

--- a/protocol/msgpack/types.go
+++ b/protocol/msgpack/types.go
@@ -168,6 +168,15 @@ type iteratorBase interface {
 
 // UnaggregatedEncoder is an encoder for encoding different types of unaggregated metrics
 type UnaggregatedEncoder interface {
+	// EncodeCounter encodes a counter
+	EncodeCounter(cp unaggregated.Counter) error
+
+	// EncodeBatchTimer encodes a batched timer
+	EncodeBatchTimer(btp unaggregated.BatchTimer) error
+
+	// EncodeGauge encodes a gauge
+	EncodeGauge(gp unaggregated.Gauge) error
+
 	// EncodeCounterWithPolicies encodes a counter with applicable policies
 	EncodeCounterWithPolicies(cp unaggregated.CounterWithPolicies) error
 

--- a/protocol/msgpack/unaggregated_encoder.go
+++ b/protocol/msgpack/unaggregated_encoder.go
@@ -69,6 +69,33 @@ func NewUnaggregatedEncoder(encoder BufferedEncoder) UnaggregatedEncoder {
 func (enc *unaggregatedEncoder) Encoder() BufferedEncoder      { return enc.encoder() }
 func (enc *unaggregatedEncoder) Reset(encoder BufferedEncoder) { enc.reset(encoder) }
 
+func (enc *unaggregatedEncoder) EncodeCounter(c unaggregated.Counter) error {
+	if err := enc.err(); err != nil {
+		return err
+	}
+	enc.encodeRootObjectFn(counterType)
+	enc.encodeCounterFn(c)
+	return enc.err()
+}
+
+func (enc *unaggregatedEncoder) EncodeBatchTimer(bt unaggregated.BatchTimer) error {
+	if err := enc.err(); err != nil {
+		return err
+	}
+	enc.encodeRootObjectFn(batchTimerType)
+	enc.encodeBatchTimerFn(bt)
+	return enc.err()
+}
+
+func (enc *unaggregatedEncoder) EncodeGauge(gp unaggregated.Gauge) error {
+	if err := enc.err(); err != nil {
+		return err
+	}
+	enc.encodeRootObjectFn(gaugeType)
+	enc.encodeGaugeFn(gp)
+	return enc.err()
+}
+
 func (enc *unaggregatedEncoder) EncodeCounterWithPolicies(cp unaggregated.CounterWithPolicies) error {
 	if err := enc.err(); err != nil {
 		return err

--- a/protocol/msgpack/unaggregated_iterator.go
+++ b/protocol/msgpack/unaggregated_iterator.go
@@ -147,8 +147,6 @@ func (it *unaggregatedIterator) decodeMetric(objType objectType) {
 		it.setErr(fmt.Errorf("unrecognized metric with policies type %v", objType))
 		return
 	}
-
-	// set VersionedPolicies to uninitialiezd
 	it.versionedPolicies = policy.UninitializedVersionedPolicies
 }
 
@@ -159,24 +157,17 @@ func (it *unaggregatedIterator) decodeMetricWithPolicies(objType objectType) {
 	}
 
 	switch objType {
-	case counterType, counterWithPoliciesType:
+	case counterWithPoliciesType:
 		it.decodeCounter()
-	case batchTimerType, batchTimerWithPoliciesType:
+	case batchTimerWithPoliciesType:
 		it.decodeBatchTimer()
-	case gaugeType, gaugeWithPoliciesType:
+	case gaugeWithPoliciesType:
 		it.decodeGauge()
 	default:
 		it.setErr(fmt.Errorf("unrecognized metric with policies type %v", objType))
 		return
 	}
-
-	switch objType {
-	case counterWithPoliciesType, batchTimerWithPoliciesType, gaugeWithPoliciesType:
-		it.decodeVersionedPolicies()
-	default:
-		it.versionedPolicies = policy.UninitializedVersionedPolicies
-	}
-
+	it.decodeVersionedPolicies()
 	it.skip(numActualFields - numExpectedFields)
 }
 

--- a/protocol/msgpack/unaggregated_iterator_test.go
+++ b/protocol/msgpack/unaggregated_iterator_test.go
@@ -65,11 +65,11 @@ func TestUnaggregatedIteratorDecodeNewerVersionThanSupported(t *testing.T) {
 		enc.encodeNumObjectFields(numFieldsForType(rootObjectType))
 		enc.encodeObjectType(objType)
 	}
-	require.NoError(t, testUnaggregatedEncode(t, enc, input.metric, input.versionedPolicies))
+	require.NoError(t, testUnaggregatedEncodeWithPolicies(t, enc, input.metric, input.versionedPolicies))
 
 	// Now restore the encode top-level function and encode another counter
 	enc.encodeRootObjectFn = enc.encodeRootObject
-	require.NoError(t, testUnaggregatedEncode(t, enc, input.metric, input.versionedPolicies))
+	require.NoError(t, testUnaggregatedEncodeWithPolicies(t, enc, input.metric, input.versionedPolicies))
 
 	// Check that we skipped the first counter and successfully decoded the second counter
 	it := testUnaggregatedIterator(t, bytes.NewBuffer(enc.Encoder().Buffer.Bytes()))
@@ -94,7 +94,7 @@ func TestUnaggregatedIteratorDecodeRootObjectMoreFieldsThanExpected(t *testing.T
 		enc.encodeNumObjectFields(numFieldsForType(rootObjectType) + 1)
 		enc.encodeObjectType(objType)
 	}
-	testUnaggregatedEncode(t, enc, input.metric, input.versionedPolicies)
+	testUnaggregatedEncodeWithPolicies(t, enc, input.metric, input.versionedPolicies)
 	enc.encodeVarint(0)
 	require.NoError(t, enc.err())
 
@@ -117,7 +117,7 @@ func TestUnaggregatedIteratorDecodeCounterWithPoliciesMoreFieldsThanExpected(t *
 		enc.encodeCounterFn(cp.Counter)
 		enc.encodeVersionedPoliciesFn(cp.VersionedPolicies)
 	}
-	testUnaggregatedEncode(t, enc, input.metric, input.versionedPolicies)
+	testUnaggregatedEncodeWithPolicies(t, enc, input.metric, input.versionedPolicies)
 	enc.encodeVarint(0)
 	require.NoError(t, enc.err())
 
@@ -141,7 +141,7 @@ func TestUnaggregatedIteratorDecodeCounterMoreFieldsThanExpected(t *testing.T) {
 		enc.encodeVarint(int64(c.Value))
 		enc.encodeVarint(0)
 	}
-	require.NoError(t, testUnaggregatedEncode(t, enc, input.metric, input.versionedPolicies))
+	require.NoError(t, testUnaggregatedEncodeWithPolicies(t, enc, input.metric, input.versionedPolicies))
 
 	it := testUnaggregatedIterator(t, enc.Encoder().Buffer)
 
@@ -166,7 +166,7 @@ func TestUnaggregatedIteratorDecodeBatchTimerMoreFieldsThanExpected(t *testing.T
 		}
 		enc.encodeVarint(0)
 	}
-	require.NoError(t, testUnaggregatedEncode(t, enc, input.metric, input.versionedPolicies))
+	require.NoError(t, testUnaggregatedEncodeWithPolicies(t, enc, input.metric, input.versionedPolicies))
 
 	it := testUnaggregatedIterator(t, enc.Encoder().Buffer)
 
@@ -188,7 +188,7 @@ func TestUnaggregatedIteratorDecodeGaugeMoreFieldsThanExpected(t *testing.T) {
 		enc.encodeFloat64(g.Value)
 		enc.encodeVarint(0)
 	}
-	require.NoError(t, testUnaggregatedEncode(t, enc, input.metric, input.versionedPolicies))
+	require.NoError(t, testUnaggregatedEncodeWithPolicies(t, enc, input.metric, input.versionedPolicies))
 
 	it := testUnaggregatedIterator(t, enc.Encoder().Buffer)
 
@@ -211,7 +211,7 @@ func TestUnaggregatedIteratorDecodePolicyWithCustomResolution(t *testing.T) {
 		},
 	}
 	enc := testUnaggregatedEncoder(t)
-	require.NoError(t, testUnaggregatedEncode(t, enc, input.metric, input.versionedPolicies))
+	require.NoError(t, testUnaggregatedEncodeWithPolicies(t, enc, input.metric, input.versionedPolicies))
 
 	it := testUnaggregatedIterator(t, enc.Encoder().Buffer)
 
@@ -234,7 +234,7 @@ func TestUnaggregatedIteratorDecodePolicyWithCustomRetention(t *testing.T) {
 		},
 	}
 	enc := testUnaggregatedEncoder(t)
-	require.NoError(t, testUnaggregatedEncode(t, enc, input.metric, input.versionedPolicies))
+	require.NoError(t, testUnaggregatedEncodeWithPolicies(t, enc, input.metric, input.versionedPolicies))
 
 	it := testUnaggregatedIterator(t, enc.Encoder().Buffer)
 
@@ -266,7 +266,7 @@ func TestUnaggregatedIteratorDecodePolicyMoreFieldsThanExpected(t *testing.T) {
 		baseEncoder.encodeRetention(p.Retention)
 		baseEncoder.encodeVarint(0)
 	}
-	require.NoError(t, testUnaggregatedEncode(t, enc, input.metric, input.versionedPolicies))
+	require.NoError(t, testUnaggregatedEncodeWithPolicies(t, enc, input.metric, input.versionedPolicies))
 
 	it := testUnaggregatedIterator(t, enc.Encoder().Buffer)
 
@@ -302,7 +302,7 @@ func TestUnaggregatedIteratorDecodeVersionedPoliciesMoreFieldsThanExpected(t *te
 		}
 		enc.encodeVarint(0)
 	}
-	require.NoError(t, testUnaggregatedEncode(t, enc, input.metric, input.versionedPolicies))
+	require.NoError(t, testUnaggregatedEncodeWithPolicies(t, enc, input.metric, input.versionedPolicies))
 
 	it := testUnaggregatedIterator(t, enc.Encoder().Buffer)
 
@@ -322,7 +322,7 @@ func TestUnaggregatedIteratorDecodeCounterFewerFieldsThanExpected(t *testing.T) 
 		enc.encodeNumObjectFields(numFieldsForType(counterType) - 1)
 		enc.encodeID(c.ID)
 	}
-	require.NoError(t, testUnaggregatedEncode(t, enc, input.metric, input.versionedPolicies))
+	require.NoError(t, testUnaggregatedEncodeWithPolicies(t, enc, input.metric, input.versionedPolicies))
 
 	it := testUnaggregatedIterator(t, enc.Encoder().Buffer)
 
@@ -363,7 +363,7 @@ func TestUnaggregatedIteratorDecodeInvalidTimeUnit(t *testing.T) {
 		versionedPolicies: testVersionedPoliciesWithInvalidTimeUnit,
 	}
 	enc := testUnaggregatedEncoder(t)
-	require.NoError(t, testUnaggregatedEncode(t, enc, input.metric, input.versionedPolicies))
+	require.NoError(t, testUnaggregatedEncodeWithPolicies(t, enc, input.metric, input.versionedPolicies))
 	it := testUnaggregatedIterator(t, enc.Encoder().Buffer)
 	validateUnaggregatedDecodeResults(t, it, nil, errors.New("invalid precision unknown"))
 }


### PR DESCRIPTION
This pull request exposes support for encoding and decoding metrics without policies. Previously this functionality was private, but if we want to send metrics between clients and the collector we need to be able to encode and decode metrics without policies. 

As a side note, currently I plan to encode tags in the `ID` field of a metric in a manner similar to how we encode tags that we send over the wire. So, for example, a metric with tags `{"name": "foo", "service": "bar", "dc": "baz1"}` would be encoded as `foo+service=bar,dc=baz1`. I need to write some benchmarks but my suspicion is that parsing such a string encoding would be as efficient aa parsing an encoded messagePack map object.