### PR TITLE
Explicitly mark versioned policies as default if needed

### DIFF
--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -65,3 +65,37 @@ func TestPoliciesByResolutionAsc(t *testing.T) {
 	sort.Sort(ByResolutionAsc(inputs))
 	require.Equal(t, expected, inputs)
 }
+
+func TestDefaultVersionedPolicies(t *testing.T) {
+	var (
+		version = 2
+		cutover = time.Now()
+	)
+	vp := DefaultVersionedPolicies(version, cutover)
+	require.Equal(t, version, vp.Version)
+	require.Equal(t, cutover, vp.Cutover)
+	require.True(t, vp.IsDefault())
+	require.Equal(t, defaultPolicies, vp.Policies())
+}
+
+func TestCustomVersionedPolicies(t *testing.T) {
+	var (
+		version  = 2
+		cutover  = time.Now()
+		policies = []Policy{
+			{
+				Resolution: Resolution{Window: 10 * time.Second, Precision: xtime.Second},
+				Retention:  Retention(6 * time.Hour),
+			},
+			{
+				Resolution: Resolution{Window: 10 * time.Second, Precision: xtime.Second},
+				Retention:  Retention(2 * time.Hour),
+			},
+		}
+	)
+	vp := CustomVersionedPolicies(version, cutover, policies)
+	require.Equal(t, version, vp.Version)
+	require.Equal(t, cutover, vp.Cutover)
+	require.False(t, vp.IsDefault())
+	require.Equal(t, policies, vp.Policies())
+}

--- a/protocol/msgpack/schema.go
+++ b/protocol/msgpack/schema.go
@@ -77,7 +77,7 @@ const (
 	numUnknownResolutionFields      = 3
 	numKnownRetentionFields         = 2
 	numUnknownRetentionFields       = 2
-	numDefaultVersionedPolicyFields = 1
+	numDefaultVersionedPolicyFields = 3
 	numCustomVersionedPolicyFields  = 4
 )
 

