### PR TITLE
Cache id and policies and buffer timer values when decoding unaggregated metrics

### DIFF
--- a/metric/unaggregated/types.go
+++ b/metric/unaggregated/types.go
@@ -25,12 +25,13 @@ import (
 
 	"github.com/m3db/m3metrics/metric"
 	"github.com/m3db/m3metrics/policy"
+	"github.com/m3db/m3x/pool"
 )
 
-// Type is a metric type
+// Type is a metric type.
 type Type int8
 
-// List of supported metric types
+// List of supported metric types.
 const (
 	UnknownType Type = iota
 	CounterType
@@ -51,37 +52,37 @@ func (t Type) String() string {
 	}
 }
 
-// Counter is a counter containing the counter ID and the counter value
+// Counter is a counter containing the counter ID and the counter value.
 type Counter struct {
 	ID    metric.ID
 	Value int64
 }
 
-// BatchTimer is a timer containing the timer ID and a list of timer values
+// BatchTimer is a timer containing the timer ID and a list of timer values.
 type BatchTimer struct {
 	ID     metric.ID
 	Values []float64
 }
 
-// Gauge is a gauge containing the gauge ID and the value at certain time
+// Gauge is a gauge containing the gauge ID and the value at certain time.
 type Gauge struct {
 	ID    metric.ID
 	Value float64
 }
 
-// CounterWithPolicies is a counter with applicable policies
+// CounterWithPolicies is a counter with applicable policies.
 type CounterWithPolicies struct {
 	Counter
 	policy.VersionedPolicies
 }
 
-// BatchTimerWithPolicies is a batch timer with applicable policies
+// BatchTimerWithPolicies is a batch timer with applicable policies.
 type BatchTimerWithPolicies struct {
 	BatchTimer
 	policy.VersionedPolicies
 }
 
