### PR TITLE
Add methods to serialize and deserialize a metric's name and tags into bytes

### DIFF
--- a/metric/serialize.go
+++ b/metric/serialize.go
@@ -1,0 +1,81 @@
+package metric
+
+import (
+	"bytes"
+	"errors"
+)
+
+const (
+	defaultTagsMapLen = 4
+
+	// ComponentSplitter is the separator for different compoenents of the path
+	ComponentSplitter = '+'
+	// TagPairSplitter is the separator for tag pairs
+	TagPairSplitter = ','
+	// TagNameSplitter is the separator for tag name and values
+	TagNameSplitter = '='
+)
+
+var (
+	errParseTagFailure = errors.New("Unable to parse tags, unable to parse tags")
+	errEmptyTagKey     = errors.New("Tag keys cannot be empty")
+	errEmptyTagValue   = errors.New("Tag values cannot be empty")
+)
+
+// Serialize serializes the name and tags of a metric into a buffer of bytes
+func Serialize(name string, tags map[string]string, buf *bytes.Buffer) {
+	buf.WriteString(name)
+	if len(tags) > 0 {
+		buf.WriteRune(ComponentSplitter)
+	}
+
+	first := true
+	for key, val := range tags {
+		if !first {
+			buf.WriteRune(TagPairSplitter)
+		} else {
+			first = false
+		}
+
+		buf.WriteString(key)
+		buf.WriteRune(TagNameSplitter)
+		buf.WriteString(val)
+	}
+}
+
+// Deserialize extracts the name and tags for a metric from a buffer of bytes
+func Deserialize(buf []byte) (string, map[string]string, error) {
+	n := bytes.IndexByte(buf, ComponentSplitter)
+	if n == -1 {
+		return string(buf), nil, nil
+	}
+
+	name := string(buf[:n])
+	buf = buf[(n + 1):]
+	tags := make(map[string]string)
+
+	for {
+		n = bytes.IndexByte(buf, TagNameSplitter)
+		switch n {
+		case -1:
+			return "", nil, errParseTagFailure
+		case 0:
+			return "", nil, errEmptyTagKey
+		}
+
+		key := string(buf[:n])
+		buf = buf[(n + 1):]
+
+		n = bytes.IndexByte(buf, TagPairSplitter)
+		switch n {
+		case -1:
+			tags[key] = string(buf)
+			return name, tags, nil
+		case 0:
+			return "", nil, errEmptyTagValue
+		}
+
+		tags[key] = string(buf[:n])
+		buf = buf[(n + 1):]
+	}
+}

