### PR TITLE
Search rules backwards

### DIFF
--- a/rules/mapping.go
+++ b/rules/mapping.go
@@ -117,10 +117,9 @@ func (mc *mappingRule) ActiveRule(timeNs int64) *mappingRule {
 }
 
 func (mc *mappingRule) activeIndex(timeNs int64) int {
-	idx := 0
-	for idx < len(mc.snapshots) && mc.snapshots[idx].cutoverNs <= timeNs {
-		idx++
+	idx := len(mc.snapshots) - 1
+	for idx >= 0 && mc.snapshots[idx].cutoverNs > timeNs {
+		idx--
 	}
-	idx--
 	return idx
 }

--- a/rules/mapping_test.go
+++ b/rules/mapping_test.go
@@ -171,9 +171,5 @@ func TestMappingRuleActiveRuleFound_Second(t *testing.T) {
 func TestMappingRuleActiveRuleFound_First(t *testing.T) {
 	mr, err := newMappingRule(testMappingRuleSchema, nil)
 	require.NoError(t, err)
-	expected := &mappingRule{
-		uuid:      mr.uuid,
-		snapshots: mr.snapshots,
-	}
-	require.Equal(t, expected, mr.ActiveRule(20000))
+	require.Equal(t, mr, mr.ActiveRule(20000))
 }

--- a/rules/mapping_test.go
+++ b/rules/mapping_test.go
@@ -140,10 +140,16 @@ func TestMappingRuleActiveSnapshotNotFound(t *testing.T) {
 	require.Nil(t, mr.ActiveSnapshot(0))
 }
 
-func TestMappingRuleActiveSnapshotFound(t *testing.T) {
+func TestMappingRuleActiveSnapshotFound_Second(t *testing.T) {
 	mr, err := newMappingRule(testMappingRuleSchema, nil)
 	require.NoError(t, err)
 	require.Equal(t, mr.snapshots[1], mr.ActiveSnapshot(100000))
+}
+
+func TestMappingRuleActiveSnapshotFound_First(t *testing.T) {
+	mr, err := newMappingRule(testMappingRuleSchema, nil)
+	require.NoError(t, err)
+	require.Equal(t, mr.snapshots[0], mr.ActiveSnapshot(20000))
 }
 
 func TestMappingRuleActiveRuleNotFound(t *testing.T) {
@@ -152,7 +158,7 @@ func TestMappingRuleActiveRuleNotFound(t *testing.T) {
 	require.Equal(t, mr, mr.ActiveRule(0))
 }
 
-func TestMappingRuleActiveRuleFound(t *testing.T) {
+func TestMappingRuleActiveRuleFound_Second(t *testing.T) {
 	mr, err := newMappingRule(testMappingRuleSchema, nil)
 	require.NoError(t, err)
 	expected := &mappingRule{
@@ -160,4 +166,14 @@ func TestMappingRuleActiveRuleFound(t *testing.T) {
 		snapshots: mr.snapshots[1:],
 	}
 	require.Equal(t, expected, mr.ActiveRule(100000))
+}
+
+func TestMappingRuleActiveRuleFound_First(t *testing.T) {
+	mr, err := newMappingRule(testMappingRuleSchema, nil)
+	require.NoError(t, err)
+	expected := &mappingRule{
+		uuid:      mr.uuid,
+		snapshots: mr.snapshots,
+	}
+	require.Equal(t, expected, mr.ActiveRule(20000))
 }


### PR DESCRIPTION
Rules are stored by cutover time ascending, searching backwards should
be faster

@xichen2020 @robskillington @jeromefroe 