-// GaugeWithPolicies is a gauge with applicable policies
+// GaugeWithPolicies is a gauge with applicable policies.
 type GaugeWithPolicies struct {
 	Gauge
 	policy.VersionedPolicies
@@ -92,17 +93,20 @@ type GaugeWithPolicies struct {
 // which determines which value field is valid. We intentionally do not use value
 // pointers and nil checks to determine which type is valid in order to avoid the GC
 // overhead of marking and sweeping the metrics.
+// NB(xichen): possibly use refcounting to replace explicit ownership tracking.
 type MetricUnion struct {
 	Type          Type
 	ID            metric.ID
 	CounterVal    int64
 	BatchTimerVal []float64
 	GaugeVal      float64
+	OwnsID        bool
+	TimerValPool  pool.FloatsPool
 }
 
 var emptyMetricUnion MetricUnion
 
-// String is the string representation of a metric union
+// String is the string representation of a metric union.
 func (m *MetricUnion) String() string {
 	switch m.Type {
 	case CounterType:
@@ -119,14 +123,14 @@ func (m *MetricUnion) String() string {
 	}
 }
 
-// Reset resets the metric union
+// Reset resets the metric union.
 func (m *MetricUnion) Reset() { *m = emptyMetricUnion }
 
-// Counter returns the counter metric
+// Counter returns the counter metric.
 func (m *MetricUnion) Counter() Counter { return Counter{ID: m.ID, Value: m.CounterVal} }
 
-// BatchTimer returns the batch timer metric
+// BatchTimer returns the batch timer metric.
 func (m *MetricUnion) BatchTimer() BatchTimer { return BatchTimer{ID: m.ID, Values: m.BatchTimerVal} }
 
-// Gauge returns the gauge metric
+// Gauge returns the gauge metric.
 func (m *MetricUnion) Gauge() Gauge { return Gauge{ID: m.ID, Value: m.GaugeVal} }

--- a/metric/unaggregated/types.go
+++ b/metric/unaggregated/types.go
@@ -90,9 +90,9 @@ type GaugeWithPolicies struct {
 
 // MetricUnion is a union of different types of metrics, only one of which is valid
 // at any given time. The actual type of the metric depends on the type field,
-// which determines which value field is valid. We intentionally do not use value
-// pointers and nil checks to determine which type is valid in order to avoid the GC
-// overhead of marking and sweeping the metrics.
+// which determines which value field is valid. Note that if the timer values are
+// allocated from a pool, the TimerValPool should be set to the originating pool,
+// and the caller is responsible for returning the timer values to the pool.
 // NB(xichen): possibly use refcounting to replace explicit ownership tracking.
 type MetricUnion struct {
 	Type          Type

--- a/protocol/msgpack/aggregated_roundtrip_test.go
+++ b/protocol/msgpack/aggregated_roundtrip_test.go
@@ -105,7 +105,7 @@ func toRawMetric(t *testing.T, m interface{}) aggregated.RawMetric {
 		require.Fail(t, "unrecognized metric type %T", m)
 	}
 	require.NoError(t, encoder.err())
-	return NewRawMetric(data)
+	return NewRawMetric(data, 16)
 }
 
 func validateAggregatedRoundtrip(t *testing.T, inputs ...metricWithPolicy) {

--- a/protocol/msgpack/buffered_encoder_test.go
+++ b/protocol/msgpack/buffered_encoder_test.go
@@ -26,15 +26,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func testBufferedEncoder() *bufferedEncoder {
-	return NewBufferedEncoder().(*bufferedEncoder)
-}
-
 func TestBufferedEncoderReset(t *testing.T) {
 	encoder := testBufferedEncoder()
 	inputs := []interface{}{1, 2.0, "foo", byte(8)}
 
-	// Encode for the first time
+	// Encode for the first time.
 	for _, input := range inputs {
 		encoder.Encode(input)
 	}
@@ -42,10 +38,10 @@ func TestBufferedEncoderReset(t *testing.T) {
 	results := make([]byte, len(encoded))
 	copy(results, encoded)
 
-	// Reset the encoder
+	// Reset the encoder.
 	encoder.Reset()
 
-	// Encode for the second time
+	// Encode for the second time.
 	for _, input := range inputs {
 		encoder.Encode(input)
 	}
@@ -60,11 +56,15 @@ func TestBufferedEncoderClose(t *testing.T) {
 	encoder := testBufferedEncoder()
 	require.False(t, encoder.closed)
 
-	// Close the encoder should set the flag
+	// Close the encoder should set the flag.
 	encoder.Close()
 	require.True(t, encoder.closed)
 
-	// Close the encoder again should be a no-op
+	// Close the encoder again should be a no-op.
 	encoder.Close()
 	require.True(t, encoder.closed)
+}
+
+func testBufferedEncoder() *bufferedEncoder {
+	return NewBufferedEncoder().(*bufferedEncoder)
 }

--- a/protocol/msgpack/options.go
+++ b/protocol/msgpack/options.go
@@ -20,111 +20,139 @@
 
 package msgpack
 
-import (
-	"github.com/m3db/m3metrics/policy"
-	xpool "github.com/m3db/m3x/pool"
-)
+import xpool "github.com/m3db/m3x/pool"
 
 const (
 	// Whether the iterator should ignore higher-than-supported version
-	// by default for unaggregated metrics
+	// by default for unaggregated iterator.
 	defaultUnaggregatedIgnoreHigherVersion = false
 
+	// Default reader buffer size for the unaggregated iterator.
+	defaultUnaggregatedReaderBufferSize = 1440
+
+	// Whether a float slice is considered a "large" slice and therefore
+	// resort to the pool for allocating that slice.
+	defaultLargeFloatsSize = 1024
+
 	// Whether the iterator should ignore higher-than-supported version
-	// by default for aggregated metrics
+	// by default for aggregated iterator.
 	defaultAggregatedIgnoreHigherVersion = false
+
+	// Default reader buffer size for the aggregated iterator.
+	defaultAggregatedReaderBufferSize = 1440
 )
 
 type unaggregatedIteratorOptions struct {
 	ignoreHigherVersion bool
-	floatsPool          xpool.FloatsPool
-	policiesPool        policy.PoliciesPool
+	readerBufferSize    int
+	largeFloatsSize     int
+	largeFloatsPool     xpool.FloatsPool
 	iteratorPool        UnaggregatedIteratorPool
 }
 
 // NewUnaggregatedIteratorOptions creates a new set of unaggregated iterator options
 func NewUnaggregatedIteratorOptions() UnaggregatedIteratorOptions {
-	floatsPool := xpool.NewFloatsPool(nil, nil)
-	floatsPool.Init()
+	largeFloatsPool := xpool.NewFloatsPool(nil, nil)
+	largeFloatsPool.Init()
 
-	policiesPool := policy.NewPoliciesPool(nil, nil)
-	policiesPool.Init()
-
-	return unaggregatedIteratorOptions{
+	return &unaggregatedIteratorOptions{
 		ignoreHigherVersion: defaultUnaggregatedIgnoreHigherVersion,
-		floatsPool:          floatsPool,
-		policiesPool:        policiesPool,
+		readerBufferSize:    defaultUnaggregatedReaderBufferSize,
+		largeFloatsSize:     defaultLargeFloatsSize,
+		largeFloatsPool:     largeFloatsPool,
 	}
 }
 
-func (o unaggregatedIteratorOptions) SetIgnoreHigherVersion(value bool) UnaggregatedIteratorOptions {
-	opts := o
+func (o *unaggregatedIteratorOptions) SetIgnoreHigherVersion(value bool) UnaggregatedIteratorOptions {
+	opts := *o
 	opts.ignoreHigherVersion = value
-	return opts
+	return &opts
 }
 
-func (o unaggregatedIteratorOptions) IgnoreHigherVersion() bool {
+func (o *unaggregatedIteratorOptions) IgnoreHigherVersion() bool {
 	return o.ignoreHigherVersion
 }
 
-func (o unaggregatedIteratorOptions) SetFloatsPool(value xpool.FloatsPool) UnaggregatedIteratorOptions {
-	opts := o
-	opts.floatsPool = value
-	return opts
+func (o *unaggregatedIteratorOptions) SetReaderBufferSize(value int) UnaggregatedIteratorOptions {
+	opts := *o
+	opts.readerBufferSize = value
+	return &opts
 }
 
-func (o unaggregatedIteratorOptions) FloatsPool() xpool.FloatsPool {
-	return o.floatsPool
+func (o *unaggregatedIteratorOptions) ReaderBufferSize() int {
+	return o.readerBufferSize
 }
 
-func (o unaggregatedIteratorOptions) SetPoliciesPool(value policy.PoliciesPool) UnaggregatedIteratorOptions {
-	opts := o
-	opts.policiesPool = value
-	return opts
+func (o *unaggregatedIteratorOptions) SetLargeFloatsSize(value int) UnaggregatedIteratorOptions {
+	opts := *o
+	opts.largeFloatsSize = value
+	return &opts
 }
 
-func (o unaggregatedIteratorOptions) PoliciesPool() policy.PoliciesPool {
-	return o.policiesPool
+func (o *unaggregatedIteratorOptions) LargeFloatsSize() int {
+	return o.largeFloatsSize
 }
 
-func (o unaggregatedIteratorOptions) SetIteratorPool(value UnaggregatedIteratorPool) UnaggregatedIteratorOptions {
-	opts := o
+func (o *unaggregatedIteratorOptions) SetLargeFloatsPool(value xpool.FloatsPool) UnaggregatedIteratorOptions {
+	opts := *o
+	opts.largeFloatsPool = value
+	return &opts
+}
+
+func (o *unaggregatedIteratorOptions) LargeFloatsPool() xpool.FloatsPool {
+	return o.largeFloatsPool
+}
+
+func (o *unaggregatedIteratorOptions) SetIteratorPool(value UnaggregatedIteratorPool) UnaggregatedIteratorOptions {
+	opts := *o
 	opts.iteratorPool = value
-	return opts
+	return &opts
 }
 
-func (o unaggregatedIteratorOptions) IteratorPool() UnaggregatedIteratorPool {
+func (o *unaggregatedIteratorOptions) IteratorPool() UnaggregatedIteratorPool {
 	return o.iteratorPool
 }
 
 type aggregatedIteratorOptions struct {
 	ignoreHigherVersion bool
+	readerBufferSize    int
 	iteratorPool        AggregatedIteratorPool
 }
 
 // NewAggregatedIteratorOptions creates a new set of aggregated iterator options
 func NewAggregatedIteratorOptions() AggregatedIteratorOptions {
-	return aggregatedIteratorOptions{
+	return &aggregatedIteratorOptions{
 		ignoreHigherVersion: defaultAggregatedIgnoreHigherVersion,
+		readerBufferSize:    defaultAggregatedReaderBufferSize,
 	}
 }
 
-func (o aggregatedIteratorOptions) SetIgnoreHigherVersion(value bool) AggregatedIteratorOptions {
-	opts := o
+func (o *aggregatedIteratorOptions) SetIgnoreHigherVersion(value bool) AggregatedIteratorOptions {
+	opts := *o
 	opts.ignoreHigherVersion = value
-	return opts
+	return &opts
 }
 
-func (o aggregatedIteratorOptions) IgnoreHigherVersion() bool {
+func (o *aggregatedIteratorOptions) IgnoreHigherVersion() bool {
 	return o.ignoreHigherVersion
 }
 
-func (o aggregatedIteratorOptions) SetIteratorPool(value AggregatedIteratorPool) AggregatedIteratorOptions {
-	opts := o
-	opts.iteratorPool = value
-	return opts
+func (o *aggregatedIteratorOptions) SetReaderBufferSize(value int) AggregatedIteratorOptions {
+	opts := *o
+	opts.readerBufferSize = value
+	return &opts
 }
 
-func (o aggregatedIteratorOptions) IteratorPool() AggregatedIteratorPool {
+func (o *aggregatedIteratorOptions) ReaderBufferSize() int {
+	return o.readerBufferSize
+}
+
+func (o *aggregatedIteratorOptions) SetIteratorPool(value AggregatedIteratorPool) AggregatedIteratorOptions {
+	opts := *o
+	opts.iteratorPool = value
+	return &opts
+}
+
+func (o *aggregatedIteratorOptions) IteratorPool() AggregatedIteratorPool {
 	return o.iteratorPool
 }

--- a/protocol/msgpack/types.go
+++ b/protocol/msgpack/types.go
@@ -29,7 +29,7 @@ import (
 	"github.com/m3db/m3metrics/metric/aggregated"
 	"github.com/m3db/m3metrics/metric/unaggregated"
 	"github.com/m3db/m3metrics/policy"
-	xpool "github.com/m3db/m3x/pool"
+	"github.com/m3db/m3x/pool"
 )
 
 // Buffer is a byte buffer
@@ -151,6 +151,9 @@ type iteratorBase interface {
 	// setErr sets the iterator error
 	setErr(err error)
 
+	// reader returns the buffered reader.
+	reader() bufReader
+
 	// decodePolicy decodes a policy
 	decodePolicy() policy.Policy
 
@@ -214,50 +217,59 @@ type UnaggregatedEncoder interface {
 	Reset(encoder BufferedEncoder)
 }
 
-// UnaggregatedIterator is an iterator for decoding different types of unaggregated metrics
+// UnaggregatedIterator is an iterator for decoding different types of unaggregated metrics.
 type UnaggregatedIterator interface {
-	// Next returns true if there are more items to decode
+	// Next returns true if there are more items to decode.
 	Next() bool
 
-	// Value returns the current metric and applicable policies
+	// Value returns the current metric and applicable policies.
+	// The returned value remains valid until the next Next() call.
 	Value() (unaggregated.MetricUnion, policy.VersionedPolicies)
 
-	// Err returns the error encountered during decoding, if any
+	// Err returns the error encountered during decoding, if any.
 	Err() error
 
-	// Reset resets the iterator
+	// Reset resets the iterator.
 	Reset(reader io.Reader)
 
-	// Close closes the iterator
+	// Close closes the iterator.
 	Close()
 }
 
-// UnaggregatedIteratorOptions provide options for unaggregated iterators
+// UnaggregatedIteratorOptions provide options for unaggregated iterators.
 type UnaggregatedIteratorOptions interface {
 	// SetIgnoreHigherVersion determines whether the iterator ignores messages
-	// with higher-than-supported version
+	// with higher-than-supported version.
 	SetIgnoreHigherVersion(value bool) UnaggregatedIteratorOptions
 
 	// IgnoreHigherVersion returns whether the iterator ignores messages with
-	// higher-than-supported version
+	// higher-than-supported version.
 	IgnoreHigherVersion() bool
 
-	// SetFloatsPool sets the floats pool
-	SetFloatsPool(value xpool.FloatsPool) UnaggregatedIteratorOptions
+	// SetReaderBufferSize sets the reader buffer size.
+	SetReaderBufferSize(value int) UnaggregatedIteratorOptions
 
-	// FloatsPool returns the floats pool
-	FloatsPool() xpool.FloatsPool
+	// ReaderBufferSize returns the reader buffer size.
+	ReaderBufferSize() int
 
-	// SetPoliciesPool sets the policies pool
-	SetPoliciesPool(value policy.PoliciesPool) UnaggregatedIteratorOptions
+	// SetLargeFloatsSize determines whether a float slice is considered a "large"
+	// slice and therefore resort to the pool for allocating that slice.
+	SetLargeFloatsSize(value int) UnaggregatedIteratorOptions
 
-	// PoliciesPool returns the policies pool
-	PoliciesPool() policy.PoliciesPool
+	// LargeFloatsSize returns whether a float slice is considered a "large"
+	// slice and therefore resort to the pool for allocating that slice.
+	LargeFloatsSize() int
 
-	// SetIteratorPool sets the unaggregated iterator pool
+	// SetLargeFloatsPool sets the large floats pool.
+	SetLargeFloatsPool(value pool.FloatsPool) UnaggregatedIteratorOptions
+
+	// LargeFloatsPool returns the large floats pool.
+	LargeFloatsPool() pool.FloatsPool
+
+	// SetIteratorPool sets the unaggregated iterator pool.
 	SetIteratorPool(value UnaggregatedIteratorPool) UnaggregatedIteratorOptions
 
-	// IteratorPool returns the unaggregated iterator pool
+	// IteratorPool returns the unaggregated iterator pool.
 	IteratorPool() UnaggregatedIteratorPool
 }
 
@@ -312,20 +324,26 @@ type AggregatedIterator interface {
 	Close()
 }
 
-// AggregatedIteratorOptions provide options for aggregated iterators
+// AggregatedIteratorOptions provide options for aggregated iterators.
 type AggregatedIteratorOptions interface {
 	// SetIgnoreHigherVersion determines whether the iterator ignores messages
-	// with higher-than-supported version
+	// with higher-than-supported version.
 	SetIgnoreHigherVersion(value bool) AggregatedIteratorOptions
 
 	// IgnoreHigherVersion returns whether the iterator ignores messages with
-	// higher-than-supported version
+	// higher-than-supported version.
 	IgnoreHigherVersion() bool
 
-	// SetIteratorPool sets the aggregated iterator pool
+	// SetReaderBufferSize sets the reader buffer size.
+	SetReaderBufferSize(value int) AggregatedIteratorOptions
+
+	// ReaderBufferSize returns the reader buffer size.
+	ReaderBufferSize() int
+
+	// SetIteratorPool sets the aggregated iterator pool.
 	SetIteratorPool(value AggregatedIteratorPool) AggregatedIteratorOptions
 
-	// IteratorPool returns the aggregated iterator pool
+	// IteratorPool returns the aggregated iterator pool.
 	IteratorPool() AggregatedIteratorPool
 }
 

--- a/protocol/msgpack/unaggregated_encoder.go
+++ b/protocol/msgpack/unaggregated_encoder.go
@@ -25,7 +25,7 @@ import (
 	"github.com/m3db/m3metrics/policy"
 )
 
-// Various object-level encoding functions to facilitate testing
+// Various object-level encoding functions to facilitate testing.
 type encodeRootObjectFn func(objType objectType)
 type encodeCounterWithPoliciesFn func(cp unaggregated.CounterWithPolicies)
 type encodeBatchTimerWithPoliciesFn func(btp unaggregated.BatchTimerWithPolicies)
@@ -50,7 +50,7 @@ type unaggregatedEncoder struct {
 	encodeVersionedPoliciesFn      encodeVersionedPoliciesFn      // versioned policies encoding function
 }
 
-// NewUnaggregatedEncoder creates a new unaggregated encoder
+// NewUnaggregatedEncoder creates a new unaggregated encoder.
 func NewUnaggregatedEncoder(encoder BufferedEncoder) UnaggregatedEncoder {
 	enc := &unaggregatedEncoder{encoderBase: newBaseEncoder(encoder)}
 
@@ -143,7 +143,7 @@ func (enc *unaggregatedEncoder) encodeGauge(g unaggregated.Gauge) {
 
 func (enc *unaggregatedEncoder) encodeVersionedPolicies(vp policy.VersionedPolicies) {
 	// NB(xichen): if this is a default policy, we do not encode the actual policies
-	// to optimize for the common case
+	// to optimize for the common case.
 	if vp.IsDefault() {
 		enc.encodeNumObjectFields(numFieldsForType(defaultVersionedPoliciesType))
 		enc.encodeObjectType(defaultVersionedPoliciesType)
@@ -151,7 +151,7 @@ func (enc *unaggregatedEncoder) encodeVersionedPolicies(vp policy.VersionedPolic
 		enc.encodeTime(vp.Cutover)
 		return
 	}
-	// Otherwise fallback to encoding the entire object
+	// Otherwise fallback to encoding the entire object.
 	enc.encodeNumObjectFields(numFieldsForType(customVersionedPoliciesType))
 	enc.encodeObjectType(customVersionedPoliciesType)
 	enc.encodeVersion(vp.Version)

--- a/protocol/msgpack/unaggregated_iterator.go
+++ b/protocol/msgpack/unaggregated_iterator.go
@@ -24,9 +24,10 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/m3db/m3metrics/metric"
 	"github.com/m3db/m3metrics/metric/unaggregated"
 	"github.com/m3db/m3metrics/policy"
-	xpool "github.com/m3db/m3x/pool"
+	"github.com/m3db/m3x/pool"
 )
 
 // unaggregatedIterator uses MessagePack to decode different types of unaggregated metrics.
@@ -34,33 +35,39 @@ import (
 type unaggregatedIterator struct {
 	iteratorBase
 
-	ignoreHigherVersion bool                     // whether we ignore messages with a higher-than-supported version
-	floatsPool          xpool.FloatsPool         // pool for float slices
-	policiesPool        policy.PoliciesPool      // pool for policies
-	iteratorPool        UnaggregatedIteratorPool // pool for unaggregated iterators
-	closed              bool                     // whether the iterator is closed
-	metric              unaggregated.MetricUnion // current metric
-	versionedPolicies   policy.VersionedPolicies // current policies
+	ignoreHigherVersion bool
+	largeFloatsSize     int
+	largeFloatsPool     pool.FloatsPool
+	iteratorPool        UnaggregatedIteratorPool
+
+	closed            bool
+	metric            unaggregated.MetricUnion
+	versionedPolicies policy.VersionedPolicies
+	id                metric.ID
+	policies          []policy.Policy
+	timerValues       []float64
 }
 
-// NewUnaggregatedIterator creates a new unaggregated iterator
+// NewUnaggregatedIterator creates a new unaggregated iterator.
 func NewUnaggregatedIterator(reader io.Reader, opts UnaggregatedIteratorOptions) UnaggregatedIterator {
 	if opts == nil {
 		opts = NewUnaggregatedIteratorOptions()
 	}
-	return &unaggregatedIterator{
-		iteratorBase:        newBaseIterator(reader),
+	it := &unaggregatedIterator{
+		iteratorBase:        newBaseIterator(reader, opts.ReaderBufferSize()),
 		ignoreHigherVersion: opts.IgnoreHigherVersion(),
-		floatsPool:          opts.FloatsPool(),
-		policiesPool:        opts.PoliciesPool(),
+		largeFloatsSize:     opts.LargeFloatsSize(),
+		largeFloatsPool:     opts.LargeFloatsPool(),
 		iteratorPool:        opts.IteratorPool(),
 	}
+	return it
 }
 
 func (it *unaggregatedIterator) Err() error { return it.err() }
 
 func (it *unaggregatedIterator) Reset(reader io.Reader) {
 	it.closed = false
+	it.metric.Reset()
 	it.reset(reader)
 }
 
@@ -73,9 +80,9 @@ func (it *unaggregatedIterator) Next() bool {
 		return false
 	}
 
-	// Resetting the metric to avoid holding onto the float64 slices
-	// in the metric field even though they may not be used
-	it.metric.Reset()
+	// Reset the pointers in metric union to reduce GC sweep overhead.
+	it.metric.BatchTimerVal = nil
+	it.metric.TimerValPool = nil
 
 	return it.decodeRootObject()
 }
@@ -99,7 +106,7 @@ func (it *unaggregatedIterator) decodeRootObject() bool {
 		return false
 	}
 	// If the actual version is higher than supported version, we skip
-	// the data for this metric and continue to the next
+	// the data for this metric and continue to the next.
 	if version > unaggregatedVersion {
 		if it.ignoreHigherVersion {
 			it.skip(it.decodeNumObjectFields())
@@ -108,7 +115,7 @@ func (it *unaggregatedIterator) decodeRootObject() bool {
 		it.setErr(fmt.Errorf("received version %d is higher than supported version %d", version, unaggregatedVersion))
 		return false
 	}
-	// Otherwise we proceed to decoding normally
+	// Otherwise we proceed to decoding normally.
 	numExpectedFields, numActualFields, ok := it.checkNumFieldsForType(rootObjectType)
 	if !ok {
 		return false
@@ -166,12 +173,28 @@ func (it *unaggregatedIterator) decodeBatchTimer() {
 	}
 	it.metric.Type = unaggregated.BatchTimerType
 	it.metric.ID = it.decodeID()
-	numValues := it.decodeArrayLen()
-	values := it.floatsPool.Get(numValues)
-	for i := 0; i < numValues; i++ {
-		values = append(values, it.decodeFloat64())
+	var (
+		timerValues []float64
+		poolAlloc   = false
+		numValues   = it.decodeArrayLen()
+	)
+	if cap(it.timerValues) >= numValues {
+		it.timerValues = it.timerValues[:0]
+		timerValues = it.timerValues
+	} else if numValues <= it.largeFloatsSize {
+		it.timerValues = make([]float64, 0, numValues)
+		timerValues = it.timerValues
+	} else {
+		timerValues = it.largeFloatsPool.Get(numValues)
+		poolAlloc = true
 	}
-	it.metric.BatchTimerVal = values
+	for i := 0; i < numValues; i++ {
+		timerValues = append(timerValues, it.decodeFloat64())
+	}
+	it.metric.BatchTimerVal = timerValues
+	if poolAlloc {
+		it.metric.TimerValPool = it.largeFloatsPool
+	}
 	it.skip(numActualFields - numExpectedFields)
 }
 
@@ -204,13 +227,39 @@ func (it *unaggregatedIterator) decodeVersionedPolicies() {
 		it.skip(numActualFields - numExpectedFields)
 	case customVersionedPoliciesType:
 		numPolicies := it.decodeArrayLen()
-		policies := it.policiesPool.Get(numPolicies)
-		for i := 0; i < numPolicies; i++ {
-			policies = append(policies, it.decodePolicy())
+		if cap(it.policies) < numPolicies {
+			it.policies = make([]policy.Policy, 0, numPolicies)
+		} else {
+			it.policies = it.policies[:0]
 		}
-		it.versionedPolicies = policy.CustomVersionedPolicies(version, cutover, policies)
+		for i := 0; i < numPolicies; i++ {
+			it.policies = append(it.policies, it.decodePolicy())
+		}
+		it.versionedPolicies = policy.CustomVersionedPolicies(version, cutover, it.policies)
 		it.skip(numActualFields - numExpectedFields)
 	default:
 		it.setErr(fmt.Errorf("unrecognized versioned policies type: %v", versionedPoliciesType))
 	}
+}
+
+func (it *unaggregatedIterator) decodeID() metric.ID {
+	idLen := it.decodeBytesLen()
+	if it.err() != nil {
+		return nil
+	}
+	// NB(xichen): DecodeBytesLen() returns -1 if the byte slice is nil.
+	if idLen == -1 {
+		it.id = it.id[:0]
+		return metric.ID(it.id)
+	}
+	if cap(it.id) < idLen {
+		it.id = make([]byte, idLen)
+	} else {
+		it.id = it.id[:idLen]
+	}
+	if _, err := io.ReadFull(it.reader(), it.id); err != nil {
+		it.setErr(err)
+		return nil
+	}
+	return it.id
 }

--- a/protocol/msgpack/unaggregated_iterator_pool.go
+++ b/protocol/msgpack/unaggregated_iterator_pool.go
@@ -26,7 +26,7 @@ type unaggregatedIteratorPool struct {
 	pool pool.ObjectPool
 }
 
-// NewUnaggregatedIteratorPool creates a new pool for unaggregated iterators
+// NewUnaggregatedIteratorPool creates a new pool for unaggregated iterators.
 func NewUnaggregatedIteratorPool(opts pool.ObjectPoolOptions) UnaggregatedIteratorPool {
 	return &unaggregatedIteratorPool{pool: pool.NewObjectPool(opts)}
 }

--- a/protocol/msgpack/unaggregated_iterator_pool_test.go
+++ b/protocol/msgpack/unaggregated_iterator_pool_test.go
@@ -36,19 +36,19 @@ func TestUnaggregatedIteratorPool(t *testing.T) {
 		return NewUnaggregatedIterator(nil, itOpts)
 	})
 
-	// Retrieve an iterator from the pool
+	// Retrieve an iterator from the pool.
 	it := p.Get()
 	it.Reset(bytes.NewBuffer([]byte{0x1, 0x2}))
 
-	// Closing the iterator should put it back to the pool
+	// Closing the iterator should put it back to the pool.
 	it.Close()
 	require.True(t, it.(*unaggregatedIterator).closed)
 
-	// Retrieve the iterator and assert it's the same iterator
+	// Retrieve the iterator and assert it's the same iterator.
 	it = p.Get()
 	require.True(t, it.(*unaggregatedIterator).closed)
 
-	// Reset the iterator and assert it's been reset
+	// Reset the iterator and assert it's been reset.
 	it.Reset(nil)
 	require.False(t, it.(*unaggregatedIterator).closed)
 }

--- a/protocol/msgpack/unaggregated_iterator_test.go
+++ b/protocol/msgpack/unaggregated_iterator_test.go
@@ -236,13 +236,14 @@ func TestUnaggregatedIteratorDecodeBatchTimerWithAllocPoolAlloc(t *testing.T) {
 	enc := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
 	bt := unaggregated.BatchTimer{
 		ID:     []byte("foo"),
-		Values: []float64{1.0, 2.0, 3.0, 4.0},
+		Values: []float64{1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0},
 	}
 	enc.encodeBatchTimer(bt)
 	require.NoError(t, enc.err())
 
 	// Allocate a large enough buffer to avoid triggering an allocation.
 	it := testUnaggregatedIterator(t, enc.Encoder().Buffer()).(*unaggregatedIterator)
+	it.timerValues = nil
 	it.largeFloatsSize = 2
 	it.decodeBatchTimer()
 

--- a/protocol/msgpack/unaggregated_iterator_test.go
+++ b/protocol/msgpack/unaggregated_iterator_test.go
@@ -21,12 +21,14 @@
 package msgpack
 
 import (
+	"bufio"
 	"bytes"
 	"errors"
 	"io"
 	"testing"
 	"time"
 
+	"github.com/m3db/m3metrics/metric"
 	"github.com/m3db/m3metrics/metric/unaggregated"
 	"github.com/m3db/m3metrics/policy"
 	"github.com/m3db/m3x/time"
@@ -34,22 +36,226 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func validateUnaggregatedDecodeResults(
-	t *testing.T,
-	it UnaggregatedIterator,
-	expectedResults []metricWithPolicies,
-	expectedErr error,
-) {
-	var results []metricWithPolicies
-	for it.Next() {
-		value, policies := it.Value()
-		results = append(results, metricWithPolicies{
-			metric:            value,
-			versionedPolicies: policies,
-		})
+func TestUnaggregatedIteratorDecodeDefaultPolicies(t *testing.T) {
+	enc := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
+	enc.encodeVersionedPolicies(testDefaultVersionedPolicies)
+	require.NoError(t, enc.err())
+	it := testUnaggregatedIterator(t, enc.Encoder().Buffer()).(*unaggregatedIterator)
+	it.decodeVersionedPolicies()
+	require.NoError(t, it.Err())
+	_, vp := it.Value()
+	require.Equal(t, testDefaultVersionedPolicies, vp)
+}
+
+func TestUnaggregatedIteratorDecodeCustomPoliciesWithAlloc(t *testing.T) {
+	enc := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
+	enc.encodeVersionedPolicies(testCustomVersionedPolicies)
+	require.NoError(t, enc.err())
+	it := testUnaggregatedIterator(t, enc.Encoder().Buffer()).(*unaggregatedIterator)
+	it.decodeVersionedPolicies()
+	require.NoError(t, it.Err())
+	_, vp := it.Value()
+	require.Equal(t, testCustomVersionedPolicies, vp)
+	require.Equal(t, len(it.policies), len(testCustomVersionedPolicies.Policies()))
+}
+
+func TestUnaggregatedIteratorDecodeCustomPoliciesNoAlloc(t *testing.T) {
+	enc := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
+	enc.encodeVersionedPolicies(testCustomVersionedPolicies)
+	require.NoError(t, enc.err())
+	it := testUnaggregatedIterator(t, enc.Encoder().Buffer()).(*unaggregatedIterator)
+	it.policies = make([]policy.Policy, len(testCustomVersionedPolicies.Policies())*3)
+	it.decodeVersionedPolicies()
+	require.NoError(t, it.Err())
+	_, vp := it.Value()
+	require.Equal(t, testCustomVersionedPolicies, vp)
+	require.Equal(t, len(it.policies), len(testCustomVersionedPolicies.Policies()))
+}
+
+func TestUnaggregatedIteratorDecodeIDDecodeBytesLenError(t *testing.T) {
+	enc := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
+	enc.encodeFloat64(1.0)
+	require.NoError(t, enc.err())
+	it := testUnaggregatedIterator(t, enc.Encoder().Buffer()).(*unaggregatedIterator)
+	require.Equal(t, 0, len(it.decodeID()))
+	require.Error(t, it.Err())
+}
+
+func TestUnaggregatedIteratorDecodeIDNilBytes(t *testing.T) {
+	enc := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
+	enc.encodeBytes(nil)
+	require.NoError(t, enc.err())
+	it := testUnaggregatedIterator(t, enc.Encoder().Buffer()).(*unaggregatedIterator)
+	require.Equal(t, 0, len(it.decodeID()))
+	require.NoError(t, it.Err())
+}
+
+func TestUnaggregatedIteratorDecodeIDWithAlloc(t *testing.T) {
+	enc := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
+	data := []byte("foobarbaz")
+	enc.encodeBytes(data)
+	require.NoError(t, enc.err())
+	it := testUnaggregatedIterator(t, enc.Encoder().Buffer()).(*unaggregatedIterator)
+	require.Equal(t, metric.ID(data), it.decodeID())
+	require.NoError(t, it.Err())
+}
+
+func TestUnaggregatedIteratorDecodeIDNoAlloc(t *testing.T) {
+	enc := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
+	data := []byte("foobarbaz")
+	enc.encodeBytes(data)
+	require.NoError(t, enc.err())
+	it := testUnaggregatedIterator(t, enc.Encoder().Buffer()).(*unaggregatedIterator)
+	it.id = make([]byte, len(data)*3)
+	require.Equal(t, metric.ID(data), it.decodeID())
+	require.NoError(t, it.Err())
+}
+
+func TestUnaggregatedIteratorDecodeIDReadError(t *testing.T) {
+	enc := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
+	data := []byte("foobarbazasierasekr")
+	enc.encodeBytesLen(len(data) + 1)
+	require.NoError(t, enc.err())
+
+	it := testUnaggregatedIterator(t, enc.Encoder().Buffer()).(*unaggregatedIterator)
+	require.Equal(t, 0, len(it.decodeID()))
+	require.Error(t, it.Err())
+}
+
+func TestUnaggregatedIteratorDecodeIDReadSuccess(t *testing.T) {
+	enc := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
+	data := []byte("foobarbazasierasekr")
+	enc.encodeBytes(data)
+	require.NoError(t, enc.err())
+
+	// Intentionally buffer some data in the buffered reader.
+	buf := append([]byte{1}, enc.Encoder().Bytes()...)
+	reader := bufio.NewReaderSize(bytes.NewBuffer(buf), 16)
+	reader.Read(make([]byte, 1))
+
+	it := testUnaggregatedIterator(t, reader).(*unaggregatedIterator)
+	it.id = make([]byte, len(data)/2)
+	require.Equal(t, metric.ID(data), it.decodeID())
+	require.NoError(t, it.Err())
+}
+
+func TestUnaggregatedIteratorDecodeBatchTimerDecodeArrayLenError(t *testing.T) {
+	enc := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
+	enc.encodeFloat64(1.0)
+	require.NoError(t, enc.err())
+	it := testUnaggregatedIterator(t, enc.Encoder().Buffer()).(*unaggregatedIterator)
+	it.decodeBatchTimer()
+	require.Error(t, it.Err())
+}
+
+func TestUnaggregatedIteratorDecodeBatchTimerNoValues(t *testing.T) {
+	enc := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
+	bt := unaggregated.BatchTimer{
+		ID:     []byte("foo"),
+		Values: nil,
 	}
-	require.Equal(t, expectedErr, it.Err())
-	require.Equal(t, expectedResults, results)
+	enc.encodeBatchTimer(bt)
+	require.NoError(t, enc.err())
+
+	it := testUnaggregatedIterator(t, enc.Encoder().Buffer()).(*unaggregatedIterator)
+	it.decodeBatchTimer()
+
+	require.NoError(t, it.Err())
+	mu, _ := it.Value()
+	require.Equal(t, unaggregated.BatchTimerType, mu.Type)
+	require.Equal(t, metric.ID("foo"), mu.ID)
+	require.Equal(t, 0, len(mu.BatchTimerVal))
+	require.False(t, mu.OwnsID)
+	require.Nil(t, mu.TimerValPool)
+}
+
+func TestUnaggregatedIteratorDecodeBatchTimerDecodeFloat64Error(t *testing.T) {
+	enc := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
+	enc.encodeBatchTimerFn = func(bt unaggregated.BatchTimer) {
+		enc.encodeNumObjectFields(numFieldsForType(batchTimerType))
+		enc.encodeID(bt.ID)
+		enc.encodeArrayLen(len(bt.Values))
+		enc.encodeBytes([]byte("foo"))
+	}
+	require.NoError(t, enc.err())
+
+	it := testUnaggregatedIterator(t, enc.Encoder().Buffer()).(*unaggregatedIterator)
+	it.decodeBatchTimer()
+
+	require.Error(t, it.Err())
+}
+
+func TestUnaggregatedIteratorDecodeBatchTimerNoAlloc(t *testing.T) {
+	enc := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
+	bt := unaggregated.BatchTimer{
+		ID:     []byte("foo"),
+		Values: []float64{1.0, 2.0, 3.0, 4.0},
+	}
+	enc.encodeBatchTimer(bt)
+	require.NoError(t, enc.err())
+
+	// Allocate a large enough buffer to avoid triggering an allocation.
+	it := testUnaggregatedIterator(t, enc.Encoder().Buffer()).(*unaggregatedIterator)
+	it.timerValues = make([]float64, 1000)
+	it.decodeBatchTimer()
+
+	require.NoError(t, it.Err())
+	mu, _ := it.Value()
+	require.Equal(t, unaggregated.BatchTimerType, mu.Type)
+	require.Equal(t, metric.ID("foo"), mu.ID)
+	require.Equal(t, bt.Values, mu.BatchTimerVal)
+	require.Equal(t, cap(it.timerValues), cap(mu.BatchTimerVal))
+	require.False(t, mu.OwnsID)
+	require.Nil(t, mu.TimerValPool)
+}
+
+func TestUnaggregatedIteratorDecodeBatchTimerWithAllocNonPoolAlloc(t *testing.T) {
+	enc := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
+	bt := unaggregated.BatchTimer{
+		ID:     []byte("foo"),
+		Values: []float64{1.0, 2.0, 3.0, 4.0},
+	}
+	enc.encodeBatchTimer(bt)
+	require.NoError(t, enc.err())
+
+	// Allocate a large enough buffer to avoid triggering an allocation.
+	it := testUnaggregatedIterator(t, enc.Encoder().Buffer()).(*unaggregatedIterator)
+	it.decodeBatchTimer()
+
+	require.NoError(t, it.Err())
+	mu, _ := it.Value()
+	require.Equal(t, unaggregated.BatchTimerType, mu.Type)
+	require.Equal(t, metric.ID("foo"), mu.ID)
+	require.Equal(t, bt.Values, mu.BatchTimerVal)
+	require.Equal(t, cap(it.timerValues), cap(mu.BatchTimerVal))
+	require.False(t, mu.OwnsID)
+	require.Nil(t, mu.TimerValPool)
+}
+
+func TestUnaggregatedIteratorDecodeBatchTimerWithAllocPoolAlloc(t *testing.T) {
+	enc := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
+	bt := unaggregated.BatchTimer{
+		ID:     []byte("foo"),
+		Values: []float64{1.0, 2.0, 3.0, 4.0},
+	}
+	enc.encodeBatchTimer(bt)
+	require.NoError(t, enc.err())
+
+	// Allocate a large enough buffer to avoid triggering an allocation.
+	it := testUnaggregatedIterator(t, enc.Encoder().Buffer()).(*unaggregatedIterator)
+	it.largeFloatsSize = 2
+	it.decodeBatchTimer()
+
+	require.NoError(t, it.Err())
+	mu, _ := it.Value()
+	require.Equal(t, unaggregated.BatchTimerType, mu.Type)
+	require.Equal(t, metric.ID("foo"), mu.ID)
+	require.Equal(t, bt.Values, mu.BatchTimerVal)
+	require.True(t, cap(mu.BatchTimerVal) >= len(bt.Values))
+	require.Nil(t, it.timerValues)
+	require.False(t, mu.OwnsID)
+	require.NotNil(t, mu.TimerValPool)
+	require.Equal(t, it.largeFloatsPool, mu.TimerValPool)
 }
 
 func TestUnaggregatedIteratorDecodeNewerVersionThanSupported(t *testing.T) {
@@ -59,7 +265,7 @@ func TestUnaggregatedIteratorDecodeNewerVersionThanSupported(t *testing.T) {
 	}
 	enc := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
 
-	// Version encoded is higher than supported version
+	// Version encoded is higher than supported version.
 	enc.encodeRootObjectFn = func(objType objectType) {
 		enc.encodeVersion(unaggregatedVersion + 1)
 		enc.encodeNumObjectFields(numFieldsForType(rootObjectType))
@@ -67,11 +273,11 @@ func TestUnaggregatedIteratorDecodeNewerVersionThanSupported(t *testing.T) {
 	}
 	require.NoError(t, testUnaggregatedEncode(t, enc, input.metric, input.versionedPolicies))
 
-	// Now restore the encode top-level function and encode another counter
+	// Now restore the encode top-level function and encode another counter.
 	enc.encodeRootObjectFn = enc.encodeRootObject
 	require.NoError(t, testUnaggregatedEncode(t, enc, input.metric, input.versionedPolicies))
 
-	// Check that we skipped the first counter and successfully decoded the second counter
+	// Check that we skipped the first counter and successfully decoded the second counter.
 	it := testUnaggregatedIterator(t, bytes.NewBuffer(enc.Encoder().Bytes()))
 	it.(*unaggregatedIterator).ignoreHigherVersion = true
 	validateUnaggregatedDecodeResults(t, it, []metricWithPolicies{input}, io.EOF)
@@ -88,7 +294,7 @@ func TestUnaggregatedIteratorDecodeRootObjectMoreFieldsThanExpected(t *testing.T
 	}
 	enc := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
 
-	// Pretend we added an extra int field to the root object
+	// Pretend we added an extra int field to the root object.
 	enc.encodeRootObjectFn = func(objType objectType) {
 		enc.encodeVersion(unaggregatedVersion)
 		enc.encodeNumObjectFields(numFieldsForType(rootObjectType) + 1)
@@ -100,7 +306,7 @@ func TestUnaggregatedIteratorDecodeRootObjectMoreFieldsThanExpected(t *testing.T
 
 	it := testUnaggregatedIterator(t, enc.Encoder().Buffer())
 
-	// Check that we successfully decoded the counter
+	// Check that we successfully decoded the counter.
 	validateUnaggregatedDecodeResults(t, it, []metricWithPolicies{input}, io.EOF)
 }
 
@@ -111,19 +317,19 @@ func TestUnaggregatedIteratorDecodeCounterWithPoliciesMoreFieldsThanExpected(t *
 	}
 	enc := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
 
-	// Pretend we added an extra int field to the counter with policies object
+	// Pretend we added an extra int field to the counter with policies object.
 	enc.encodeCounterWithPoliciesFn = func(cp unaggregated.CounterWithPolicies) {
 		enc.encodeNumObjectFields(numFieldsForType(counterWithPoliciesType) + 1)
 		enc.encodeCounterFn(cp.Counter)
 		enc.encodeVersionedPoliciesFn(cp.VersionedPolicies)
+		enc.encodeVarint(0)
 	}
 	testUnaggregatedEncode(t, enc, input.metric, input.versionedPolicies)
-	enc.encodeVarint(0)
 	require.NoError(t, enc.err())
 
 	it := testUnaggregatedIterator(t, enc.Encoder().Buffer())
 
-	// Check that we successfully decoded the counter
+	// Check that we successfully decoded the counter.
 	validateUnaggregatedDecodeResults(t, it, []metricWithPolicies{input}, io.EOF)
 }
 
@@ -134,7 +340,7 @@ func TestUnaggregatedIteratorDecodeCounterMoreFieldsThanExpected(t *testing.T) {
 	}
 	enc := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
 
-	// Pretend we added an extra int field to the counter object
+	// Pretend we added an extra int field to the counter object.
 	enc.encodeCounterFn = func(c unaggregated.Counter) {
 		enc.encodeNumObjectFields(numFieldsForType(counterType) + 1)
 		enc.encodeID(c.ID)
@@ -145,7 +351,7 @@ func TestUnaggregatedIteratorDecodeCounterMoreFieldsThanExpected(t *testing.T) {
 
 	it := testUnaggregatedIterator(t, enc.Encoder().Buffer())
 
-	// Check that we successfully decoded the counter
+	// Check that we successfully decoded the counter.
 	validateUnaggregatedDecodeResults(t, it, []metricWithPolicies{input}, io.EOF)
 }
 
@@ -156,7 +362,7 @@ func TestUnaggregatedIteratorDecodeBatchTimerMoreFieldsThanExpected(t *testing.T
 	}
 	enc := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
 
-	// Pretend we added an extra int field to the batch timer object
+	// Pretend we added an extra int field to the batch timer object.
 	enc.encodeBatchTimerFn = func(bt unaggregated.BatchTimer) {
 		enc.encodeNumObjectFields(numFieldsForType(batchTimerType) + 1)
 		enc.encodeID(bt.ID)
@@ -170,7 +376,7 @@ func TestUnaggregatedIteratorDecodeBatchTimerMoreFieldsThanExpected(t *testing.T
 
 	it := testUnaggregatedIterator(t, enc.Encoder().Buffer())
 
-	// Check that we successfully decoded the batch timer
+	// Check that we successfully decoded the batch timer.
 	validateUnaggregatedDecodeResults(t, it, []metricWithPolicies{input}, io.EOF)
 }
 
@@ -181,7 +387,7 @@ func TestUnaggregatedIteratorDecodeGaugeMoreFieldsThanExpected(t *testing.T) {
 	}
 	enc := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
 
-	// Pretend we added an extra int field to the gauge object
+	// Pretend we added an extra int field to the gauge object.
 	enc.encodeGaugeFn = func(g unaggregated.Gauge) {
 		enc.encodeNumObjectFields(numFieldsForType(gaugeType) + 1)
 		enc.encodeID(g.ID)
@@ -192,7 +398,7 @@ func TestUnaggregatedIteratorDecodeGaugeMoreFieldsThanExpected(t *testing.T) {
 
 	it := testUnaggregatedIterator(t, enc.Encoder().Buffer())
 
-	// Check that we successfully decoded the gauge
+	// Check that we successfully decoded the gauge.
 	validateUnaggregatedDecodeResults(t, it, []metricWithPolicies{input}, io.EOF)
 }
 
@@ -212,7 +418,7 @@ func TestUnaggregatedIteratorDecodePolicyWithCustomResolution(t *testing.T) {
 
 	it := testUnaggregatedIterator(t, enc.Encoder().Buffer())
 
-	// Check that we successfully decoded the policy
+	// Check that we successfully decoded the policy.
 	validateUnaggregatedDecodeResults(t, it, []metricWithPolicies{input}, io.EOF)
 }
 
@@ -232,7 +438,7 @@ func TestUnaggregatedIteratorDecodePolicyWithCustomRetention(t *testing.T) {
 
 	it := testUnaggregatedIterator(t, enc.Encoder().Buffer())
 
-	// Check that we successfully decoded the policy
+	// Check that we successfully decoded the policy.
 	validateUnaggregatedDecodeResults(t, it, []metricWithPolicies{input}, io.EOF)
 }
 
@@ -250,7 +456,7 @@ func TestUnaggregatedIteratorDecodePolicyMoreFieldsThanExpected(t *testing.T) {
 	enc := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
 	baseEncoder := enc.encoderBase.(*baseEncoder)
 
-	// Pretend we added an extra int field to the policy object
+	// Pretend we added an extra int field to the policy object.
 	baseEncoder.encodePolicyFn = func(p policy.Policy) {
 		baseEncoder.encodeNumObjectFields(numFieldsForType(policyType) + 1)
 		baseEncoder.encodeResolution(p.Resolution())
@@ -261,7 +467,7 @@ func TestUnaggregatedIteratorDecodePolicyMoreFieldsThanExpected(t *testing.T) {
 
 	it := testUnaggregatedIterator(t, enc.Encoder().Buffer())
 
-	// Check that we successfully decoded the policy
+	// Check that we successfully decoded the policy.
 	validateUnaggregatedDecodeResults(t, it, []metricWithPolicies{input}, io.EOF)
 }
 
@@ -278,7 +484,7 @@ func TestUnaggregatedIteratorDecodeVersionedPoliciesMoreFieldsThanExpected(t *te
 	}
 	enc := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
 
-	// Pretend we added an extra int field to the policy object
+	// Pretend we added an extra int field to the policy object.
 	enc.encodeVersionedPoliciesFn = func(vp policy.VersionedPolicies) {
 		enc.encodeNumObjectFields(numFieldsForType(customVersionedPoliciesType) + 1)
 		enc.encodeObjectType(customVersionedPoliciesType)
@@ -295,7 +501,7 @@ func TestUnaggregatedIteratorDecodeVersionedPoliciesMoreFieldsThanExpected(t *te
 
 	it := testUnaggregatedIterator(t, enc.Encoder().Buffer())
 
-	// Check that we successfully decoded the policy
+	// Check that we successfully decoded the policy.
 	validateUnaggregatedDecodeResults(t, it, []metricWithPolicies{input}, io.EOF)
 }
 
@@ -306,7 +512,7 @@ func TestUnaggregatedIteratorDecodeCounterFewerFieldsThanExpected(t *testing.T) 
 	}
 	enc := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
 
-	// Pretend we added an extra int field to the counter object
+	// Pretend we added an extra int field to the counter object.
 	enc.encodeCounterFn = func(c unaggregated.Counter) {
 		enc.encodeNumObjectFields(numFieldsForType(counterType) - 1)
 		enc.encodeID(c.ID)
@@ -315,7 +521,7 @@ func TestUnaggregatedIteratorDecodeCounterFewerFieldsThanExpected(t *testing.T) 
 
 	it := testUnaggregatedIterator(t, enc.Encoder().Buffer())
 
-	// Check that we successfully decoded the counter
+	// Check that we encountered an error during decoding.
 	validateUnaggregatedDecodeResults(t, it, nil, errors.New("number of fields mismatch: expected 2 actual 1"))
 }
 
@@ -355,4 +561,23 @@ func TestUnaggregatedIteratorDecodeInvalidTimeUnit(t *testing.T) {
 	require.NoError(t, testUnaggregatedEncode(t, enc, input.metric, input.versionedPolicies))
 	it := testUnaggregatedIterator(t, enc.Encoder().Buffer())
 	validateUnaggregatedDecodeResults(t, it, nil, errors.New("invalid precision unknown"))
+}
+
+func validateUnaggregatedDecodeResults(
+	t *testing.T,
+	it UnaggregatedIterator,
+	expectedResults []metricWithPolicies,
+	expectedErr error,
+) {
+	var results []metricWithPolicies
+	for it.Next() {
+		value, policies := it.Value()
+		policies = toVersionedPolicies(t, policies)
+		results = append(results, metricWithPolicies{
+			metric:            value,
+			versionedPolicies: policies,
+		})
+	}
+	require.Equal(t, expectedErr, it.Err())
+	validateMetricsWithPolicies(t, expectedResults, results)
 }


### PR DESCRIPTION
cc @jeromefroe @cw9 @martin-mao 

This PR adds many improvements in terms of perf and memory / GC efficiency for the unaggregated iterator, given the observation that the decoded value is always processed before the next value is decoded. The notable improvements include:
* The unaggregated iterator used to always allocate a new byte slice for decoded metric ids. It now has an internal byte slice that caches the decoded metric id and does zero copy when reading off the wire. This reduces memory / GC overhead and improves performance.
* The unaggregated iterator used to always allocate a policy slice for decoded policies. It now has an internal policy slice that caches the decoded policies.
* The unaggregated iterator used to always allocate a float64 slice for decoded timer values. It now has an internal float64 slice to hold small to medium sized timer values and only allocate it from the pool if the timer values are large enough (the size threshold is configurable).

There will be a follow up PR that incorporates these changes into m3aggregator.