### PR TITLE
Add rollup metric ID to match result

### DIFF
--- a/rules/options.go
+++ b/rules/options.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package rules
+
+import "github.com/m3db/m3metrics/filters"
+
+// NewIDFn creates a new metric ID based on the metric name and metric tag pairs
+type NewIDFn func(name string, tags []TagPair) string
+
+// Options provide a set of options for rule matching
+type Options interface {
+	// SetNewSortedTagIteratorFn sets the new sorted tag iterator function
+	SetNewSortedTagIteratorFn(value filters.NewSortedTagIteratorFn) Options
+
+	// NewSortedTagIteratorFn returns the new sorted tag iterator function
+	NewSortedTagIteratorFn() filters.NewSortedTagIteratorFn
+
+	// SetNewIDFn sets the new id function
+	SetNewIDFn(value NewIDFn) Options
+
+	// NewIDFn returns the new id function
+	NewIDFn() NewIDFn
+}
+
+type options struct {
+	iterFn  filters.NewSortedTagIteratorFn
+	newIDFn NewIDFn
+}
+
+// NewOptions creates a new set of options
+func NewOptions() Options {
+	return &options{}
+}
+
+func (o *options) SetNewSortedTagIteratorFn(value filters.NewSortedTagIteratorFn) Options {
+	opts := o
+	opts.iterFn = value
+	return opts
+}
+
+func (o *options) NewSortedTagIteratorFn() filters.NewSortedTagIteratorFn {
+	return o.iterFn
+}
+
+func (o *options) SetNewIDFn(value NewIDFn) Options {
+	opts := o
+	opts.newIDFn = value
+	return opts
+}
+
+func (o *options) NewIDFn() NewIDFn {
+	return o.newIDFn
+}