--- a/protocol/msgpack/unaggregated_iterator_test.go
+++ b/protocol/msgpack/unaggregated_iterator_test.go
@@ -55,7 +55,7 @@ func validateUnaggregatedDecodeResults(
 func TestUnaggregatedIteratorDecodeNewerVersionThanSupported(t *testing.T) {
 	input := metricWithPolicies{
 		metric:            testCounter,
-		versionedPolicies: policy.DefaultVersionedPolicies,
+		versionedPolicies: testDefaultVersionedPolicies,
 	}
 	enc := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
 
@@ -84,7 +84,7 @@ func TestUnaggregatedIteratorDecodeNewerVersionThanSupported(t *testing.T) {
 func TestUnaggregatedIteratorDecodeRootObjectMoreFieldsThanExpected(t *testing.T) {
 	input := metricWithPolicies{
 		metric:            testCounter,
-		versionedPolicies: policy.DefaultVersionedPolicies,
+		versionedPolicies: testDefaultVersionedPolicies,
 	}
 	enc := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
 
@@ -107,7 +107,7 @@ func TestUnaggregatedIteratorDecodeRootObjectMoreFieldsThanExpected(t *testing.T
 func TestUnaggregatedIteratorDecodeCounterWithPoliciesMoreFieldsThanExpected(t *testing.T) {
 	input := metricWithPolicies{
 		metric:            testCounter,
-		versionedPolicies: policy.DefaultVersionedPolicies,
+		versionedPolicies: testDefaultVersionedPolicies,
 	}
 	enc := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
 
@@ -130,7 +130,7 @@ func TestUnaggregatedIteratorDecodeCounterWithPoliciesMoreFieldsThanExpected(t *
 func TestUnaggregatedIteratorDecodeCounterMoreFieldsThanExpected(t *testing.T) {
 	input := metricWithPolicies{
 		metric:            testCounter,
-		versionedPolicies: policy.DefaultVersionedPolicies,
+		versionedPolicies: testDefaultVersionedPolicies,
 	}
 	enc := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
 
@@ -152,7 +152,7 @@ func TestUnaggregatedIteratorDecodeCounterMoreFieldsThanExpected(t *testing.T) {
 func TestUnaggregatedIteratorDecodeBatchTimerMoreFieldsThanExpected(t *testing.T) {
 	input := metricWithPolicies{
 		metric:            testBatchTimer,
-		versionedPolicies: policy.DefaultVersionedPolicies,
+		versionedPolicies: testDefaultVersionedPolicies,
 	}
 	enc := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
 
@@ -177,7 +177,7 @@ func TestUnaggregatedIteratorDecodeBatchTimerMoreFieldsThanExpected(t *testing.T
 func TestUnaggregatedIteratorDecodeGaugeMoreFieldsThanExpected(t *testing.T) {
 	input := metricWithPolicies{
 		metric:            testGauge,
-		versionedPolicies: policy.DefaultVersionedPolicies,
+		versionedPolicies: testDefaultVersionedPolicies,
 	}
 	enc := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
 
@@ -199,16 +199,16 @@ func TestUnaggregatedIteratorDecodeGaugeMoreFieldsThanExpected(t *testing.T) {
 func TestUnaggregatedIteratorDecodePolicyWithCustomResolution(t *testing.T) {
 	input := metricWithPolicies{
 		metric: testGauge,
-		versionedPolicies: policy.VersionedPolicies{
-			Version: 1,
-			Cutover: time.Now(),
-			Policies: []policy.Policy{
+		versionedPolicies: policy.CustomVersionedPolicies(
+			1,
+			time.Now(),
+			[]policy.Policy{
 				{
 					Resolution: policy.Resolution{Window: 3 * time.Second, Precision: xtime.Second},
 					Retention:  policy.Retention(time.Hour),
 				},
 			},
-		},
+		),
 	}
 	enc := testUnaggregatedEncoder(t)
 	require.NoError(t, testUnaggregatedEncode(t, enc, input.metric, input.versionedPolicies))
@@ -222,16 +222,16 @@ func TestUnaggregatedIteratorDecodePolicyWithCustomResolution(t *testing.T) {
 func TestUnaggregatedIteratorDecodePolicyWithCustomRetention(t *testing.T) {
 	input := metricWithPolicies{
 		metric: testGauge,
-		versionedPolicies: policy.VersionedPolicies{
-			Version: 1,
-			Cutover: time.Now(),
-			Policies: []policy.Policy{
+		versionedPolicies: policy.CustomVersionedPolicies(
+			1,
+			time.Now(),
+			[]policy.Policy{
 				{
 					Resolution: policy.Resolution{Window: time.Second, Precision: xtime.Second},
 					Retention:  policy.Retention(289 * time.Hour),
 				},
 			},
-		},
+		),
 	}
 	enc := testUnaggregatedEncoder(t)
 	require.NoError(t, testUnaggregatedEncode(t, enc, input.metric, input.versionedPolicies))
@@ -245,16 +245,16 @@ func TestUnaggregatedIteratorDecodePolicyWithCustomRetention(t *testing.T) {
 func TestUnaggregatedIteratorDecodePolicyMoreFieldsThanExpected(t *testing.T) {
 	input := metricWithPolicies{
 		metric: testGauge,
-		versionedPolicies: policy.VersionedPolicies{
-			Version: 1,
-			Cutover: time.Now(),
-			Policies: []policy.Policy{
+		versionedPolicies: policy.CustomVersionedPolicies(
+			1,
+			time.Now(),
+			[]policy.Policy{
 				{
 					Resolution: policy.Resolution{Window: time.Second, Precision: xtime.Second},
 					Retention:  policy.Retention(time.Hour),
 				},
 			},
-		},
+		),
 	}
 	enc := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
 	baseEncoder := enc.encoderBase.(*baseEncoder)
@@ -277,16 +277,16 @@ func TestUnaggregatedIteratorDecodePolicyMoreFieldsThanExpected(t *testing.T) {
 func TestUnaggregatedIteratorDecodeVersionedPoliciesMoreFieldsThanExpected(t *testing.T) {
 	input := metricWithPolicies{
 		metric: testGauge,
-		versionedPolicies: policy.VersionedPolicies{
-			Version: 1,
-			Cutover: time.Now(),
-			Policies: []policy.Policy{
+		versionedPolicies: policy.CustomVersionedPolicies(
+			1,
+			time.Now(),
+			[]policy.Policy{
 				{
 					Resolution: policy.Resolution{Window: time.Second, Precision: xtime.Second},
 					Retention:  policy.Retention(time.Hour),
 				},
 			},
-		},
+		),
 	}
 	enc := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
 
@@ -296,8 +296,9 @@ func TestUnaggregatedIteratorDecodeVersionedPoliciesMoreFieldsThanExpected(t *te
 		enc.encodeObjectType(customVersionedPoliciesType)
 		enc.encodeVersion(vp.Version)
 		enc.encodeTime(vp.Cutover)
-		enc.encodeArrayLen(len(vp.Policies))
-		for _, policy := range vp.Policies {
+		policies := vp.Policies()
+		enc.encodeArrayLen(len(policies))
+		for _, policy := range policies {
 			enc.encodePolicy(policy)
 		}
 		enc.encodeVarint(0)
@@ -313,7 +314,7 @@ func TestUnaggregatedIteratorDecodeVersionedPoliciesMoreFieldsThanExpected(t *te
 func TestUnaggregatedIteratorDecodeCounterFewerFieldsThanExpected(t *testing.T) {
 	input := metricWithPolicies{
 		metric:            testCounter,
-		versionedPolicies: policy.DefaultVersionedPolicies,
+		versionedPolicies: testDefaultVersionedPolicies,
 	}
 	enc := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
 

--- a/protocol/msgpack/unaggregated_roundtrip_test.go
+++ b/protocol/msgpack/unaggregated_roundtrip_test.go
@@ -54,29 +54,34 @@ var (
 		GaugeVal: 123.456,
 	}
 
-	testVersionedPoliciesWithInvalidTimeUnit = policy.VersionedPolicies{
-		Version: 1,
-		Cutover: time.Now(),
-		Policies: []policy.Policy{
+	testDefaultVersionedPolicies = policy.DefaultVersionedPolicies(
+		policy.DefaultPolicyVersion,
+		time.Now(),
+	)
+
+	testVersionedPoliciesWithInvalidTimeUnit = policy.CustomVersionedPolicies(
+		1,
+		time.Now(),
+		[]policy.Policy{
 			{
 				Resolution: policy.Resolution{Window: time.Second, Precision: xtime.Unit(100)},
 				Retention:  policy.Retention(time.Hour),
 			},
 		},
-	}
+	)
 
 	testInputWithAllTypesAndDefaultPolicies = []metricWithPolicies{
 		{
 			metric:            testCounter,
-			versionedPolicies: policy.DefaultVersionedPolicies,
+			versionedPolicies: testDefaultVersionedPolicies,
 		},
 		{
 			metric:            testBatchTimer,
-			versionedPolicies: policy.DefaultVersionedPolicies,
+			versionedPolicies: testDefaultVersionedPolicies,
 		},
 		{
 			metric:            testGauge,
-			versionedPolicies: policy.DefaultVersionedPolicies,
+			versionedPolicies: testDefaultVersionedPolicies,
 		},
 	}
 
@@ -84,25 +89,25 @@ var (
 		// Retain this metric at 1 second resolution for 1 hour
 		{
 			metric: testCounter,
-			versionedPolicies: policy.VersionedPolicies{
-				Version: 1,
-				Cutover: time.Now(),
-				Policies: []policy.Policy{
+			versionedPolicies: policy.CustomVersionedPolicies(
+				1,
+				time.Now(),
+				[]policy.Policy{
 					{
 						Resolution: policy.Resolution{Window: time.Second, Precision: xtime.Second},
 						Retention:  policy.Retention(time.Hour),
 					},
 				},
-			},
+			),
 		},
 		// Retain this metric at 20 second resolution for 6 hours,
 		// then 1 minute for 2 days, then 10 minutes for 25 days
 		{
 			metric: testBatchTimer,
-			versionedPolicies: policy.VersionedPolicies{
-				Version: 2,
-				Cutover: time.Now(),
-				Policies: []policy.Policy{
+			versionedPolicies: policy.CustomVersionedPolicies(
+				2,
+				time.Now(),
+				[]policy.Policy{
 					{
 						Resolution: policy.Resolution{Window: 20 * time.Second, Precision: xtime.Second},
 						Retention:  policy.Retention(6 * time.Hour),
@@ -116,21 +121,21 @@ var (
 						Retention:  policy.Retention(25 * 24 * time.Hour),
 					},
 				},
-			},
+			),
 		},
 		// Retain this metric at 10 minute resolution for 45 days
 		{
 			metric: testGauge,
-			versionedPolicies: policy.VersionedPolicies{
-				Version: 2,
-				Cutover: time.Now(),
-				Policies: []policy.Policy{
+			versionedPolicies: policy.CustomVersionedPolicies(
+				2,
+				time.Now(),
+				[]policy.Policy{
 					{
 						Resolution: policy.Resolution{Window: 10 * time.Minute, Precision: xtime.Minute},
 						Retention:  policy.Retention(45 * 24 * time.Hour),
 					},
 				},
-			},
+			),
 		},
 	}
 )
@@ -254,21 +259,21 @@ func validateUnaggregatedRoundtripWithEncoderAndIterator(
 func TestUnaggregatedEncodeDecodeCounterWithDefaultPolicies(t *testing.T) {
 	validateUnaggregatedRoundtrip(t, metricWithPolicies{
 		metric:            testCounter,
-		versionedPolicies: policy.DefaultVersionedPolicies,
+		versionedPolicies: testDefaultVersionedPolicies,
 	})
 }
 
 func TestUnaggregatedEncodeDecodeBatchTimerWithDefaultPolicies(t *testing.T) {
 	validateUnaggregatedRoundtrip(t, metricWithPolicies{
 		metric:            testBatchTimer,
-		versionedPolicies: policy.DefaultVersionedPolicies,
+		versionedPolicies: testDefaultVersionedPolicies,
 	})
 }
 
 func TestUnaggregatedEncodeDecodeGaugeWithDefaultPolicies(t *testing.T) {
 	validateUnaggregatedRoundtrip(t, metricWithPolicies{
 		metric:            testGauge,
-		versionedPolicies: policy.DefaultVersionedPolicies,
+		versionedPolicies: testDefaultVersionedPolicies,
 	})
 }
 
@@ -285,11 +290,11 @@ func TestUnaggregatedEncodeDecodeStress(t *testing.T) {
 	numMetrics := 10000
 	allMetrics := []unaggregated.MetricUnion{testCounter, testBatchTimer, testGauge}
 	allPolicies := []policy.VersionedPolicies{
-		policy.DefaultVersionedPolicies,
-		{
-			Version: 2,
-			Cutover: time.Now(),
-			Policies: []policy.Policy{
+		testDefaultVersionedPolicies,
+		policy.CustomVersionedPolicies(
+			2,
+			time.Now(),
+			[]policy.Policy{
 				{
 					Resolution: policy.Resolution{Window: time.Second, Precision: xtime.Second},
 					Retention:  policy.Retention(6 * time.Hour),
@@ -299,7 +304,7 @@ func TestUnaggregatedEncodeDecodeStress(t *testing.T) {
 					Retention:  policy.Retention(2 * 24 * time.Hour),
 				},
 			},
-		},
+		),
 	}
 
 	encoder := testUnaggregatedEncoder(t)


### PR DESCRIPTION
This PR addresses an issue where we used to use the policy version to determine whether the policies are the default policies (in particular, if the version is 0, we consider it as default, and non-default otherwise). This however means if we mark the policy as the default when the rules for a namespace are deleted, the policy version will be 0 regardless of what the actual policy version is, causing the aggregation tier to ignore such policies.

This PR introduces the `isDefault` and `policies` field in the `VersionedPolicies` object so we can explicitly mark policies as default while respecting the actual policy version.