### PR TITLE
Add Buffer and Encoder interface for better separation of concerns

### DIFF
--- a/protocol/msgpack/aggregated_iterator_test.go
+++ b/protocol/msgpack/aggregated_iterator_test.go
@@ -69,7 +69,7 @@ func TestAggregatedIteratorDecodeNewerVersionThanSupported(t *testing.T) {
 	enc.encodeRootObjectFn = enc.encodeRootObject
 	require.NoError(t, testAggregatedEncode(t, enc, input.metric.(aggregated.Metric), input.policy))
 
-	it := testAggregatedIterator(t, enc.Encoder().Buffer)
+	it := testAggregatedIterator(t, enc.Encoder().Buffer())
 	it.(*aggregatedIterator).ignoreHigherVersion = true
 
 	// Check that we skipped the first metric and successfully decoded the second metric
@@ -93,7 +93,7 @@ func TestAggregatedIteratorDecodeRootObjectMoreFieldsThanExpected(t *testing.T) 
 	enc.encodeVarint(0)
 	require.NoError(t, enc.err())
 
-	it := testAggregatedIterator(t, enc.Encoder().Buffer)
+	it := testAggregatedIterator(t, enc.Encoder().Buffer())
 
 	// Check that we successfully decoded the metric
 	validateAggregatedDecodeResults(t, it, []metricWithPolicy{input}, io.EOF)
@@ -116,7 +116,7 @@ func TestAggregatedIteratorDecodeRawMetricMoreFieldsThanExpected(t *testing.T) {
 	enc.encodeVarint(0)
 	require.NoError(t, enc.err())
 
-	it := testAggregatedIterator(t, enc.Encoder().Buffer)
+	it := testAggregatedIterator(t, enc.Encoder().Buffer())
 
 	// Check that we successfully decoded the metric
 	validateAggregatedDecodeResults(t, it, []metricWithPolicy{input}, io.EOF)
@@ -138,7 +138,7 @@ func TestAggregatedIteratorDecodeMetricHigherVersionThanSupported(t *testing.T) 
 	testAggregatedEncode(t, enc, input.metric.(aggregated.Metric), input.policy)
 	require.NoError(t, enc.err())
 
-	it := testAggregatedIterator(t, enc.Encoder().Buffer)
+	it := testAggregatedIterator(t, enc.Encoder().Buffer())
 	require.True(t, it.Next())
 	rawMetric, _ := it.Value()
 	_, err := rawMetric.Value()
@@ -161,7 +161,7 @@ func TestAggregatedIteratorDecodeMetricMoreFieldsThanExpected(t *testing.T) {
 	testAggregatedEncode(t, enc, input.metric.(aggregated.Metric), input.policy)
 	require.NoError(t, enc.err())
 
-	it := testAggregatedIterator(t, enc.Encoder().Buffer)
+	it := testAggregatedIterator(t, enc.Encoder().Buffer())
 
 	// Check that we successfully decoded the metric
 	validateAggregatedDecodeResults(t, it, []metricWithPolicy{input}, io.EOF)

--- a/protocol/msgpack/base_encoder.go
+++ b/protocol/msgpack/base_encoder.go
@@ -181,5 +181,5 @@ func (enc *baseEncoder) writeRaw(buf []byte) {
 	if enc.encodeErr != nil {
 		return
 	}
-	_, enc.encodeErr = enc.bufEncoder.Buffer.Write(buf)
+	_, enc.encodeErr = enc.bufEncoder.Buffer().Write(buf)
 }

--- a/protocol/msgpack/buffered_encoder.go
+++ b/protocol/msgpack/buffered_encoder.go
@@ -29,7 +29,7 @@ import (
 type bufferedEncoder struct {
 	*msgpack.Encoder
 
-	buf    *bytes.Buffer
+	buf    bytes.Buffer
 	closed bool
 	pool   BufferedEncoderPool
 }
@@ -41,16 +41,13 @@ func NewBufferedEncoder() BufferedEncoder {
 
 // NewPooledBufferedEncoder creates a new pooled buffered encoder
 func NewPooledBufferedEncoder(p BufferedEncoderPool) BufferedEncoder {
-	buf := bytes.NewBuffer(nil)
-	return &bufferedEncoder{
-		Encoder: msgpack.NewEncoder(buf),
-		buf:     buf,
-		closed:  false,
-		pool:    p,
-	}
+	var enc bufferedEncoder
+	enc.Encoder = msgpack.NewEncoder(&enc.buf)
+	enc.pool = p
+	return &enc
 }
 
-func (enc *bufferedEncoder) Buffer() *bytes.Buffer { return enc.buf }
+func (enc *bufferedEncoder) Buffer() *bytes.Buffer { return &enc.buf }
 
 func (enc *bufferedEncoder) Bytes() []byte { return enc.buf.Bytes() }
 

--- a/protocol/msgpack/buffered_encoder_pool_test.go
+++ b/protocol/msgpack/buffered_encoder_pool_test.go
@@ -36,17 +36,17 @@ func TestBufferedEncoderPool(t *testing.T) {
 
 	// Retrieve an encoder from the pool
 	encoder := p.Get()
-	encoder.Buffer.Write([]byte{1, 2, 3})
-	require.Equal(t, 3, encoder.Buffer.Len())
+	encoder.Buffer().Write([]byte{1, 2, 3})
+	require.Equal(t, 3, encoder.Buffer().Len())
 
 	// Closing the encoder should put it back to the pool
 	encoder.Close()
 
 	// Retrieve the encoder and assert it's the same encoder
 	encoder = p.Get()
-	require.Equal(t, 3, encoder.Buffer.Len())
+	require.Equal(t, 3, encoder.Buffer().Len())
 
 	// Reset the encoder and assert it's been reset
 	encoder.Reset()
-	require.Equal(t, 0, encoder.Buffer.Len())
+	require.Equal(t, 0, encoder.Buffer().Len())
 }

--- a/protocol/msgpack/buffered_encoder_test.go
+++ b/protocol/msgpack/buffered_encoder_test.go
@@ -26,8 +26,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func testBufferedEncoder() BufferedEncoder {
-	return NewBufferedEncoder()
+func testBufferedEncoder() *bufferedEncoder {
+	return NewBufferedEncoder().(*bufferedEncoder)
 }
 
 func TestBufferedEncoderReset(t *testing.T) {

--- a/protocol/msgpack/types.go
+++ b/protocol/msgpack/types.go
@@ -31,17 +31,48 @@ import (
 	"github.com/m3db/m3metrics/policy"
 	"github.com/m3db/m3metrics/pool"
 	xpool "github.com/m3db/m3x/pool"
-
-	"gopkg.in/vmihailenco/msgpack.v2"
 )
 
-// BufferedEncoder is an messagePack-based encoder backed by byte buffers
-type BufferedEncoder struct {
-	*msgpack.Encoder
+// Buffer is a byte buffer
+type Buffer interface {
+	// Buffer returns the bytes buffer
+	Buffer() *bytes.Buffer
 
-	Buffer *bytes.Buffer
-	closed bool
-	pool   BufferedEncoderPool
+	// Bytes returns the buffered bytes
+	Bytes() []byte
+
+	// Reset resets the buffer
+	Reset()
+
+	// Close closes the buffer
+	Close()
+}
+
+// Encoder is an encoder
+type Encoder interface {
+	// EncodeTime encodes a time value
+	EncodeTime(value time.Time) error
+
+	// EncodeInt64 encodes an int64 value
+	EncodeInt64(value int64) error
+
+	// EncodeFloat64 encodes a float64 value
+	EncodeFloat64(value float64) error
+
+	// EncodeBytes encodes a byte slice
+	EncodeBytes(value []byte) error
+
+	// EncodeBytesLen encodes the length of a byte slice
+	EncodeBytesLen(value int) error
+
+	// EncodeArrayLen encodes the length of an array
+	EncodeArrayLen(value int) error
+}
+
+// BufferedEncoder is an encoder backed by byte buffers
+type BufferedEncoder interface {
+	Buffer
+	Encoder
 }
 
 // BufferedEncoderAlloc allocates a bufferer encoder

--- a/protocol/msgpack/unaggregated_iterator_test.go
+++ b/protocol/msgpack/unaggregated_iterator_test.go
@@ -72,11 +72,11 @@ func TestUnaggregatedIteratorDecodeNewerVersionThanSupported(t *testing.T) {
 	require.NoError(t, testUnaggregatedEncode(t, enc, input.metric, input.versionedPolicies))
 
 	// Check that we skipped the first counter and successfully decoded the second counter
-	it := testUnaggregatedIterator(t, bytes.NewBuffer(enc.Encoder().Buffer.Bytes()))
+	it := testUnaggregatedIterator(t, bytes.NewBuffer(enc.Encoder().Bytes()))
 	it.(*unaggregatedIterator).ignoreHigherVersion = true
 	validateUnaggregatedDecodeResults(t, it, []metricWithPolicies{input}, io.EOF)
 
-	it.Reset(bytes.NewBuffer(enc.Encoder().Buffer.Bytes()))
+	it.Reset(bytes.NewBuffer(enc.Encoder().Bytes()))
 	it.(*unaggregatedIterator).ignoreHigherVersion = false
 	validateUnaggregatedDecodeResults(t, it, nil, errors.New("received version 2 is higher than supported version 1"))
 }
@@ -98,7 +98,7 @@ func TestUnaggregatedIteratorDecodeRootObjectMoreFieldsThanExpected(t *testing.T
 	enc.encodeVarint(0)
 	require.NoError(t, enc.err())
 
-	it := testUnaggregatedIterator(t, enc.Encoder().Buffer)
+	it := testUnaggregatedIterator(t, enc.Encoder().Buffer())
 
 	// Check that we successfully decoded the counter
 	validateUnaggregatedDecodeResults(t, it, []metricWithPolicies{input}, io.EOF)
@@ -121,7 +121,7 @@ func TestUnaggregatedIteratorDecodeCounterWithPoliciesMoreFieldsThanExpected(t *
 	enc.encodeVarint(0)
 	require.NoError(t, enc.err())
 
-	it := testUnaggregatedIterator(t, enc.Encoder().Buffer)
+	it := testUnaggregatedIterator(t, enc.Encoder().Buffer())
 
 	// Check that we successfully decoded the counter
 	validateUnaggregatedDecodeResults(t, it, []metricWithPolicies{input}, io.EOF)
@@ -143,7 +143,7 @@ func TestUnaggregatedIteratorDecodeCounterMoreFieldsThanExpected(t *testing.T) {
 	}
 	require.NoError(t, testUnaggregatedEncode(t, enc, input.metric, input.versionedPolicies))
 
-	it := testUnaggregatedIterator(t, enc.Encoder().Buffer)
+	it := testUnaggregatedIterator(t, enc.Encoder().Buffer())
 
 	// Check that we successfully decoded the counter
 	validateUnaggregatedDecodeResults(t, it, []metricWithPolicies{input}, io.EOF)
@@ -168,7 +168,7 @@ func TestUnaggregatedIteratorDecodeBatchTimerMoreFieldsThanExpected(t *testing.T
 	}
 	require.NoError(t, testUnaggregatedEncode(t, enc, input.metric, input.versionedPolicies))
 
-	it := testUnaggregatedIterator(t, enc.Encoder().Buffer)
+	it := testUnaggregatedIterator(t, enc.Encoder().Buffer())
 
 	// Check that we successfully decoded the batch timer
 	validateUnaggregatedDecodeResults(t, it, []metricWithPolicies{input}, io.EOF)
@@ -190,7 +190,7 @@ func TestUnaggregatedIteratorDecodeGaugeMoreFieldsThanExpected(t *testing.T) {
 	}
 	require.NoError(t, testUnaggregatedEncode(t, enc, input.metric, input.versionedPolicies))
 
-	it := testUnaggregatedIterator(t, enc.Encoder().Buffer)
+	it := testUnaggregatedIterator(t, enc.Encoder().Buffer())
 
 	// Check that we successfully decoded the gauge
 	validateUnaggregatedDecodeResults(t, it, []metricWithPolicies{input}, io.EOF)
@@ -213,7 +213,7 @@ func TestUnaggregatedIteratorDecodePolicyWithCustomResolution(t *testing.T) {
 	enc := testUnaggregatedEncoder(t)
 	require.NoError(t, testUnaggregatedEncode(t, enc, input.metric, input.versionedPolicies))
 
-	it := testUnaggregatedIterator(t, enc.Encoder().Buffer)
+	it := testUnaggregatedIterator(t, enc.Encoder().Buffer())
 
 	// Check that we successfully decoded the policy
 	validateUnaggregatedDecodeResults(t, it, []metricWithPolicies{input}, io.EOF)
@@ -236,7 +236,7 @@ func TestUnaggregatedIteratorDecodePolicyWithCustomRetention(t *testing.T) {
 	enc := testUnaggregatedEncoder(t)
 	require.NoError(t, testUnaggregatedEncode(t, enc, input.metric, input.versionedPolicies))
 
-	it := testUnaggregatedIterator(t, enc.Encoder().Buffer)
+	it := testUnaggregatedIterator(t, enc.Encoder().Buffer())
 
 	// Check that we successfully decoded the policy
 	validateUnaggregatedDecodeResults(t, it, []metricWithPolicies{input}, io.EOF)
@@ -268,7 +268,7 @@ func TestUnaggregatedIteratorDecodePolicyMoreFieldsThanExpected(t *testing.T) {
 	}
 	require.NoError(t, testUnaggregatedEncode(t, enc, input.metric, input.versionedPolicies))
 
-	it := testUnaggregatedIterator(t, enc.Encoder().Buffer)
+	it := testUnaggregatedIterator(t, enc.Encoder().Buffer())
 
 	// Check that we successfully decoded the policy
 	validateUnaggregatedDecodeResults(t, it, []metricWithPolicies{input}, io.EOF)
@@ -305,7 +305,7 @@ func TestUnaggregatedIteratorDecodeVersionedPoliciesMoreFieldsThanExpected(t *te
 	}
 	require.NoError(t, testUnaggregatedEncode(t, enc, input.metric, input.versionedPolicies))
 
-	it := testUnaggregatedIterator(t, enc.Encoder().Buffer)
+	it := testUnaggregatedIterator(t, enc.Encoder().Buffer())
 
 	// Check that we successfully decoded the policy
 	validateUnaggregatedDecodeResults(t, it, []metricWithPolicies{input}, io.EOF)
@@ -325,7 +325,7 @@ func TestUnaggregatedIteratorDecodeCounterFewerFieldsThanExpected(t *testing.T) 
 	}
 	require.NoError(t, testUnaggregatedEncode(t, enc, input.metric, input.versionedPolicies))
 
-	it := testUnaggregatedIterator(t, enc.Encoder().Buffer)
+	it := testUnaggregatedIterator(t, enc.Encoder().Buffer())
 
 	// Check that we successfully decoded the counter
 	validateUnaggregatedDecodeResults(t, it, nil, errors.New("number of fields mismatch: expected 2 actual 1"))
@@ -365,6 +365,6 @@ func TestUnaggregatedIteratorDecodeInvalidTimeUnit(t *testing.T) {
 	}
 	enc := testUnaggregatedEncoder(t)
 	require.NoError(t, testUnaggregatedEncode(t, enc, input.metric, input.versionedPolicies))
-	it := testUnaggregatedIterator(t, enc.Encoder().Buffer)
+	it := testUnaggregatedIterator(t, enc.Encoder().Buffer())
 	validateUnaggregatedDecodeResults(t, it, nil, errors.New("invalid precision unknown"))
 }


### PR DESCRIPTION
cc @robskillington @prateek @ben-lerner @cw9 

This PR adds the `Buffer` and the `Encoder` interface to conceptually separate the byte buffering operations and the encoding operations for better separation of concerns.