--- a/rules/rule_test.go
+++ b/rules/rule_test.go
@@ -21,6 +21,8 @@
 package rules
 
 import (
+	"bytes"
+	"fmt"
 	"testing"
 	"time"
 
@@ -31,21 +33,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 )
-
-type testRollupTargetData struct {
-	target RollupTarget
-	result bool
-}
-
-type testMappingsData struct {
-	id     string
-	result []policy.Policy
-}
-
-type testRollupsData struct {
-	id     string
-	result []RollupTarget
-}
 
 func TestRollupTargetSameTransform(t *testing.T) {
 	policies := []policy.Policy{
@@ -86,6 +73,152 @@ func TestRollupTargetClone(t *testing.T) {
 	cloned.Policies[0] = policy.EmptyPolicy
 	require.Equal(t, target.Tags, []string{"bar1", "bar2"})
 	require.Equal(t, target.Policies, policies)
+}
+
+func TestRuleSetMatchMappingRules(t *testing.T) {
+	ruleSetConfig := &schema.RuleSet{
+		Version:      1,
+		Cutover:      time.Now().UnixNano(),
+		MappingRules: testMappingRulesConfig(),
+	}
+	ruleSet, err := NewRuleSet(ruleSetConfig, testRuleSetOptions())
+	require.NoError(t, err)
+
+	inputs := []testMappingsData{
+		{
+			id: "mtagName1=mtagValue1",
+			result: []policy.Policy{
+				policy.NewPolicy(10*time.Second, xtime.Second, 12*time.Hour),
+				policy.NewPolicy(time.Minute, xtime.Minute, 24*time.Hour),
+				policy.NewPolicy(5*time.Minute, xtime.Minute, 48*time.Hour),
+			},
+		},
+		{
+			id: "mtagName1=mtagValue2",
+			result: []policy.Policy{
+				policy.NewPolicy(10*time.Second, xtime.Second, 24*time.Hour),
+			},
+		},
+	}
+	for _, input := range inputs {
+		res := ruleSet.Match(input.id)
+		require.Equal(t, ruleSet.Version(), res.Version())
+		require.Equal(t, ruleSet.Cutover(), res.Cutover())
+		require.Equal(t, input.result, res.Mappings().Policies())
+	}
+}
+
+func TestRuleSetMatchRollupRules(t *testing.T) {
+	ruleSetConfig := &schema.RuleSet{
+		RollupRules: testRollupRulesConfig(),
+	}
+	ruleSet, err := NewRuleSet(ruleSetConfig, testRuleSetOptions())
+	require.NoError(t, err)
+
+	inputs := []testRollupResultsData{
+		{
+			id: "rtagName1=rtagValue1,rtagName2=rtagValue2,rtagName3=rtagValue3",
+			result: []RollupResult{
+				{
+					ID: "rName1|rtagName1=rtagValue1,rtagName2=rtagValue2",
+					Policies: []policy.Policy{
+						policy.NewPolicy(10*time.Second, xtime.Second, 12*time.Hour),
+						policy.NewPolicy(time.Minute, xtime.Minute, 24*time.Hour),
+						policy.NewPolicy(5*time.Minute, xtime.Minute, 48*time.Hour),
+					},
+				},
+				{
+					ID: "rName2|rtagName1=rtagValue1",
+					Policies: []policy.Policy{
+						policy.NewPolicy(10*time.Second, xtime.Second, 24*time.Hour),
+					},
+				},
+			},
+		},
+		{
+			id: "rtagName1=rtagValue2",
+			result: []RollupResult{
+				{
+					ID: "rName3|rtagName1=rtagValue2",
+					Policies: []policy.Policy{
+						policy.NewPolicy(time.Minute, xtime.Minute, time.Hour),
+					},
+				},
+			},
+		},
+		{
+			id:     "rtagName5=rtagValue5",
+			result: []RollupResult{},
+		},
+	}
+	for _, input := range inputs {
+		res := ruleSet.Match(input.id)
+		require.Equal(t, ruleSet.Version(), res.Version())
+		require.Equal(t, ruleSet.Cutover(), res.Cutover())
+		require.Equal(t, len(input.result), res.NumRollups())
+		for i := 0; i < len(input.result); i++ {
+			id, policies := res.Rollups(i)
+			require.Equal(t, input.result[i].ID, id)
+			require.Equal(t, input.result[i].Policies, policies.Policies())
+		}
+	}
+}
+
+func TestTombstonedRuleSetMatch(t *testing.T) {
+	ruleSetConfig := &schema.RuleSet{
+		Version:      1,
+		Cutover:      time.Now().UnixNano(),
+		Tombstoned:   true,
+		MappingRules: testMappingRulesConfig(),
+		RollupRules:  testRollupRulesConfig(),
+	}
+	ruleSet, err := NewRuleSet(ruleSetConfig, testRuleSetOptions())
+	require.NoError(t, err)
+
+	expected := NewMatchResult(ruleSet.Version(), ruleSet.Cutover(), nil, nil)
+	id := "rtagName1=rtagValue1"
+	require.Equal(t, expected, ruleSet.Match(id))
+}
+
+type testRollupTargetData struct {
+	target RollupTarget
+	result bool
+}
+
+type testMappingsData struct {
+	id     string
+	result []policy.Policy
+}
+
+type testRollupResultsData struct {
+	id     string
+	result []RollupResult
+}
+
+func testRuleSetOptions() Options {
+	return NewOptions().
+		SetNewSortedTagIteratorFn(filters.NewMockSortedTagIterator).
+		SetNewIDFn(mockNewID)
+}
+
+func mockNewID(name string, tags []TagPair) string {
+	if len(tags) == 0 {
+		return name
+	}
+	var buf bytes.Buffer
+	buf.WriteString(fmt.Sprintf("%s", name))
+	if len(tags) > 0 {
+		buf.WriteString("|")
+		for idx, p := range tags {
+			buf.WriteString(p.Name)
+			buf.WriteString("=")
+			buf.WriteString(p.Value)
+			if idx < len(tags)-1 {
+				buf.WriteString(",")
+			}
+		}
+	}
+	return buf.String()
 }
 
 func testMappingRulesConfig() []*schema.MappingRule {
@@ -197,11 +330,14 @@ func testMappingRulesConfig() []*schema.MappingRule {
 func testRollupRulesConfig() []*schema.RollupRule {
 	return []*schema.RollupRule{
 		{
-			TagFilters: map[string]string{"rtagName1": "rtagValue1"},
+			TagFilters: map[string]string{
+				"rtagName1": "rtagValue1",
+				"rtagName2": "rtagValue2",
+			},
 			Targets: []*schema.RollupTarget{
 				&schema.RollupTarget{
 					Name: "rName1",
-					Tags: []string{"rtag1", "rtag2"},
+					Tags: []string{"rtagName1", "rtagName2"},
 					Policies: []*schema.Policy{
 						&schema.Policy{
 							Resolution: &schema.Resolution{
@@ -235,11 +371,14 @@ func testRollupRulesConfig() []*schema.RollupRule {
 			},
 		},
 		{
-			TagFilters: map[string]string{"rtagName1": "rtagValue1"},
+			TagFilters: map[string]string{
+				"rtagName1": "rtagValue1",
+				"rtagName2": "rtagValue2",
+			},
 			Targets: []*schema.RollupTarget{
 				&schema.RollupTarget{
 					Name: "rName1",
-					Tags: []string{"rtag1", "rtag2"},
+					Tags: []string{"rtagName1", "rtagName2"},
 					Policies: []*schema.Policy{
 						&schema.Policy{
 							Resolution: &schema.Resolution{
@@ -264,11 +403,14 @@ func testRollupRulesConfig() []*schema.RollupRule {
 			},
 		},
 		{
-			TagFilters: map[string]string{"rtagName1": "rtagValue1"},
+			TagFilters: map[string]string{
+				"rtagName1": "rtagValue1",
+				"rtagName2": "rtagValue2",
+			},
 			Targets: []*schema.RollupTarget{
 				&schema.RollupTarget{
 					Name: "rName1",
-					Tags: []string{"rtag1", "rtag2"},
+					Tags: []string{"rtagName1", "rtagName2"},
 					Policies: []*schema.Policy{
 						&schema.Policy{
 							Resolution: &schema.Resolution{
@@ -301,7 +443,7 @@ func testRollupRulesConfig() []*schema.RollupRule {
 				},
 				&schema.RollupTarget{
 					Name: "rName2",
-					Tags: []string{"rtag1"},
+					Tags: []string{"rtagName1"},
 					Policies: []*schema.Policy{
 						&schema.Policy{
 							Resolution: &schema.Resolution{
@@ -317,11 +459,13 @@ func testRollupRulesConfig() []*schema.RollupRule {
 			},
 		},
 		{
-			TagFilters: map[string]string{"rtagName1": "rtagValue2"},
+			TagFilters: map[string]string{
+				"rtagName1": "rtagValue2",
+			},
 			Targets: []*schema.RollupTarget{
 				&schema.RollupTarget{
 					Name: "rName3",
-					Tags: []string{"rtag1", "rtag2"},
+					Tags: []string{"rtagName1", "rtagName2"},
 					Policies: []*schema.Policy{
 						&schema.Policy{
 							Resolution: &schema.Resolution{
@@ -337,106 +481,4 @@ func testRollupRulesConfig() []*schema.RollupRule {
 			},
 		},
 	}
-}
-
-func TestRuleSetMatchMappingRules(t *testing.T) {
-	ruleSetConfig := &schema.RuleSet{
-		Version:      1,
-		Cutover:      time.Now().UnixNano(),
-		MappingRules: testMappingRulesConfig(),
-	}
-	ruleSet, err := NewRuleSet(ruleSetConfig, filters.NewMockSortedTagIterator)
-	require.NoError(t, err)
-
-	inputs := []testMappingsData{
-		{
-			id: "mtagName1=mtagValue1",
-			result: []policy.Policy{
-				policy.NewPolicy(10*time.Second, xtime.Second, 12*time.Hour),
-				policy.NewPolicy(time.Minute, xtime.Minute, 24*time.Hour),
-				policy.NewPolicy(5*time.Minute, xtime.Minute, 48*time.Hour),
-			},
-		},
-		{
-			id: "mtagName1=mtagValue2",
-			result: []policy.Policy{
-				policy.NewPolicy(10*time.Second, xtime.Second, 24*time.Hour),
-			},
-		},
-	}
-	for _, input := range inputs {
-		res := ruleSet.Match(input.id)
-		require.Equal(t, ruleSet.Version(), res.Version)
-		require.Equal(t, ruleSet.Cutover(), res.Cutover)
-		require.Equal(t, input.result, res.Mappings)
-	}
-}
-
-func TestRuleSetMatchRollupRules(t *testing.T) {
-	ruleSetConfig := &schema.RuleSet{
-		RollupRules: testRollupRulesConfig(),
-	}
-	ruleSet, err := NewRuleSet(ruleSetConfig, filters.NewMockSortedTagIterator)
-	require.NoError(t, err)
-
-	inputs := []testRollupsData{
-		{
-			id: "rtagName1=rtagValue1",
-			result: []RollupTarget{
-				{
-					Name: "rName1",
-					Tags: []string{"rtag1", "rtag2"},
-					Policies: []policy.Policy{
-						policy.NewPolicy(10*time.Second, xtime.Second, 12*time.Hour),
-						policy.NewPolicy(time.Minute, xtime.Minute, 24*time.Hour),
-						policy.NewPolicy(5*time.Minute, xtime.Minute, 48*time.Hour),
-					},
-				},
-				{
-					Name: "rName2",
-					Tags: []string{"rtag1"},
-					Policies: []policy.Policy{
-						policy.NewPolicy(10*time.Second, xtime.Second, 24*time.Hour),
-					},
-				},
-			},
-		},
-		{
-			id: "rtagName1=rtagValue2",
-			result: []RollupTarget{
-				{
-					Name: "rName3",
-					Tags: []string{"rtag1", "rtag2"},
-					Policies: []policy.Policy{
-						policy.NewPolicy(time.Minute, xtime.Minute, time.Hour),
-					},
-				},
-			},
-		},
-	}
-	for _, input := range inputs {
-		res := ruleSet.Match(input.id)
-		require.Equal(t, ruleSet.Version(), res.Version)
-		require.Equal(t, ruleSet.Cutover(), res.Cutover)
-		require.Equal(t, input.result, res.Rollups)
-	}
-}
-
-func TestTombstonedRuleSetMatch(t *testing.T) {
-	ruleSetConfig := &schema.RuleSet{
-		Version:      1,
-		Cutover:      time.Now().UnixNano(),
-		Tombstoned:   true,
-		MappingRules: testMappingRulesConfig(),
-		RollupRules:  testRollupRulesConfig(),
-	}
-	ruleSet, err := NewRuleSet(ruleSetConfig, filters.NewMockSortedTagIterator)
-	require.NoError(t, err)
-
-	expected := MatchResult{
-		Version: ruleSet.Version(),
-		Cutover: ruleSet.Cutover(),
-	}
-	id := "rtagName1=rtagValue1"
-	require.Equal(t, expected, ruleSet.Match(id))
 }


### PR DESCRIPTION
This PR stores the ID of the rollup metrics in the match result to avoid repeatedly recomputing the id from the name and the tags in the rollup targets, saving significant CPU time and reducing memory allocations.