--- a/metric/serialize.go
+++ b/metric/serialize.go
@@ -7,14 +7,14 @@ import (
 )
 
 const (
-	defaultTagsMapLen = 8
-
 	// ComponentSplitter is the separator for different compoenents of the path
 	ComponentSplitter = '+'
 	// TagPairSplitter is the separator for tag pairs
 	TagPairSplitter = ','
 	// TagNameSplitter is the separator for tag name and values
 	TagNameSplitter = '='
+
+	defaultTagsMapLen = 8
 )
 
 var (
@@ -23,27 +23,19 @@ var (
 	errEmptyTagValue   = errors.New("Tag values cannot be empty")
 )
 
-// Serialize serializes the name and tags of a metric into a buffer of bytes
+// Serialize converts the name and tags of a metric into a sequence of bytes. It does not perform
+// any input validation to avoid the performance penalty. Instead, all such validation, for example,
+// ensuring that name and tags do not contain any invalid characters, must be performed by the
+// caller.
 func Serialize(buf *bytes.Buffer, name string, tags ...map[string]string) error {
 	buf.WriteString(name)
 	if len(tags) > 0 {
 		buf.WriteRune(ComponentSplitter)
 	}
 
-	// NB(jeromefroe): we do not check for duplicate tags here to avoid the performance penalty
 	first := true
 	for _, tagMap := range tags {
 		for key, val := range tagMap {
-			if len(key) == 0 {
-				buf.Reset()
-				return errEmptyTagKey
-			}
-
-			if len(val) == 0 {
-				buf.Reset()
-				return errEmptyTagValue
-			}
-
 			if !first {
 				buf.WriteRune(TagPairSplitter)
 			} else {
@@ -59,7 +51,8 @@ func Serialize(buf *bytes.Buffer, name string, tags ...map[string]string) error 
 	return nil
 }
 
-// Deserialize extracts the name and tags for a metric from a buffer of bytes
+// Deserialize extracts the name and tags for a metric from a buffer of bytes. Tags are extracted
+// in order so if a key is repeated, the last value will be returned in the map.
 func Deserialize(buf []byte) (string, map[string]string, error) {
 	n := bytes.IndexByte(buf, ComponentSplitter)
 	if n == -1 {
@@ -71,24 +64,16 @@ func Deserialize(buf []byte) (string, map[string]string, error) {
 	tags := make(map[string]string, defaultTagsMapLen)
 
 	for {
-		n = bytes.IndexByte(buf, TagNameSplitter)
-		switch n {
-		case -1:
+		if n = bytes.IndexByte(buf, TagNameSplitter); n == -1 {
 			return "", nil, errParseTagFailure
-		case 0:
-			return "", nil, errEmptyTagKey
 		}
 
 		key := string(buf[:n])
 		buf = buf[(n + 1):]
 
-		n = bytes.IndexByte(buf, TagPairSplitter)
-		switch n {
-		case -1:
+		if n = bytes.IndexByte(buf, TagPairSplitter); n == -1 {
 			tags[key] = string(buf)
 			return name, tags, nil
-		case 0:
-			return "", nil, errEmptyTagValue
 		}
 
 		tags[key] = string(buf[:n])

--- a/metric/serialize_benchmark_test.go
+++ b/metric/serialize_benchmark_test.go
@@ -8,7 +8,7 @@ import (
 func BenchmarkSerialize(b *testing.B) {
 	buf := new(bytes.Buffer)
 	for n := 0; n < b.N; n++ {
-		Serialize(name, tags, buf)
+		Serialize(buf, name, commonTags, serviceTags)
 	}
 }
 

--- a/metric/serialize_benchmark_test.go
+++ b/metric/serialize_benchmark_test.go
@@ -1,0 +1,20 @@
+package metric
+
+import (
+	"bytes"
+	"testing"
+)
+
+func BenchmarkSerialize(b *testing.B) {
+	buf := new(bytes.Buffer)
+	for n := 0; n < b.N; n++ {
+		Serialize(name, tags, buf)
+	}
+}
+
+func BenchmarkDeserialize(b *testing.B) {
+	buf := []byte(expected)
+	for n := 0; n < b.N; n++ {
+		Deserialize(buf)
+	}
+}

--- a/metric/serialize_test.go
+++ b/metric/serialize_test.go
@@ -8,84 +8,105 @@ import (
 )
 
 var (
-	name = "foobar"
-	tags = map[string]string{
+	name       = "foobar"
+	commonTags = map[string]string{
 		"service": "fizzbuzz",
 		"dc":      "ewr1",
 		"env":     "production",
 	}
-	expected = "foobar+service=fizzbuzz,dc=ewr1,env=production"
+	serviceTags = map[string]string{
+		"type": "requests",
+		"city": "nyc",
+	}
+	expected = "foobar+service=fizzbuzz,dc=ewr1,env=production,type=requests,city=nyc"
 )
 
 func TestSerializeName(t *testing.T) {
-	testSerialize(t, name, nil, name)
+	testSerialize(t, name, name)
 }
 
 func TestSerializeNameAndTags(t *testing.T) {
 	// NB(jeromefroe): Since iterating over a map is randomized we can't rely on tags to be serialized
 	// in the same order across calls to Serialize. Consequently we test with only one tag here.
-	tags := map[string]string{
+	commonTags := map[string]string{
 		"service": "fizzbuzz",
 	}
-	expected := "foobar+service=fizzbuzz"
-	testSerialize(t, name, tags, expected)
+	serviceTags := map[string]string{
+		"type": "requests",
+	}
+	expected := "foobar+service=fizzbuzz,type=requests"
+	testSerialize(t, expected, name, commonTags, serviceTags)
 }
 
-func testSerialize(t *testing.T, name string, tags map[string]string, expected string) {
+func testSerialize(t *testing.T, expected string, name string, tags ...map[string]string) {
 	buf := new(bytes.Buffer)
-	Serialize(name, tags, buf)
+	Serialize(buf, name, tags...)
 	assert.Equal(t, expected, string(buf.Bytes()))
 }
 
 func TestDeserializeName(t *testing.T) {
-	testDeserialize(t, []byte(name), name, nil, nil)
+	testDeserialize(t, []byte(name), nil, name)
 }
 
 func TestDeserializeNameAndTags(t *testing.T) {
 	buf := []byte(expected)
-	testDeserialize(t, buf, name, tags, nil)
+	testDeserialize(t, buf, nil, name, commonTags, serviceTags)
 }
 
 func TestDeserializeErrInvalidTags(t *testing.T) {
 	buf := []byte("foobar+")
-	testDeserialize(t, buf, "", nil, errParseTagFailure)
+	testDeserialize(t, buf, errParseTagFailure, "")
 }
 
 func TestDeserializeErrEmptyTagKey(t *testing.T) {
 	buf := []byte("foobar+service=fizzbuzz,=ewr1,env=production")
-	testDeserialize(t, buf, "", nil, errEmptyTagKey)
+	testDeserialize(t, buf, errEmptyTagKey, "")
 }
 
 func TestDeserializeErrEmptyTagValue(t *testing.T) {
 	buf := []byte("foobar+service=,dc=ewr1,env=production")
-	testDeserialize(t, buf, "", nil, errEmptyTagValue)
+	testDeserialize(t, buf, errEmptyTagValue, "")
 }
 
-func testDeserialize(t *testing.T, buf []byte, name string, tags map[string]string, err error) {
+func testDeserialize(t *testing.T, buf []byte, err error, name string, tags ...map[string]string) {
+	allTags := combineTags(tags...)
 	actualName, actualTags, actualErr := Deserialize(buf)
+
 	assert.Equal(t, name, actualName)
-	assert.Equal(t, tags, actualTags)
+	assert.Equal(t, allTags, actualTags)
 	assert.Equal(t, err, actualErr)
 }
 
 func TestRoundtripName(t *testing.T) {
-	testRoundtrip(t, "foobar", nil)
+	testRoundtrip(t, "foobar")
 }
 
 func TestRoundtripNameAndTags(t *testing.T) {
-	tags := map[string]string{
-		"service": "fizzbuzz",
-		"dc":      "ewr1",
-		"env":     "production",
-	}
-	testRoundtrip(t, "foobar", tags)
+	testRoundtrip(t, "foobar", commonTags, serviceTags)
 }
 
-func testRoundtrip(t *testing.T, name string, tags map[string]string) {
+func testRoundtrip(t *testing.T, name string, tags ...map[string]string) {
 	buf := new(bytes.Buffer)
-	Serialize(name, tags, buf)
+	Serialize(buf, name, tags...)
+
 	actualName, actualTags, err := Deserialize(buf.Bytes())
+
+	allTags := combineTags(tags...)
 	assert.Nil(t, err)
 	assert.Equal(t, name, actualName)
-	assert.Equal(t, tags, actualTags)
+	assert.Equal(t, allTags, actualTags)
+}
+
+func combineTags(tags ...map[string]string) map[string]string {
+	if len(tags) == 0 {
+		return nil
+	}
+
+	allTags := make(map[string]string)
+	for _, tagMap := range tags {
+		for key, val := range tagMap {
+			allTags[key] = val
+		}
+	}
+	return allTags
 }

--- a/metric/serialize_test.go
+++ b/metric/serialize_test.go
@@ -22,7 +22,7 @@ var (
 )
 
 func TestSerializeName(t *testing.T) {
-	testSerialize(t, name, name)
+	testSerialize(t, name, nil, name)
 }
 
 func TestSerializeNameAndTags(t *testing.T) {
@@ -35,12 +35,29 @@ func TestSerializeNameAndTags(t *testing.T) {
 		"type": "requests",
 	}
 	expected := "foobar+service=fizzbuzz,type=requests"
-	testSerialize(t, expected, name, commonTags, serviceTags)
+	testSerialize(t, expected, nil, name, commonTags, serviceTags)
 }
 
-func testSerialize(t *testing.T, expected string, name string, tags ...map[string]string) {
+func TestSerializeEmptyTagKey(t *testing.T) {
+	commonTags := map[string]string{
+		"service": "fizzbuzz",
+		"":        "foo",
+	}
+	testSerialize(t, "", errEmptyTagKey, name, commonTags, serviceTags)
+}
+
+func TestSerializeEmptyTagValue(t *testing.T) {
+	commonTags := map[string]string{
+		"service": "fizzbuzz",
+		"foo":     "",
+	}
+	testSerialize(t, "", errEmptyTagValue, name, commonTags, serviceTags)
+}
+
+func testSerialize(t *testing.T, expected string, err error, name string, tags ...map[string]string) {
 	buf := new(bytes.Buffer)
-	Serialize(buf, name, tags...)
+	actualErr := Serialize(buf, name, tags...)
+	assert.Equal(t, err, actualErr)
 	assert.Equal(t, expected, string(buf.Bytes()))
 }
 

--- a/metric/serialize_test.go
+++ b/metric/serialize_test.go
@@ -1,0 +1,91 @@
+package metric
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	name = "foobar"
+	tags = map[string]string{
+		"service": "fizzbuzz",
+		"dc":      "ewr1",
+		"env":     "production",
+	}
+	expected = "foobar+service=fizzbuzz,dc=ewr1,env=production"
+)
+
+func TestSerializeName(t *testing.T) {
+	testSerialize(t, name, nil, name)
+}
+
+func TestSerializeNameAndTags(t *testing.T) {
+	// NB(jeromefroe): Since iterating over a map is randomized we can't rely on tags to be serialized
+	// in the same order across calls to Serialize. Consequently we test with only one tag here.
+	tags := map[string]string{
+		"service": "fizzbuzz",
+	}
+	expected := "foobar+service=fizzbuzz"
+	testSerialize(t, name, tags, expected)
+}
+
+func testSerialize(t *testing.T, name string, tags map[string]string, expected string) {
+	buf := new(bytes.Buffer)
+	Serialize(name, tags, buf)
+	assert.Equal(t, expected, string(buf.Bytes()))
+}
+
+func TestDeserializeName(t *testing.T) {
+	testDeserialize(t, []byte(name), name, nil, nil)
+}
+
+func TestDeserializeNameAndTags(t *testing.T) {
+	buf := []byte(expected)
+	testDeserialize(t, buf, name, tags, nil)
+}
+
+func TestDeserializeErrInvalidTags(t *testing.T) {
+	buf := []byte("foobar+")
+	testDeserialize(t, buf, "", nil, errParseTagFailure)
+}
+
+func TestDeserializeErrEmptyTagKey(t *testing.T) {
+	buf := []byte("foobar+service=fizzbuzz,=ewr1,env=production")
+	testDeserialize(t, buf, "", nil, errEmptyTagKey)
+}
+
+func TestDeserializeErrEmptyTagValue(t *testing.T) {
+	buf := []byte("foobar+service=,dc=ewr1,env=production")
+	testDeserialize(t, buf, "", nil, errEmptyTagValue)
+}
+
+func testDeserialize(t *testing.T, buf []byte, name string, tags map[string]string, err error) {
+	actualName, actualTags, actualErr := Deserialize(buf)
+	assert.Equal(t, name, actualName)
+	assert.Equal(t, tags, actualTags)
+	assert.Equal(t, err, actualErr)
+}
+
+func TestRoundtripName(t *testing.T) {
+	testRoundtrip(t, "foobar", nil)
+}
+
+func TestRoundtripNameAndTags(t *testing.T) {
+	tags := map[string]string{
+		"service": "fizzbuzz",
+		"dc":      "ewr1",
+		"env":     "production",
+	}
+	testRoundtrip(t, "foobar", tags)
+}
+
+func testRoundtrip(t *testing.T, name string, tags map[string]string) {
+	buf := new(bytes.Buffer)
+	Serialize(name, tags, buf)
+	actualName, actualTags, err := Deserialize(buf.Bytes())
+	assert.Nil(t, err)
+	assert.Equal(t, name, actualName)
+	assert.Equal(t, tags, actualTags)
+}


### PR DESCRIPTION
To send metrics between clients and the collector we will need to serialize and deserialize a metric's name and tags into bytes. Consequently, this PR adds two such methods `Serialize` and `Deserialize` to accomplish that. I benchmarked both functions, and the results are below:

```
BenchmarkSerialize-4             3000000               491 ns/op             191 B/op          0 allocs/op
BenchmarkDeserialize-4           2000000               856 ns/op             408 B/op         13 allocs/op
```
