### PR TITLE
Provide APIs to match multiple policies within a time range and send multiple policies across network

### DIFF
--- a/metric/aggregated/types.go
+++ b/metric/aggregated/types.go
@@ -31,8 +31,8 @@ import (
 // Metric is a metric, which is essentially a named value at certain time.
 type Metric struct {
 	metric.ID
-	TimeNs int64
-	Value  float64
+	TimeNanos int64
+	Value     float64
 }
 
 // String is the string representation of a metric.
@@ -40,7 +40,7 @@ func (m Metric) String() string {
 	return fmt.Sprintf(
 		"{id:%s,timestamp:%s,value:%f}",
 		m.ID.String(),
-		time.Unix(0, m.TimeNs).String(),
+		time.Unix(0, m.TimeNanos).String(),
 		m.Value,
 	)
 }
@@ -48,8 +48,8 @@ func (m Metric) String() string {
 // ChunkedMetric is a metric with a chunked ID.
 type ChunkedMetric struct {
 	metric.ChunkedID
-	TimeNs int64
-	Value  float64
+	TimeNanos int64
+	Value     float64
 }
 
 // RawMetric is a metric in its raw form (e.g., encoded bytes associated with
@@ -58,8 +58,8 @@ type RawMetric interface {
 	// ID is the metric identifier.
 	ID() (metric.ID, error)
 
-	// TimeNs is the metric timestamp in nanoseconds.
-	TimeNs() (int64, error)
+	// TimeNanos is the metric timestamp in nanoseconds.
+	TimeNanos() (int64, error)
 
 	// Value is the metric value.
 	Value() (float64, error)

--- a/metric/aggregated/types.go
+++ b/metric/aggregated/types.go
@@ -31,8 +31,8 @@ import (
 // Metric is a metric, which is essentially a named value at certain time.
 type Metric struct {
 	metric.ID
-	Timestamp time.Time
-	Value     float64
+	TimeNs int64
+	Value  float64
 }
 
 // String is the string representation of a metric.
@@ -40,7 +40,7 @@ func (m Metric) String() string {
 	return fmt.Sprintf(
 		"{id:%s,timestamp:%s,value:%f}",
 		m.ID.String(),
-		m.Timestamp.String(),
+		time.Unix(0, m.TimeNs).String(),
 		m.Value,
 	)
 }
@@ -48,8 +48,8 @@ func (m Metric) String() string {
 // ChunkedMetric is a metric with a chunked ID.
 type ChunkedMetric struct {
 	metric.ChunkedID
-	Timestamp time.Time
-	Value     float64
+	TimeNs int64
+	Value  float64
 }
 
 // RawMetric is a metric in its raw form (e.g., encoded bytes associated with
@@ -58,8 +58,8 @@ type RawMetric interface {
 	// ID is the metric identifier.
 	ID() (metric.ID, error)
 
-	// Timestamp is the metric timestamp.
-	Timestamp() (time.Time, error)
+	// TimeNs is the metric timestamp in nanoseconds.
+	TimeNs() (int64, error)
 
 	// Value is the metric value.
 	Value() (float64, error)

--- a/metric/unaggregated/types.go
+++ b/metric/unaggregated/types.go
@@ -70,22 +70,22 @@ type Gauge struct {
 	Value float64
 }
 
-// CounterWithPolicies is a counter with applicable policies.
-type CounterWithPolicies struct {
+// CounterWithPoliciesList is a counter with applicable policies list.
+type CounterWithPoliciesList struct {
 	Counter
-	policy.VersionedPolicies
+	policy.PoliciesList
 }
 
-// BatchTimerWithPolicies is a batch timer with applicable policies.
-type BatchTimerWithPolicies struct {
+// BatchTimerWithPoliciesList is a batch timer with applicable policies list.
+type BatchTimerWithPoliciesList struct {
 	BatchTimer
-	policy.VersionedPolicies
+	policy.PoliciesList
 }
 
-// GaugeWithPolicies is a gauge with applicable policies.
-type GaugeWithPolicies struct {
+// GaugeWithPoliciesList is a gauge with applicable policies list.
+type GaugeWithPoliciesList struct {
 	Gauge
-	policy.VersionedPolicies
+	policy.PoliciesList
 }
 
 // MetricUnion is a union of different types of metrics, only one of which is valid

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -42,12 +42,6 @@ var (
 	// EmptyPolicy represents an empty policy.
 	EmptyPolicy Policy
 
-	// DefaultPolicies are the default policies.
-	DefaultPolicies = []Policy{
-		NewPolicy(10*time.Second, xtime.Second, 2*24*time.Hour),
-		NewPolicy(time.Minute, xtime.Minute, 30*24*time.Hour),
-	}
-
 	// DefaultStagedPolicies represents a default staged policies.
 	DefaultStagedPolicies StagedPolicies
 

--- a/policy/policy_benchmark_test.go
+++ b/policy/policy_benchmark_test.go
@@ -26,76 +26,76 @@ import (
 )
 
 var (
-	testNowNs = time.Now().UnixNano()
+	testNowNanos = time.Now().UnixNano()
 )
 
 func BenchmarkStagedPoliciesAsStruct(b *testing.B) {
-	sp := NewStagedPolicies(testNowNs, false, defaultPolicies)
+	sp := NewStagedPolicies(testNowNanos, false, DefaultPolicies)
 	for n := 0; n < b.N; n++ {
 		validatePolicyByValue(b, sp)
 	}
 }
 
 func BenchmarkStagedPoliciesAsPointer(b *testing.B) {
-	sp := NewStagedPolicies(testNowNs, false, defaultPolicies)
+	sp := NewStagedPolicies(testNowNanos, false, DefaultPolicies)
 	for n := 0; n < b.N; n++ {
 		validatePolicyByPointer(b, &sp)
 	}
 }
 
 func BenchmarkStagedPoliciesAsInterface(b *testing.B) {
-	sp := &testStagedPolicies{cutoverNs: testNowNs, policies: defaultPolicies}
+	sp := &testStagedPolicies{cutoverNanos: testNowNanos, policies: DefaultPolicies}
 	for n := 0; n < b.N; n++ {
 		validatePolicyByInterface(b, sp)
 	}
 }
 
 func BenchmarkStagedPoliciesAsStructExported(b *testing.B) {
-	sp := testStagedPolicies{cutoverNs: testNowNs, policies: defaultPolicies}
+	sp := testStagedPolicies{cutoverNanos: testNowNanos, policies: DefaultPolicies}
 	for n := 0; n < b.N; n++ {
 		validatePolicyByStructExported(b, sp)
 	}
 }
 
 type testStagedPoliciesInt64 interface {
-	CutoverNs() int64
+	CutoverNanos() int64
 }
 
 // StagedPolicies represent a list of policies at a specified version.
 type testStagedPolicies struct {
-	cutoverNs  int64
-	tombstoned bool
-	policies   []Policy
+	cutoverNanos int64
+	tombstoned   bool
+	policies     []Policy
 }
 
-func (v testStagedPolicies) ValCutoverNs() int64 {
-	return v.cutoverNs
+func (v testStagedPolicies) ValCutoverNanos() int64 {
+	return v.cutoverNanos
 }
 
-func (v *testStagedPolicies) CutoverNs() int64 {
-	return v.cutoverNs
+func (v *testStagedPolicies) CutoverNanos() int64 {
+	return v.cutoverNanos
 }
 
 func validatePolicyByValue(b *testing.B, sp StagedPolicies) {
-	if sp.CutoverNs != testNowNs {
+	if sp.CutoverNanos != testNowNanos {
 		b.FailNow()
 	}
 }
 
 func validatePolicyByPointer(b *testing.B, sp *StagedPolicies) {
-	if sp.CutoverNs != testNowNs {
+	if sp.CutoverNanos != testNowNanos {
 		b.FailNow()
 	}
 }
 
 func validatePolicyByInterface(b *testing.B, sp testStagedPoliciesInt64) {
-	if sp.CutoverNs() != testNowNs {
+	if sp.CutoverNanos() != testNowNanos {
 		b.FailNow()
 	}
 }
 
 func validatePolicyByStructExported(b *testing.B, sp testStagedPolicies) {
-	if sp.ValCutoverNs() != testNowNs {
+	if sp.ValCutoverNanos() != testNowNanos {
 		b.FailNow()
 	}
 }

--- a/policy/policy_benchmark_test.go
+++ b/policy/policy_benchmark_test.go
@@ -23,35 +23,41 @@ package policy
 import (
 	"testing"
 	"time"
+
+	"github.com/m3db/m3x/time"
 )
 
 var (
 	testNowNanos = time.Now().UnixNano()
+	testPolicies = []Policy{
+		NewPolicy(10*time.Second, xtime.Second, 2*24*time.Hour),
+		NewPolicy(time.Minute, xtime.Minute, 30*24*time.Hour),
+	}
 )
 
 func BenchmarkStagedPoliciesAsStruct(b *testing.B) {
-	sp := NewStagedPolicies(testNowNanos, false, DefaultPolicies)
+	sp := NewStagedPolicies(testNowNanos, false, testPolicies)
 	for n := 0; n < b.N; n++ {
 		validatePolicyByValue(b, sp)
 	}
 }
 
 func BenchmarkStagedPoliciesAsPointer(b *testing.B) {
-	sp := NewStagedPolicies(testNowNanos, false, DefaultPolicies)
+	sp := NewStagedPolicies(testNowNanos, false, testPolicies)
 	for n := 0; n < b.N; n++ {
 		validatePolicyByPointer(b, &sp)
 	}
 }
 
 func BenchmarkStagedPoliciesAsInterface(b *testing.B) {
-	sp := &testStagedPolicies{cutoverNanos: testNowNanos, policies: DefaultPolicies}
+	sp := &testStagedPolicies{cutoverNanos: testNowNanos, policies: testPolicies}
 	for n := 0; n < b.N; n++ {
 		validatePolicyByInterface(b, sp)
 	}
 }
 
 func BenchmarkStagedPoliciesAsStructExported(b *testing.B) {
-	sp := testStagedPolicies{cutoverNanos: testNowNanos, policies: DefaultPolicies}
+	sp := testStagedPolicies{cutoverNanos: testNowNanos, policies: testPolicies}
 	for n := 0; n < b.N; n++ {
 		validatePolicyByStructExported(b, sp)
 	}

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -45,30 +45,20 @@ func TestPoliciesByResolutionAsc(t *testing.T) {
 	require.Equal(t, expected, inputs)
 }
 
-func TestDefaultVersionedPolicies(t *testing.T) {
-	var (
-		version = 2
-		cutover = time.Now()
-	)
-	vp := DefaultVersionedPolicies(version, cutover)
-	require.Equal(t, version, vp.Version)
-	require.Equal(t, cutover, vp.Cutover)
-	require.True(t, vp.IsDefault())
-	require.Equal(t, defaultPolicies, vp.Policies())
+func TestStagedPoliciesHasDefaultPolicies(t *testing.T) {
+	sp := NewStagedPolicies(testNowNs, true, nil)
+	require.Equal(t, testNowNs, sp.CutoverNs)
+	require.True(t, sp.hasDefaultPolicies())
+	require.Equal(t, defaultPolicies, sp.Policies())
 }
 
-func TestCustomVersionedPolicies(t *testing.T) {
-	var (
-		version  = 2
-		cutover  = time.Now()
-		policies = []Policy{
-			NewPolicy(10*time.Second, xtime.Second, 6*time.Hour),
-			NewPolicy(10*time.Second, xtime.Second, 2*time.Hour),
-		}
-	)
-	vp := CustomVersionedPolicies(version, cutover, policies)
-	require.Equal(t, version, vp.Version)
-	require.Equal(t, cutover, vp.Cutover)
-	require.False(t, vp.IsDefault())
-	require.Equal(t, policies, vp.Policies())
+func TestStagedPoliciesHasCustomPolicies(t *testing.T) {
+	policies := []Policy{
+		NewPolicy(10*time.Second, xtime.Second, 6*time.Hour),
+		NewPolicy(10*time.Second, xtime.Second, 2*time.Hour),
+	}
+	sp := NewStagedPolicies(testNowNs, false, policies)
+	require.Equal(t, testNowNs, sp.CutoverNs)
+	require.False(t, sp.hasDefaultPolicies())
+	require.Equal(t, policies, sp.Policies())
 }

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -46,10 +46,10 @@ func TestPoliciesByResolutionAsc(t *testing.T) {
 }
 
 func TestStagedPoliciesHasDefaultPolicies(t *testing.T) {
-	sp := NewStagedPolicies(testNowNs, true, nil)
-	require.Equal(t, testNowNs, sp.CutoverNs)
-	require.True(t, sp.hasDefaultPolicies())
-	require.Equal(t, defaultPolicies, sp.Policies())
+	sp := NewStagedPolicies(testNowNanos, true, nil)
+	require.Equal(t, testNowNanos, sp.CutoverNanos)
+	_, isDefault := sp.Policies()
+	require.True(t, isDefault)
 }
 
 func TestStagedPoliciesHasCustomPolicies(t *testing.T) {
@@ -57,10 +57,11 @@ func TestStagedPoliciesHasCustomPolicies(t *testing.T) {
 		NewPolicy(10*time.Second, xtime.Second, 6*time.Hour),
 		NewPolicy(10*time.Second, xtime.Second, 2*time.Hour),
 	}
-	sp := NewStagedPolicies(testNowNs, false, policies)
-	require.Equal(t, testNowNs, sp.CutoverNs)
-	require.False(t, sp.hasDefaultPolicies())
-	require.Equal(t, policies, sp.Policies())
+	sp := NewStagedPolicies(testNowNanos, false, policies)
+	require.Equal(t, testNowNanos, sp.CutoverNanos)
+	actual, isDefault := sp.Policies()
+	require.False(t, isDefault)
+	require.Equal(t, policies, actual)
 }
 
 func TestStagedPoliciesSamePoliciesDefaultPolicies(t *testing.T) {
@@ -162,7 +163,7 @@ func TestStagedPoliciesIsEmpty(t *testing.T) {
 		},
 	}
 	for _, input := range inputs {
-		require.Equal(t, input.expected, input.sp.isEmpty())
+		require.Equal(t, input.expected, input.sp.IsDefault())
 	}
 }
 
@@ -187,7 +188,7 @@ func TestPoliciesListIsDefault(t *testing.T) {
 			expected: false,
 		},
 		{
-			pl:       []StagedPolicies{EmptyStagedPolicies, EmptyStagedPolicies},
+			pl:       []StagedPolicies{DefaultStagedPolicies, DefaultStagedPolicies},
 			expected: false,
 		},
 	}

--- a/protocol/msgpack/aggregated_encoder.go
+++ b/protocol/msgpack/aggregated_encoder.go
@@ -103,7 +103,7 @@ func (enc *aggregatedEncoder) encodeMetricAsRaw(m aggregated.Metric) []byte {
 	enc.buf.resetData()
 	enc.encodeMetricProlog()
 	enc.buf.encodeID(m.ID)
-	enc.buf.encodeVarint(m.TimeNs)
+	enc.buf.encodeVarint(m.TimeNanos)
 	enc.buf.encodeFloat64(m.Value)
 	return enc.buf.encoder().Bytes()
 }
@@ -112,7 +112,7 @@ func (enc *aggregatedEncoder) encodeChunkedMetricAsRaw(m aggregated.ChunkedMetri
 	enc.buf.resetData()
 	enc.encodeMetricProlog()
 	enc.buf.encodeChunkedID(m.ChunkedID)
-	enc.buf.encodeVarint(m.TimeNs)
+	enc.buf.encodeVarint(m.TimeNanos)
 	enc.buf.encodeFloat64(m.Value)
 	return enc.buf.encoder().Bytes()
 }

--- a/protocol/msgpack/aggregated_encoder.go
+++ b/protocol/msgpack/aggregated_encoder.go
@@ -103,7 +103,7 @@ func (enc *aggregatedEncoder) encodeMetricAsRaw(m aggregated.Metric) []byte {
 	enc.buf.resetData()
 	enc.encodeMetricProlog()
 	enc.buf.encodeID(m.ID)
-	enc.buf.encodeTime(m.Timestamp)
+	enc.buf.encodeVarint(m.TimeNs)
 	enc.buf.encodeFloat64(m.Value)
 	return enc.buf.encoder().Bytes()
 }
@@ -112,7 +112,7 @@ func (enc *aggregatedEncoder) encodeChunkedMetricAsRaw(m aggregated.ChunkedMetri
 	enc.buf.resetData()
 	enc.encodeMetricProlog()
 	enc.buf.encodeChunkedID(m.ChunkedID)
-	enc.buf.encodeTime(m.Timestamp)
+	enc.buf.encodeVarint(m.TimeNs)
 	enc.buf.encodeFloat64(m.Value)
 	return enc.buf.encoder().Bytes()
 }

--- a/protocol/msgpack/aggregated_encoder_test.go
+++ b/protocol/msgpack/aggregated_encoder_test.go
@@ -73,7 +73,7 @@ func TestAggregatedEncodeMetric(t *testing.T) {
 		int64(metricVersion),
 		int(numFieldsForType(metricType)),
 		[]byte(testMetric.ID),
-		testMetric.TimeNs,
+		testMetric.TimeNanos,
 		testMetric.Value,
 	}
 	require.Equal(t, expected, *result)

--- a/protocol/msgpack/aggregated_encoder_test.go
+++ b/protocol/msgpack/aggregated_encoder_test.go
@@ -73,7 +73,7 @@ func TestAggregatedEncodeMetric(t *testing.T) {
 		int64(metricVersion),
 		int(numFieldsForType(metricType)),
 		[]byte(testMetric.ID),
-		testMetric.Timestamp,
+		testMetric.TimeNs,
 		testMetric.Value,
 	}
 	require.Equal(t, expected, *result)

--- a/protocol/msgpack/aggregated_roundtrip_test.go
+++ b/protocol/msgpack/aggregated_roundtrip_test.go
@@ -37,9 +37,9 @@ import (
 
 var (
 	testMetric = aggregated.Metric{
-		ID:        metric.ID("foo"),
-		Timestamp: time.Now(),
-		Value:     123.45,
+		ID:     metric.ID("foo"),
+		TimeNs: time.Now().UnixNano(),
+		Value:  123.45,
 	}
 	testChunkedMetric = aggregated.ChunkedMetric{
 		ChunkedID: metric.ChunkedID{
@@ -47,13 +47,13 @@ var (
 			Data:   []byte("bar"),
 			Suffix: []byte(".baz"),
 		},
-		Timestamp: time.Now(),
-		Value:     123.45,
+		TimeNs: time.Now().UnixNano(),
+		Value:  123.45,
 	}
 	testMetric2 = aggregated.Metric{
-		ID:        metric.ID("bar"),
-		Timestamp: time.Now(),
-		Value:     678.90,
+		ID:     metric.ID("bar"),
+		TimeNs: time.Now().UnixNano(),
+		Value:  678.90,
 	}
 	testPolicy = policy.NewPolicy(time.Second, xtime.Second, time.Hour)
 )
@@ -142,9 +142,9 @@ func validateAggregatedRoundtripWithEncoderAndIterator(
 			id = append(id, inputMetric.ChunkedID.Suffix...)
 			expected = append(expected, metricWithPolicy{
 				metric: aggregated.Metric{
-					ID:        id,
-					Timestamp: inputMetric.Timestamp,
-					Value:     inputMetric.Value,
+					ID:     id,
+					TimeNs: inputMetric.TimeNs,
+					Value:  inputMetric.Value,
 				},
 				policy: input.policy,
 			})

--- a/protocol/msgpack/aggregated_roundtrip_test.go
+++ b/protocol/msgpack/aggregated_roundtrip_test.go
@@ -37,9 +37,9 @@ import (
 
 var (
 	testMetric = aggregated.Metric{
-		ID:     metric.ID("foo"),
-		TimeNs: time.Now().UnixNano(),
-		Value:  123.45,
+		ID:        metric.ID("foo"),
+		TimeNanos: time.Now().UnixNano(),
+		Value:     123.45,
 	}
 	testChunkedMetric = aggregated.ChunkedMetric{
 		ChunkedID: metric.ChunkedID{
@@ -47,13 +47,13 @@ var (
 			Data:   []byte("bar"),
 			Suffix: []byte(".baz"),
 		},
-		TimeNs: time.Now().UnixNano(),
-		Value:  123.45,
+		TimeNanos: time.Now().UnixNano(),
+		Value:     123.45,
 	}
 	testMetric2 = aggregated.Metric{
-		ID:     metric.ID("bar"),
-		TimeNs: time.Now().UnixNano(),
-		Value:  678.90,
+		ID:        metric.ID("bar"),
+		TimeNanos: time.Now().UnixNano(),
+		Value:     678.90,
 	}
 	testPolicy = policy.NewPolicy(time.Second, xtime.Second, time.Hour)
 )
@@ -142,9 +142,9 @@ func validateAggregatedRoundtripWithEncoderAndIterator(
 			id = append(id, inputMetric.ChunkedID.Suffix...)
 			expected = append(expected, metricWithPolicy{
 				metric: aggregated.Metric{
-					ID:     id,
-					TimeNs: inputMetric.TimeNs,
-					Value:  inputMetric.Value,
+					ID:        id,
+					TimeNanos: inputMetric.TimeNanos,
+					Value:     inputMetric.Value,
 				},
 				policy: input.policy,
 			})

--- a/protocol/msgpack/base_iterator.go
+++ b/protocol/msgpack/base_iterator.go
@@ -85,7 +85,7 @@ func (it *baseIterator) decodePolicy() policy.Policy {
 func (it *baseIterator) decodeResolution() policy.Resolution {
 	numActualFields := it.decodeNumObjectFields()
 	resolutionType := it.decodeObjectType()
-	numExpectedFields, ok := it.checkNumFieldsForTypeWithActual(
+	numExpectedFields, ok := it.checkExpectedNumFieldsForType(
 		resolutionType,
 		numActualFields,
 	)
@@ -127,7 +127,7 @@ func (it *baseIterator) decodeResolution() policy.Resolution {
 func (it *baseIterator) decodeRetention() policy.Retention {
 	numActualFields := it.decodeNumObjectFields()
 	retentionType := it.decodeObjectType()
-	numExpectedFields, ok := it.checkNumFieldsForTypeWithActual(
+	numExpectedFields, ok := it.checkExpectedNumFieldsForType(
 		retentionType,
 		numActualFields,
 	)
@@ -251,11 +251,11 @@ func (it *baseIterator) skip(numFields int) {
 
 func (it *baseIterator) checkNumFieldsForType(objType objectType) (int, int, bool) {
 	numActualFields := it.decodeNumObjectFields()
-	numExpectedFields, ok := it.checkNumFieldsForTypeWithActual(objType, numActualFields)
+	numExpectedFields, ok := it.checkExpectedNumFieldsForType(objType, numActualFields)
 	return numExpectedFields, numActualFields, ok
 }
 
-func (it *baseIterator) checkNumFieldsForTypeWithActual(
+func (it *baseIterator) checkExpectedNumFieldsForType(
 	objType objectType,
 	numActualFields int,
 ) (int, bool) {

--- a/protocol/msgpack/base_iterator.go
+++ b/protocol/msgpack/base_iterator.go
@@ -85,7 +85,7 @@ func (it *baseIterator) decodePolicy() policy.Policy {
 func (it *baseIterator) decodeResolution() policy.Resolution {
 	numActualFields := it.decodeNumObjectFields()
 	resolutionType := it.decodeObjectType()
-	numExpectedFields, numActualFields, ok := it.checkNumFieldsForTypeWithActual(
+	numExpectedFields, ok := it.checkNumFieldsForTypeWithActual(
 		resolutionType,
 		numActualFields,
 	)
@@ -127,7 +127,7 @@ func (it *baseIterator) decodeResolution() policy.Resolution {
 func (it *baseIterator) decodeRetention() policy.Retention {
 	numActualFields := it.decodeNumObjectFields()
 	retentionType := it.decodeObjectType()
-	numExpectedFields, numActualFields, ok := it.checkNumFieldsForTypeWithActual(
+	numExpectedFields, ok := it.checkNumFieldsForTypeWithActual(
 		retentionType,
 		numActualFields,
 	)
@@ -174,15 +174,6 @@ func (it *baseIterator) decodeID() metric.ID {
 	return metric.ID(it.decodeBytes())
 }
 
-func (it *baseIterator) decodeTime() time.Time {
-	if it.decodeErr != nil {
-		return time.Time{}
-	}
-	value, err := it.decoder.DecodeTime()
-	it.decodeErr = err
-	return value
-}
-
 // NB(xichen): the underlying msgpack decoder implementation
 // always decodes an int64 and looks at the actual decoded
 // value to determine the width of the integer (a.k.a. varint
@@ -192,6 +183,15 @@ func (it *baseIterator) decodeVarint() int64 {
 		return 0
 	}
 	value, err := it.decoder.DecodeInt64()
+	it.decodeErr = err
+	return value
+}
+
+func (it *baseIterator) decodeBool() bool {
+	if it.decodeErr != nil {
+		return false
+	}
+	value, err := it.decoder.DecodeBool()
 	it.decodeErr = err
 	return value
 }
@@ -251,22 +251,23 @@ func (it *baseIterator) skip(numFields int) {
 
 func (it *baseIterator) checkNumFieldsForType(objType objectType) (int, int, bool) {
 	numActualFields := it.decodeNumObjectFields()
-	return it.checkNumFieldsForTypeWithActual(objType, numActualFields)
+	numExpectedFields, ok := it.checkNumFieldsForTypeWithActual(objType, numActualFields)
+	return numExpectedFields, numActualFields, ok
 }
 
 func (it *baseIterator) checkNumFieldsForTypeWithActual(
 	objType objectType,
 	numActualFields int,
-) (int, int, bool) {
+) (int, bool) {
 	if it.decodeErr != nil {
-		return 0, 0, false
+		return 0, false
 	}
 	numExpectedFields := numFieldsForType(objType)
 	if numExpectedFields > numActualFields {
 		it.decodeErr = fmt.Errorf("number of fields mismatch: expected %d actual %d", numExpectedFields, numActualFields)
-		return 0, 0, false
+		return 0, false
 	}
-	return numExpectedFields, numActualFields, true
+	return numExpectedFields, true
 }
 
 // bufReader is a buffered reader.

--- a/protocol/msgpack/raw_metric.go
+++ b/protocol/msgpack/raw_metric.go
@@ -65,13 +65,13 @@ func (m *rawMetric) ID() (metric.ID, error) {
 	return m.metric.ID, nil
 }
 
-func (m *rawMetric) TimeNs() (int64, error) {
+func (m *rawMetric) TimeNanos() (int64, error) {
 	m.decodeID()
 	m.decodeTime()
 	if err := m.it.err(); err != nil {
 		return 0, err
 	}
-	return m.metric.TimeNs, nil
+	return m.metric.TimeNanos, nil
 }
 
 func (m *rawMetric) Value() (float64, error) {
@@ -151,11 +151,11 @@ func (m *rawMetric) decodeTime() {
 	if m.it.err() != nil || m.timeDecoded {
 		return
 	}
-	timeNs := m.it.decodeVarint()
+	timeNanos := m.it.decodeVarint()
 	if m.it.err() != nil {
 		return
 	}
-	m.metric.TimeNs = timeNs
+	m.metric.TimeNanos = timeNanos
 	m.timeDecoded = true
 }
 

--- a/protocol/msgpack/raw_metric.go
+++ b/protocol/msgpack/raw_metric.go
@@ -24,7 +24,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"time"
 
 	"github.com/m3db/m3metrics/metric"
 	"github.com/m3db/m3metrics/metric/aggregated"
@@ -38,13 +37,13 @@ type readBytesFn func(start int, n int) []byte
 
 // rawMetric is a raw metric.
 type rawMetric struct {
-	data             []byte            // raw data containing encoded metric.
-	it               iteratorBase      // base iterator for lazily decoding metric fields.
-	metric           aggregated.Metric // current metric.
-	idDecoded        bool              // whether id has been decoded.
-	timestampDecoded bool              // whether timestamp has been decoded.
-	valueDecoded     bool              // whether value has been decoded.
-	readBytesFn      readBytesFn       // reading bytes function.
+	data         []byte            // raw data containing encoded metric.
+	it           iteratorBase      // base iterator for lazily decoding metric fields.
+	metric       aggregated.Metric // current metric.
+	idDecoded    bool              // whether id has been decoded.
+	timeDecoded  bool              // whether time has been decoded.
+	valueDecoded bool              // whether value has been decoded.
+	readBytesFn  readBytesFn       // reading bytes function.
 }
 
 // NewRawMetric creates a new raw metric.
@@ -66,18 +65,18 @@ func (m *rawMetric) ID() (metric.ID, error) {
 	return m.metric.ID, nil
 }
 
-func (m *rawMetric) Timestamp() (time.Time, error) {
+func (m *rawMetric) TimeNs() (int64, error) {
 	m.decodeID()
-	m.decodeTimestamp()
+	m.decodeTime()
 	if err := m.it.err(); err != nil {
-		return time.Time{}, err
+		return 0, err
 	}
-	return m.metric.Timestamp, nil
+	return m.metric.TimeNs, nil
 }
 
 func (m *rawMetric) Value() (float64, error) {
 	m.decodeID()
-	m.decodeTimestamp()
+	m.decodeTime()
 	m.decodeValue()
 	if err := m.it.err(); err != nil {
 		return 0.0, err
@@ -87,7 +86,7 @@ func (m *rawMetric) Value() (float64, error) {
 
 func (m *rawMetric) Metric() (aggregated.Metric, error) {
 	m.decodeID()
-	m.decodeTimestamp()
+	m.decodeTime()
 	m.decodeValue()
 	if err := m.it.err(); err != nil {
 		return emptyMetric, err
@@ -102,7 +101,7 @@ func (m *rawMetric) Bytes() []byte {
 func (m *rawMetric) Reset(data []byte) {
 	m.metric = emptyMetric
 	m.idDecoded = false
-	m.timestampDecoded = false
+	m.timeDecoded = false
 	m.valueDecoded = false
 	m.data = data
 	m.reader().Reset(data)
@@ -148,16 +147,16 @@ func (m *rawMetric) decodeID() {
 	m.idDecoded = true
 }
 
-func (m *rawMetric) decodeTimestamp() {
-	if m.it.err() != nil || m.timestampDecoded {
+func (m *rawMetric) decodeTime() {
+	if m.it.err() != nil || m.timeDecoded {
 		return
 	}
-	t := m.it.decodeTime()
+	timeNs := m.it.decodeVarint()
 	if m.it.err() != nil {
 		return
 	}
-	m.metric.Timestamp = t
-	m.timestampDecoded = true
+	m.metric.TimeNs = timeNs
+	m.timeDecoded = true
 }
 
 func (m *rawMetric) decodeValue() {

--- a/protocol/msgpack/raw_metric_test.go
+++ b/protocol/msgpack/raw_metric_test.go
@@ -25,7 +25,6 @@ import (
 	"errors"
 	"io"
 	"testing"
-	"time"
 
 	"github.com/m3db/m3metrics/metric"
 	"github.com/m3db/m3metrics/metric/aggregated"
@@ -95,30 +94,30 @@ func TestRawMetricDecodeIDSuccess(t *testing.T) {
 func TestRawMetricDecodeTimestampExistingError(t *testing.T) {
 	m := testRawMetric()
 	m.it.setErr(errTestDecodeRawMetric)
-	_, err := m.Timestamp()
+	_, err := m.TimeNs()
 	require.Equal(t, errTestDecodeRawMetric, err)
 }
 
 func TestRawMetricDecodeTimestampDecodeError(t *testing.T) {
 	m := testRawMetric()
-	m.it.(*mockBaseIterator).decodeTimeFn = func() time.Time {
+	m.it.(*mockBaseIterator).decodeVarintFn = func() int64 {
 		m.it.setErr(errTestDecodeRawMetric)
-		return time.Time{}
+		return 0
 	}
-	_, err := m.Timestamp()
+	_, err := m.TimeNs()
 	require.Equal(t, errTestDecodeRawMetric, err)
 }
 
 func TestRawMetricDecodeTimestampSuccess(t *testing.T) {
 	m := testRawMetric()
-	timestamp, err := m.Timestamp()
+	timeNs, err := m.TimeNs()
 	require.NoError(t, err)
-	require.Equal(t, testMetric.Timestamp, timestamp)
-	require.True(t, m.timestampDecoded)
+	require.Equal(t, testMetric.TimeNs, timeNs)
+	require.True(t, m.timeDecoded)
 
 	// Get timestamp again to make sure we don't re-decode the timestamp.
 	require.NoError(t, err)
-	require.Equal(t, testMetric.Timestamp, timestamp)
+	require.Equal(t, testMetric.TimeNs, timeNs)
 }
 
 func TestRawMetricDecodeValueExistingError(t *testing.T) {
@@ -163,7 +162,7 @@ func TestRawMetricDecodeMetricSuccess(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, testMetric, metric)
 	require.True(t, m.idDecoded)
-	require.True(t, m.timestampDecoded)
+	require.True(t, m.timeDecoded)
 	require.True(t, m.valueDecoded)
 
 	// Get metric again to make sure we don't re-decode the metric.
@@ -187,9 +186,9 @@ func TestRawMetricNilID(t *testing.T) {
 
 func TestRawMetricReset(t *testing.T) {
 	metrics := []aggregated.Metric{
-		{ID: metric.ID("foo"), Timestamp: testMetric.Timestamp, Value: 1.0},
-		{ID: metric.ID("bar"), Timestamp: testMetric.Timestamp, Value: 2.3},
-		{ID: metric.ID("baz"), Timestamp: testMetric.Timestamp, Value: 4234.234},
+		{ID: metric.ID("foo"), TimeNs: testMetric.TimeNs, Value: 1.0},
+		{ID: metric.ID("bar"), TimeNs: testMetric.TimeNs, Value: 2.3},
+		{ID: metric.ID("baz"), TimeNs: testMetric.TimeNs, Value: 4234.234},
 	}
 	rawMetric := NewRawMetric(nil, 16)
 	for i := 0; i < len(metrics); i++ {
@@ -202,9 +201,9 @@ func TestRawMetricReset(t *testing.T) {
 
 func TestRawMetricRoundtripStress(t *testing.T) {
 	metrics := []aggregated.Metric{
-		{ID: metric.ID("foo"), Timestamp: testMetric.Timestamp, Value: 1.0},
-		{ID: metric.ID("bar"), Timestamp: testMetric.Timestamp, Value: 2.3},
-		{ID: metric.ID("baz"), Timestamp: testMetric.Timestamp, Value: 4234.234},
+		{ID: metric.ID("foo"), TimeNs: testMetric.TimeNs, Value: 1.0},
+		{ID: metric.ID("bar"), TimeNs: testMetric.TimeNs, Value: 2.3},
+		{ID: metric.ID("baz"), TimeNs: testMetric.TimeNs, Value: 4234.234},
 	}
 	var (
 		inputs  []aggregated.Metric
@@ -224,7 +223,7 @@ func TestRawMetricRoundtripStress(t *testing.T) {
 
 type decodeVersionFn func() int
 type decodeBytesLenFn func() int
-type decodeTimeFn func() time.Time
+type decodeVarintFn func() int64
 type decodeFloat64Fn func() float64
 
 type mockBaseIterator struct {
@@ -232,7 +231,7 @@ type mockBaseIterator struct {
 	itErr            error
 	decodeVersionFn  decodeVersionFn
 	decodeBytesLenFn decodeBytesLenFn
-	decodeTimeFn     decodeTimeFn
+	decodeVarintFn   decodeVarintFn
 	decodeFloat64Fn  decodeFloat64Fn
 }
 
@@ -245,8 +244,8 @@ func (it *mockBaseIterator) decodeVersion() int           { return it.decodeVers
 func (it *mockBaseIterator) decodeObjectType() objectType { return unknownType }
 func (it *mockBaseIterator) decodeNumObjectFields() int   { return 0 }
 func (it *mockBaseIterator) decodeID() metric.ID          { return nil }
-func (it *mockBaseIterator) decodeTime() time.Time        { return it.decodeTimeFn() }
-func (it *mockBaseIterator) decodeVarint() int64          { return 0 }
+func (it *mockBaseIterator) decodeVarint() int64          { return it.decodeVarintFn() }
+func (it *mockBaseIterator) decodeBool() bool             { return false }
 func (it *mockBaseIterator) decodeFloat64() float64       { return it.decodeFloat64Fn() }
 func (it *mockBaseIterator) decodeBytes() []byte          { return nil }
 func (it *mockBaseIterator) decodeBytesLen() int          { return it.decodeBytesLenFn() }
@@ -260,15 +259,15 @@ func (it *mockBaseIterator) checkNumFieldsForType(objType objectType) (int, int,
 func (it *mockBaseIterator) checkNumFieldsForTypeWithActual(
 	objType objectType,
 	numActualFields int,
-) (int, int, bool) {
-	return 0, 0, true
+) (int, bool) {
+	return 0, true
 }
 
 func testRawMetric() *rawMetric {
 	mockIt := &mockBaseIterator{}
 	mockIt.decodeVersionFn = func() int { return metricVersion }
 	mockIt.decodeBytesLenFn = func() int { return len(testMetric.ID) }
-	mockIt.decodeTimeFn = func() time.Time { return testMetric.Timestamp }
+	mockIt.decodeVarintFn = func() int64 { return testMetric.TimeNs }
 	mockIt.decodeFloat64Fn = func() float64 { return testMetric.Value }
 	mockIt.bufReader = bytes.NewReader(testRawMetricData)
 

--- a/protocol/msgpack/raw_metric_test.go
+++ b/protocol/msgpack/raw_metric_test.go
@@ -94,7 +94,7 @@ func TestRawMetricDecodeIDSuccess(t *testing.T) {
 func TestRawMetricDecodeTimestampExistingError(t *testing.T) {
 	m := testRawMetric()
 	m.it.setErr(errTestDecodeRawMetric)
-	_, err := m.TimeNs()
+	_, err := m.TimeNanos()
 	require.Equal(t, errTestDecodeRawMetric, err)
 }
 
@@ -104,20 +104,20 @@ func TestRawMetricDecodeTimestampDecodeError(t *testing.T) {
 		m.it.setErr(errTestDecodeRawMetric)
 		return 0
 	}
-	_, err := m.TimeNs()
+	_, err := m.TimeNanos()
 	require.Equal(t, errTestDecodeRawMetric, err)
 }
 
 func TestRawMetricDecodeTimestampSuccess(t *testing.T) {
 	m := testRawMetric()
-	timeNs, err := m.TimeNs()
+	timeNanos, err := m.TimeNanos()
 	require.NoError(t, err)
-	require.Equal(t, testMetric.TimeNs, timeNs)
+	require.Equal(t, testMetric.TimeNanos, timeNanos)
 	require.True(t, m.timeDecoded)
 
 	// Get timestamp again to make sure we don't re-decode the timestamp.
 	require.NoError(t, err)
-	require.Equal(t, testMetric.TimeNs, timeNs)
+	require.Equal(t, testMetric.TimeNanos, timeNanos)
 }
 
 func TestRawMetricDecodeValueExistingError(t *testing.T) {
@@ -186,9 +186,9 @@ func TestRawMetricNilID(t *testing.T) {
 
 func TestRawMetricReset(t *testing.T) {
 	metrics := []aggregated.Metric{
-		{ID: metric.ID("foo"), TimeNs: testMetric.TimeNs, Value: 1.0},
-		{ID: metric.ID("bar"), TimeNs: testMetric.TimeNs, Value: 2.3},
-		{ID: metric.ID("baz"), TimeNs: testMetric.TimeNs, Value: 4234.234},
+		{ID: metric.ID("foo"), TimeNanos: testMetric.TimeNanos, Value: 1.0},
+		{ID: metric.ID("bar"), TimeNanos: testMetric.TimeNanos, Value: 2.3},
+		{ID: metric.ID("baz"), TimeNanos: testMetric.TimeNanos, Value: 4234.234},
 	}
 	rawMetric := NewRawMetric(nil, 16)
 	for i := 0; i < len(metrics); i++ {
@@ -201,9 +201,9 @@ func TestRawMetricReset(t *testing.T) {
 
 func TestRawMetricRoundtripStress(t *testing.T) {
 	metrics := []aggregated.Metric{
-		{ID: metric.ID("foo"), TimeNs: testMetric.TimeNs, Value: 1.0},
-		{ID: metric.ID("bar"), TimeNs: testMetric.TimeNs, Value: 2.3},
-		{ID: metric.ID("baz"), TimeNs: testMetric.TimeNs, Value: 4234.234},
+		{ID: metric.ID("foo"), TimeNanos: testMetric.TimeNanos, Value: 1.0},
+		{ID: metric.ID("bar"), TimeNanos: testMetric.TimeNanos, Value: 2.3},
+		{ID: metric.ID("baz"), TimeNanos: testMetric.TimeNanos, Value: 4234.234},
 	}
 	var (
 		inputs  []aggregated.Metric
@@ -267,7 +267,7 @@ func testRawMetric() *rawMetric {
 	mockIt := &mockBaseIterator{}
 	mockIt.decodeVersionFn = func() int { return metricVersion }
 	mockIt.decodeBytesLenFn = func() int { return len(testMetric.ID) }
-	mockIt.decodeVarintFn = func() int64 { return testMetric.TimeNs }
+	mockIt.decodeVarintFn = func() int64 { return testMetric.TimeNanos }
 	mockIt.decodeFloat64Fn = func() float64 { return testMetric.Value }
 	mockIt.bufReader = bytes.NewReader(testRawMetricData)
 

--- a/protocol/msgpack/raw_metric_test.go
+++ b/protocol/msgpack/raw_metric_test.go
@@ -256,7 +256,7 @@ func (it *mockBaseIterator) checkNumFieldsForType(objType objectType) (int, int,
 	return 0, 0, true
 }
 
-func (it *mockBaseIterator) checkNumFieldsForTypeWithActual(
+func (it *mockBaseIterator) checkExpectedNumFieldsForType(
 	objType objectType,
 	numActualFields int,
 ) (int, bool) {

--- a/protocol/msgpack/schema.go
+++ b/protocol/msgpack/schema.go
@@ -40,9 +40,9 @@ const (
 	rootObjectType
 
 	// Object types exposed to the encoder interface.
-	counterWithPoliciesType
-	batchTimerWithPoliciesType
-	gaugeWithPoliciesType
+	counterWithPoliciesListType
+	batchTimerWithPoliciesListType
+	gaugeWithPoliciesListType
 	rawMetricWithPolicyType
 
 	// Object types not exposed to the encoder interface.
@@ -50,35 +50,37 @@ const (
 	batchTimerType
 	gaugeType
 	metricType
+	defaultPoliciesListType
+	customPoliciesListType
+	stagedPoliciesType
 	policyType
 	knownResolutionType
 	unknownResolutionType
 	knownRetentionType
 	unknownRetentionType
-	defaultVersionedPoliciesType
-	customVersionedPoliciesType
 
 	// Total number of object types.
 	numObjectTypes = iota
 )
 
 const (
-	numRootObjectFields             = 2
-	numCounterWithPoliciesFields    = 2
-	numBatchTimerWithPoliciesFields = 2
-	numGaugeWithPoliciesFields      = 2
-	numRawMetricWithPolicyFields    = 2
-	numCounterFields                = 2
-	numBatchTimerFields             = 2
-	numGaugeFields                  = 2
-	numMetricFields                 = 3
-	numPolicyFields                 = 2
-	numKnownResolutionFields        = 2
-	numUnknownResolutionFields      = 3
-	numKnownRetentionFields         = 2
-	numUnknownRetentionFields       = 2
-	numDefaultVersionedPolicyFields = 3
-	numCustomVersionedPolicyFields  = 4
+	numRootObjectFields                 = 2
+	numCounterWithPoliciesListFields    = 2
+	numBatchTimerWithPoliciesListFields = 2
+	numGaugeWithPoliciesListFields      = 2
+	numRawMetricWithPolicyFields        = 2
+	numCounterFields                    = 2
+	numBatchTimerFields                 = 2
+	numGaugeFields                      = 2
+	numMetricFields                     = 3
+	numDefaultStagedPoliciesListFields  = 1
+	numCustomStagedPoliciesListFields   = 2
+	numStagedPoliciesFields             = 3
+	numPolicyFields                     = 2
+	numKnownResolutionFields            = 2
+	numUnknownResolutionFields          = 3
+	numKnownRetentionFields             = 2
+	numUnknownRetentionFields           = 2
 )
 
 // NB(xichen): use a slice instead of a map to avoid lookup overhead.
@@ -96,19 +98,20 @@ func init() {
 	numObjectFields = make([]int, int(numObjectTypes))
 
 	setNumFieldsForType(rootObjectType, numRootObjectFields)
-	setNumFieldsForType(counterWithPoliciesType, numCounterWithPoliciesFields)
-	setNumFieldsForType(batchTimerWithPoliciesType, numBatchTimerWithPoliciesFields)
-	setNumFieldsForType(gaugeWithPoliciesType, numGaugeWithPoliciesFields)
+	setNumFieldsForType(counterWithPoliciesListType, numCounterWithPoliciesListFields)
+	setNumFieldsForType(batchTimerWithPoliciesListType, numBatchTimerWithPoliciesListFields)
+	setNumFieldsForType(gaugeWithPoliciesListType, numGaugeWithPoliciesListFields)
 	setNumFieldsForType(rawMetricWithPolicyType, numRawMetricWithPolicyFields)
 	setNumFieldsForType(counterType, numCounterFields)
 	setNumFieldsForType(batchTimerType, numBatchTimerFields)
 	setNumFieldsForType(gaugeType, numGaugeFields)
 	setNumFieldsForType(metricType, numMetricFields)
+	setNumFieldsForType(defaultPoliciesListType, numDefaultStagedPoliciesListFields)
+	setNumFieldsForType(customPoliciesListType, numCustomStagedPoliciesListFields)
+	setNumFieldsForType(stagedPoliciesType, numStagedPoliciesFields)
 	setNumFieldsForType(policyType, numPolicyFields)
 	setNumFieldsForType(knownResolutionType, numKnownResolutionFields)
 	setNumFieldsForType(unknownResolutionType, numUnknownResolutionFields)
 	setNumFieldsForType(knownRetentionType, numKnownRetentionFields)
 	setNumFieldsForType(unknownRetentionType, numKnownRetentionFields)
-	setNumFieldsForType(defaultVersionedPoliciesType, numDefaultVersionedPolicyFields)
-	setNumFieldsForType(customVersionedPoliciesType, numCustomVersionedPolicyFields)
 }

--- a/protocol/msgpack/types.go
+++ b/protocol/msgpack/types.go
@@ -23,7 +23,6 @@ package msgpack
 import (
 	"bytes"
 	"io"
-	"time"
 
 	"github.com/m3db/m3metrics/metric"
 	"github.com/m3db/m3metrics/metric/aggregated"
@@ -49,11 +48,11 @@ type Buffer interface {
 
 // Encoder is an encoder.
 type Encoder interface {
-	// EncodeTime encodes a time value.
-	EncodeTime(value time.Time) error
-
 	// EncodeInt64 encodes an int64 value.
 	EncodeInt64(value int64) error
+
+	// EncodeBool encodes a boolean value.
+	EncodeBool(value bool) error
 
 	// EncodeFloat64 encodes a float64 value.
 	EncodeFloat64(value float64) error
@@ -121,11 +120,11 @@ type encoderBase interface {
 	// encodeChunkedID encodes a chunked ID.
 	encodeChunkedID(id metric.ChunkedID)
 
-	// encodeTime encodes a time.
-	encodeTime(t time.Time)
-
 	// encodeVarint encodes an integer value as varint.
 	encodeVarint(value int64)
+
+	// encodeBool encodes a boolean value.
+	encodeBool(value bool)
 
 	// encodeFloat64 encodes a float64 value.
 	encodeFloat64(value float64)
@@ -169,11 +168,11 @@ type iteratorBase interface {
 	// decodeID decodes an ID.
 	decodeID() metric.ID
 
-	// decodeTime decodes a time.
-	decodeTime() time.Time
-
 	// decodeVarint decodes a variable-width integer value.
 	decodeVarint() int64
+
+	// decodeBool decodes a boolean value.
+	decodeBool() bool
 
 	// decodeFloat64 decodes a float64 value.
 	decodeFloat64() float64
@@ -196,19 +195,19 @@ type iteratorBase interface {
 
 	// checkNumFieldsForTypeWithActual compares the given number of actual fields with
 	// the number of expected fields for a given object type.
-	checkNumFieldsForTypeWithActual(objType objectType, numActualFields int) (int, int, bool)
+	checkNumFieldsForTypeWithActual(objType objectType, numActualFields int) (int, bool)
 }
 
 // UnaggregatedEncoder is an encoder for encoding different types of unaggregated metrics.
 type UnaggregatedEncoder interface {
-	// EncodeCounterWithPolicies encodes a counter with applicable policies.
-	EncodeCounterWithPolicies(cp unaggregated.CounterWithPolicies) error
+	// EncodeCounterWithPoliciesList encodes a counter with applicable policies list.
+	EncodeCounterWithPoliciesList(cp unaggregated.CounterWithPoliciesList) error
 
-	// EncodeBatchTimerWithPolicies encodes a batched timer with applicable policies.
-	EncodeBatchTimerWithPolicies(btp unaggregated.BatchTimerWithPolicies) error
+	// EncodeBatchTimerWithPoliciesList encodes a batched timer with applicable policies list.
+	EncodeBatchTimerWithPoliciesList(btp unaggregated.BatchTimerWithPoliciesList) error
 
-	// EncodeGaugeWithPolicies encodes a gauge with applicable policies.
-	EncodeGaugeWithPolicies(gp unaggregated.GaugeWithPolicies) error
+	// EncodeGaugeWithPoliciesList encodes a gauge with applicable policies list.
+	EncodeGaugeWithPoliciesList(gp unaggregated.GaugeWithPoliciesList) error
 
 	// Encoder returns the encoder.
 	Encoder() BufferedEncoder
@@ -222,9 +221,9 @@ type UnaggregatedIterator interface {
 	// Next returns true if there are more items to decode.
 	Next() bool
 
-	// Value returns the current metric and applicable policies.
+	// Value returns the current metric and applicable policies list.
 	// The returned value remains valid until the next Next() call.
-	Value() (unaggregated.MetricUnion, policy.VersionedPolicies)
+	Value() (unaggregated.MetricUnion, policy.PoliciesList)
 
 	// Err returns the error encountered during decoding, if any.
 	Err() error

--- a/protocol/msgpack/types.go
+++ b/protocol/msgpack/types.go
@@ -193,9 +193,9 @@ type iteratorBase interface {
 	// the number of expected fields for a given object type.
 	checkNumFieldsForType(objType objectType) (int, int, bool)
 
-	// checkNumFieldsForTypeWithActual compares the given number of actual fields with
+	// checkExpectedNumFieldsForType compares the given number of actual fields with
 	// the number of expected fields for a given object type.
-	checkNumFieldsForTypeWithActual(objType objectType, numActualFields int) (int, bool)
+	checkExpectedNumFieldsForType(objType objectType, numActualFields int) (int, bool)
 }
 
 // UnaggregatedEncoder is an encoder for encoding different types of unaggregated metrics.

--- a/protocol/msgpack/unaggregated_encoder.go
+++ b/protocol/msgpack/unaggregated_encoder.go
@@ -158,9 +158,9 @@ func (enc *unaggregatedEncoder) encodePoliciesList(pl policy.PoliciesList) {
 
 func (enc *unaggregatedEncoder) encodeStagedPolicies(sp policy.StagedPolicies) {
 	enc.encodeNumObjectFields(numFieldsForType(stagedPoliciesType))
-	enc.encodeVarint(sp.CutoverNs)
+	enc.encodeVarint(sp.CutoverNanos)
 	enc.encodeBool(sp.Tombstoned)
-	policies := sp.Policies()
+	policies, _ := sp.Policies()
 	enc.encodeArrayLen(len(policies))
 	for _, policy := range policies {
 		enc.encodePolicy(policy)

--- a/protocol/msgpack/unaggregated_encoder.go
+++ b/protocol/msgpack/unaggregated_encoder.go
@@ -27,27 +27,27 @@ import (
 
 // Various object-level encoding functions to facilitate testing.
 type encodeRootObjectFn func(objType objectType)
-type encodeCounterWithPoliciesFn func(cp unaggregated.CounterWithPolicies)
-type encodeBatchTimerWithPoliciesFn func(btp unaggregated.BatchTimerWithPolicies)
-type encodeGaugeWithPoliciesFn func(gp unaggregated.GaugeWithPolicies)
+type encodeCounterWithPoliciesListFn func(cp unaggregated.CounterWithPoliciesList)
+type encodeBatchTimerWithPoliciesListFn func(btp unaggregated.BatchTimerWithPoliciesList)
+type encodeGaugeWithPoliciesListFn func(gp unaggregated.GaugeWithPoliciesList)
 type encodeCounterFn func(c unaggregated.Counter)
 type encodeBatchTimerFn func(bt unaggregated.BatchTimer)
 type encodeGaugeFn func(g unaggregated.Gauge)
-type encodeVersionedPoliciesFn func(vp policy.VersionedPolicies)
+type encodePoliciesListFn func(spl policy.PoliciesList)
 
 // unaggregatedEncoder uses MessagePack for encoding different types of unaggregated metrics.
 // It is not thread-safe.
 type unaggregatedEncoder struct {
 	encoderBase
 
-	encodeRootObjectFn             encodeRootObjectFn
-	encodeCounterWithPoliciesFn    encodeCounterWithPoliciesFn
-	encodeBatchTimerWithPoliciesFn encodeBatchTimerWithPoliciesFn
-	encodeGaugeWithPoliciesFn      encodeGaugeWithPoliciesFn
-	encodeCounterFn                encodeCounterFn
-	encodeBatchTimerFn             encodeBatchTimerFn
-	encodeGaugeFn                  encodeGaugeFn
-	encodeVersionedPoliciesFn      encodeVersionedPoliciesFn
+	encodeRootObjectFn                 encodeRootObjectFn
+	encodeCounterWithPoliciesListFn    encodeCounterWithPoliciesListFn
+	encodeBatchTimerWithPoliciesListFn encodeBatchTimerWithPoliciesListFn
+	encodeGaugeWithPoliciesListFn      encodeGaugeWithPoliciesListFn
+	encodeCounterFn                    encodeCounterFn
+	encodeBatchTimerFn                 encodeBatchTimerFn
+	encodeGaugeFn                      encodeGaugeFn
+	encodePoliciesListFn               encodePoliciesListFn
 }
 
 // NewUnaggregatedEncoder creates a new unaggregated encoder.
@@ -55,13 +55,13 @@ func NewUnaggregatedEncoder(encoder BufferedEncoder) UnaggregatedEncoder {
 	enc := &unaggregatedEncoder{encoderBase: newBaseEncoder(encoder)}
 
 	enc.encodeRootObjectFn = enc.encodeRootObject
-	enc.encodeCounterWithPoliciesFn = enc.encodeCounterWithPolicies
-	enc.encodeBatchTimerWithPoliciesFn = enc.encodeBatchTimerWithPolicies
-	enc.encodeGaugeWithPoliciesFn = enc.encodeGaugeWithPolicies
+	enc.encodeCounterWithPoliciesListFn = enc.encodeCounterWithPoliciesList
+	enc.encodeBatchTimerWithPoliciesListFn = enc.encodeBatchTimerWithPoliciesList
+	enc.encodeGaugeWithPoliciesListFn = enc.encodeGaugeWithPoliciesList
 	enc.encodeCounterFn = enc.encodeCounter
 	enc.encodeBatchTimerFn = enc.encodeBatchTimer
 	enc.encodeGaugeFn = enc.encodeGauge
-	enc.encodeVersionedPoliciesFn = enc.encodeVersionedPolicies
+	enc.encodePoliciesListFn = enc.encodePoliciesList
 
 	return enc
 }
@@ -69,30 +69,30 @@ func NewUnaggregatedEncoder(encoder BufferedEncoder) UnaggregatedEncoder {
 func (enc *unaggregatedEncoder) Encoder() BufferedEncoder      { return enc.encoder() }
 func (enc *unaggregatedEncoder) Reset(encoder BufferedEncoder) { enc.reset(encoder) }
 
-func (enc *unaggregatedEncoder) EncodeCounterWithPolicies(cp unaggregated.CounterWithPolicies) error {
+func (enc *unaggregatedEncoder) EncodeCounterWithPoliciesList(cp unaggregated.CounterWithPoliciesList) error {
 	if err := enc.err(); err != nil {
 		return err
 	}
-	enc.encodeRootObjectFn(counterWithPoliciesType)
-	enc.encodeCounterWithPoliciesFn(cp)
+	enc.encodeRootObjectFn(counterWithPoliciesListType)
+	enc.encodeCounterWithPoliciesListFn(cp)
 	return enc.err()
 }
 
-func (enc *unaggregatedEncoder) EncodeBatchTimerWithPolicies(btp unaggregated.BatchTimerWithPolicies) error {
+func (enc *unaggregatedEncoder) EncodeBatchTimerWithPoliciesList(btp unaggregated.BatchTimerWithPoliciesList) error {
 	if err := enc.err(); err != nil {
 		return err
 	}
-	enc.encodeRootObjectFn(batchTimerWithPoliciesType)
-	enc.encodeBatchTimerWithPoliciesFn(btp)
+	enc.encodeRootObjectFn(batchTimerWithPoliciesListType)
+	enc.encodeBatchTimerWithPoliciesListFn(btp)
 	return enc.err()
 }
 
-func (enc *unaggregatedEncoder) EncodeGaugeWithPolicies(gp unaggregated.GaugeWithPolicies) error {
+func (enc *unaggregatedEncoder) EncodeGaugeWithPoliciesList(gp unaggregated.GaugeWithPoliciesList) error {
 	if err := enc.err(); err != nil {
 		return err
 	}
-	enc.encodeRootObjectFn(gaugeWithPoliciesType)
-	enc.encodeGaugeWithPoliciesFn(gp)
+	enc.encodeRootObjectFn(gaugeWithPoliciesListType)
+	enc.encodeGaugeWithPoliciesListFn(gp)
 	return enc.err()
 }
 
@@ -102,22 +102,22 @@ func (enc *unaggregatedEncoder) encodeRootObject(objType objectType) {
 	enc.encodeObjectType(objType)
 }
 
-func (enc *unaggregatedEncoder) encodeCounterWithPolicies(cp unaggregated.CounterWithPolicies) {
-	enc.encodeNumObjectFields(numFieldsForType(counterWithPoliciesType))
+func (enc *unaggregatedEncoder) encodeCounterWithPoliciesList(cp unaggregated.CounterWithPoliciesList) {
+	enc.encodeNumObjectFields(numFieldsForType(counterWithPoliciesListType))
 	enc.encodeCounterFn(cp.Counter)
-	enc.encodeVersionedPoliciesFn(cp.VersionedPolicies)
+	enc.encodePoliciesListFn(cp.PoliciesList)
 }
 
-func (enc *unaggregatedEncoder) encodeBatchTimerWithPolicies(btp unaggregated.BatchTimerWithPolicies) {
-	enc.encodeNumObjectFields(numFieldsForType(batchTimerWithPoliciesType))
+func (enc *unaggregatedEncoder) encodeBatchTimerWithPoliciesList(btp unaggregated.BatchTimerWithPoliciesList) {
+	enc.encodeNumObjectFields(numFieldsForType(batchTimerWithPoliciesListType))
 	enc.encodeBatchTimerFn(btp.BatchTimer)
-	enc.encodeVersionedPoliciesFn(btp.VersionedPolicies)
+	enc.encodePoliciesListFn(btp.PoliciesList)
 }
 
-func (enc *unaggregatedEncoder) encodeGaugeWithPolicies(gp unaggregated.GaugeWithPolicies) {
-	enc.encodeNumObjectFields(numFieldsForType(gaugeWithPoliciesType))
+func (enc *unaggregatedEncoder) encodeGaugeWithPoliciesList(gp unaggregated.GaugeWithPoliciesList) {
+	enc.encodeNumObjectFields(numFieldsForType(gaugeWithPoliciesListType))
 	enc.encodeGaugeFn(gp.Gauge)
-	enc.encodeVersionedPoliciesFn(gp.VersionedPolicies)
+	enc.encodePoliciesListFn(gp.PoliciesList)
 }
 
 func (enc *unaggregatedEncoder) encodeCounter(c unaggregated.Counter) {
@@ -141,22 +141,26 @@ func (enc *unaggregatedEncoder) encodeGauge(g unaggregated.Gauge) {
 	enc.encodeFloat64(g.Value)
 }
 
-func (enc *unaggregatedEncoder) encodeVersionedPolicies(vp policy.VersionedPolicies) {
-	// NB(xichen): if this is a default policy, we do not encode the actual policies
-	// to optimize for the common case.
-	if vp.IsDefault() {
-		enc.encodeNumObjectFields(numFieldsForType(defaultVersionedPoliciesType))
-		enc.encodeObjectType(defaultVersionedPoliciesType)
-		enc.encodeVersion(vp.Version)
-		enc.encodeTime(vp.Cutover)
+func (enc *unaggregatedEncoder) encodePoliciesList(pl policy.PoliciesList) {
+	if pl.IsDefault() {
+		enc.encodeNumObjectFields(numFieldsForType(defaultPoliciesListType))
+		enc.encodeObjectType(defaultPoliciesListType)
 		return
 	}
-	// Otherwise fallback to encoding the entire object.
-	enc.encodeNumObjectFields(numFieldsForType(customVersionedPoliciesType))
-	enc.encodeObjectType(customVersionedPoliciesType)
-	enc.encodeVersion(vp.Version)
-	enc.encodeTime(vp.Cutover)
-	policies := vp.Policies()
+	enc.encodeNumObjectFields(numFieldsForType(customPoliciesListType))
+	enc.encodeObjectType(customPoliciesListType)
+	numPolicies := len(pl)
+	enc.encodeArrayLen(numPolicies)
+	for i := 0; i < numPolicies; i++ {
+		enc.encodeStagedPolicies(pl[i])
+	}
+}
+
+func (enc *unaggregatedEncoder) encodeStagedPolicies(sp policy.StagedPolicies) {
+	enc.encodeNumObjectFields(numFieldsForType(stagedPoliciesType))
+	enc.encodeVarint(sp.CutoverNs)
+	enc.encodeBool(sp.Tombstoned)
+	policies := sp.Policies()
 	enc.encodeArrayLen(len(policies))
 	for _, policy := range policies {
 		enc.encodePolicy(policy)

--- a/protocol/msgpack/unaggregated_encoder_test.go
+++ b/protocol/msgpack/unaggregated_encoder_test.go
@@ -234,10 +234,10 @@ func expectedResultsForPolicy(t *testing.T, p policy.Policy) []interface{} {
 }
 
 func expectedResultsForStagedPolicies(t *testing.T, sp policy.StagedPolicies) []interface{} {
-	policies := sp.Policies()
+	policies, _ := sp.Policies()
 	results := []interface{}{
 		numFieldsForType(stagedPoliciesType),
-		sp.CutoverNs,
+		sp.CutoverNanos,
 		sp.Tombstoned,
 		len(policies),
 	}

--- a/protocol/msgpack/unaggregated_encoder_test.go
+++ b/protocol/msgpack/unaggregated_encoder_test.go
@@ -40,47 +40,58 @@ var (
 	errTestArrayLen = errors.New("test array len error")
 )
 
-func TestUnaggregatedEncodeCounterWithDefaultPolicies(t *testing.T) {
-	policies := testDefaultStagedPolicies
+func TestUnaggregatedEncodeCounterWithDefaultPoliciesList(t *testing.T) {
+	policies := testDefaultStagedPoliciesList
 	encoder, results := testCapturingUnaggregatedEncoder(t)
 	require.NoError(t, testUnaggregatedEncode(t, encoder, testCounter, policies))
-	expected := expectedResultsForUnaggregatedMetricWithPolicies(t, testCounter, policies)
+	expected := expectedResultsForUnaggregatedMetricWithPoliciesList(t, testCounter, policies)
 	require.Equal(t, expected, *results)
 }
 
-func TestUnaggregatedEncodeBatchTimerWithDefaultPolicies(t *testing.T) {
-	policies := testDefaultStagedPolicies
+func TestUnaggregatedEncodeBatchTimerWithDefaultPoliciesList(t *testing.T) {
+	policies := testDefaultStagedPoliciesList
 	encoder, results := testCapturingUnaggregatedEncoder(t)
 	require.NoError(t, testUnaggregatedEncode(t, encoder, testBatchTimer, policies))
-	expected := expectedResultsForUnaggregatedMetricWithPolicies(t, testBatchTimer, policies)
+	expected := expectedResultsForUnaggregatedMetricWithPoliciesList(t, testBatchTimer, policies)
 	require.Equal(t, expected, *results)
 }
 
-func TestUnaggregatedEncodeGaugeWithDefaultPolicies(t *testing.T) {
-	policies := testDefaultStagedPolicies
+func TestUnaggregatedEncodeGaugeWithDefaultPoliciesList(t *testing.T) {
+	policies := testDefaultStagedPoliciesList
 	encoder, results := testCapturingUnaggregatedEncoder(t)
 	require.NoError(t, testUnaggregatedEncode(t, encoder, testGauge, policies))
-	expected := expectedResultsForUnaggregatedMetricWithPolicies(t, testGauge, policies)
+	expected := expectedResultsForUnaggregatedMetricWithPoliciesList(t, testGauge, policies)
 	require.Equal(t, expected, *results)
 }
 
-func TestUnaggregatedEncodeAllTypesWithDefaultPolicies(t *testing.T) {
+func TestUnaggregatedEncodeAllTypesWithDefaultPoliciesList(t *testing.T) {
 	var expected []interface{}
 	encoder, results := testCapturingUnaggregatedEncoder(t)
-	for _, input := range testInputWithAllTypesAndDefaultPolicies {
+	for _, input := range testInputWithAllTypesAndDefaultPoliciesList {
 		require.NoError(t, testUnaggregatedEncode(t, encoder, input.metric, input.policiesList))
-		expected = append(expected, expectedResultsForUnaggregatedMetricWithPolicies(t, input.metric, input.policiesList)...)
+		expected = append(expected, expectedResultsForUnaggregatedMetricWithPoliciesList(t, input.metric, input.policiesList)...)
 	}
 
 	require.Equal(t, expected, *results)
 }
 
-func TestUnaggregatedEncodeAllTypesWithSingleCustomPolicies(t *testing.T) {
+func TestUnaggregatedEncodeAllTypesWithSingleCustomPoliciesList(t *testing.T) {
 	var expected []interface{}
 	encoder, results := testCapturingUnaggregatedEncoder(t)
-	for _, input := range testInputWithAllTypesAndSingleCustomPolicies {
+	for _, input := range testInputWithAllTypesAndSingleCustomPoliciesList {
 		require.NoError(t, testUnaggregatedEncode(t, encoder, input.metric, input.policiesList))
-		expected = append(expected, expectedResultsForUnaggregatedMetricWithPolicies(t, input.metric, input.policiesList)...)
+		expected = append(expected, expectedResultsForUnaggregatedMetricWithPoliciesList(t, input.metric, input.policiesList)...)
+	}
+
+	require.Equal(t, expected, *results)
+}
+
+func TestUnaggregatedEncodeAllTypesWithMultiCustomPolicies(t *testing.T) {
+	var expected []interface{}
+	encoder, results := testCapturingUnaggregatedEncoder(t)
+	for _, input := range testInputWithAllTypesAndMultiCustomPoliciesList {
+		require.NoError(t, testUnaggregatedEncode(t, encoder, input.metric, input.policiesList))
+		expected = append(expected, expectedResultsForUnaggregatedMetricWithPoliciesList(t, input.metric, input.policiesList)...)
 	}
 
 	require.Equal(t, expected, *results)
@@ -88,7 +99,7 @@ func TestUnaggregatedEncodeAllTypesWithSingleCustomPolicies(t *testing.T) {
 
 func TestUnaggregatedEncodeVarintError(t *testing.T) {
 	counter := testCounter
-	policies := testDefaultStagedPolicies
+	policies := testDefaultStagedPoliciesList
 
 	// Intentionally return an error when encoding varint.
 	encoder := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
@@ -106,7 +117,7 @@ func TestUnaggregatedEncodeVarintError(t *testing.T) {
 
 func TestUnaggregatedEncodeFloat64Error(t *testing.T) {
 	gauge := testGauge
-	policies := testDefaultStagedPolicies
+	policies := testDefaultStagedPoliciesList
 
 	// Intentionally return an error when encoding float64.
 	encoder := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
@@ -124,7 +135,7 @@ func TestUnaggregatedEncodeFloat64Error(t *testing.T) {
 
 func TestUnaggregatedEncodeBytesError(t *testing.T) {
 	timer := testBatchTimer
-	policies := testDefaultStagedPolicies
+	policies := testDefaultStagedPoliciesList
 
 	// Intentionally return an error when encoding array length.
 	encoder := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
@@ -168,7 +179,7 @@ func TestUnaggregatedEncodeArrayLenError(t *testing.T) {
 
 func TestUnaggregatedEncoderReset(t *testing.T) {
 	metric := testCounter
-	policies := testDefaultStagedPolicies
+	policies := testDefaultStagedPoliciesList
 
 	encoder := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
 	baseEncoder := encoder.encoderBase.(*baseEncoder)
@@ -254,7 +265,7 @@ func expectedResultsForPoliciesList(t *testing.T, pl policy.PoliciesList) []inte
 	return results
 }
 
-func expectedResultsForUnaggregatedMetricWithPolicies(
+func expectedResultsForUnaggregatedMetricWithPoliciesList(
 	t *testing.T,
 	m unaggregated.MetricUnion,
 	pl policy.PoliciesList,

--- a/protocol/msgpack/unaggregated_iterator.go
+++ b/protocol/msgpack/unaggregated_iterator.go
@@ -225,7 +225,7 @@ func (it *unaggregatedIterator) decodeGauge() {
 func (it *unaggregatedIterator) decodePoliciesList() {
 	numActualFields := it.decodeNumObjectFields()
 	policiesListType := it.decodeObjectType()
-	numExpectedFields, ok := it.checkNumFieldsForTypeWithActual(
+	numExpectedFields, ok := it.checkExpectedNumFieldsForType(
 		policiesListType,
 		numActualFields,
 	)
@@ -244,8 +244,6 @@ func (it *unaggregatedIterator) decodePoliciesList() {
 		}
 		if len(it.cachedPolicies) < numStagedPolicies {
 			it.cachedPolicies = make([][]policy.Policy, numStagedPolicies)
-		} else {
-			it.cachedPolicies = it.cachedPolicies[:numStagedPolicies]
 		}
 		for policyIdx := 0; policyIdx < numStagedPolicies; policyIdx++ {
 			decodedStagedPolicies := it.decodeStagedPolicies(policyIdx)

--- a/protocol/msgpack/unaggregated_iterator.go
+++ b/protocol/msgpack/unaggregated_iterator.go
@@ -264,9 +264,9 @@ func (it *unaggregatedIterator) decodePoliciesList() {
 func (it *unaggregatedIterator) decodeStagedPolicies(policyIdx int) policy.StagedPolicies {
 	numExpectedFields, numActualFields, ok := it.checkNumFieldsForType(stagedPoliciesType)
 	if !ok {
-		return policy.EmptyStagedPolicies
+		return policy.DefaultStagedPolicies
 	}
-	cutoverNs := it.decodeVarint()
+	cutoverNanos := it.decodeVarint()
 	tombstoned := it.decodeBool()
 	numPolicies := it.decodeArrayLen()
 	if cap(it.cachedPolicies[policyIdx]) < numPolicies {
@@ -277,7 +277,7 @@ func (it *unaggregatedIterator) decodeStagedPolicies(policyIdx int) policy.Stage
 	for i := 0; i < numPolicies; i++ {
 		it.cachedPolicies[policyIdx] = append(it.cachedPolicies[policyIdx], it.decodePolicy())
 	}
-	stagedPolicies := policy.NewStagedPolicies(cutoverNs, tombstoned, it.cachedPolicies[policyIdx])
+	stagedPolicies := policy.NewStagedPolicies(cutoverNanos, tombstoned, it.cachedPolicies[policyIdx])
 	it.skip(numActualFields - numExpectedFields)
 	return stagedPolicies
 }

--- a/protocol/msgpack/unaggregated_iterator.go
+++ b/protocol/msgpack/unaggregated_iterator.go
@@ -45,12 +45,13 @@ type unaggregatedIterator struct {
 	largeFloatsPool     pool.FloatsPool
 	iteratorPool        UnaggregatedIteratorPool
 
-	closed            bool
-	metric            unaggregated.MetricUnion
-	versionedPolicies policy.VersionedPolicies
-	id                metric.ID
-	policies          []policy.Policy
-	timerValues       []float64
+	closed             bool
+	metric             unaggregated.MetricUnion
+	policiesList       policy.PoliciesList
+	id                 metric.ID
+	timerValues        []float64
+	cachedPolicies     [][]policy.Policy
+	cachedPoliciesList policy.PoliciesList
 }
 
 // NewUnaggregatedIterator creates a new unaggregated iterator.
@@ -77,8 +78,8 @@ func (it *unaggregatedIterator) Reset(reader io.Reader) {
 	it.reset(reader)
 }
 
-func (it *unaggregatedIterator) Value() (unaggregated.MetricUnion, policy.VersionedPolicies) {
-	return it.metric, it.versionedPolicies
+func (it *unaggregatedIterator) Value() (unaggregated.MetricUnion, policy.PoliciesList) {
+	return it.metric, it.policiesList
 }
 
 func (it *unaggregatedIterator) Next() bool {
@@ -100,7 +101,9 @@ func (it *unaggregatedIterator) Close() {
 	it.closed = true
 	it.reset(emptyReader)
 	it.metric.Reset()
-	it.versionedPolicies.Reset()
+	it.policiesList = nil
+	it.cachedPolicies = nil
+	it.cachedPoliciesList = nil
 	if it.iteratorPool != nil {
 		it.iteratorPool.Put(it)
 	}
@@ -131,8 +134,8 @@ func (it *unaggregatedIterator) decodeRootObject() bool {
 		return false
 	}
 	switch objType {
-	case counterWithPoliciesType, batchTimerWithPoliciesType, gaugeWithPoliciesType:
-		it.decodeMetricWithPolicies(objType)
+	case counterWithPoliciesListType, batchTimerWithPoliciesListType, gaugeWithPoliciesListType:
+		it.decodeMetricWithPoliciesList(objType)
 	default:
 		it.setErr(fmt.Errorf("unrecognized object type %v", objType))
 	}
@@ -141,23 +144,23 @@ func (it *unaggregatedIterator) decodeRootObject() bool {
 	return it.err() == nil
 }
 
-func (it *unaggregatedIterator) decodeMetricWithPolicies(objType objectType) {
+func (it *unaggregatedIterator) decodeMetricWithPoliciesList(objType objectType) {
 	numExpectedFields, numActualFields, ok := it.checkNumFieldsForType(objType)
 	if !ok {
 		return
 	}
 	switch objType {
-	case counterWithPoliciesType:
+	case counterWithPoliciesListType:
 		it.decodeCounter()
-	case batchTimerWithPoliciesType:
+	case batchTimerWithPoliciesListType:
 		it.decodeBatchTimer()
-	case gaugeWithPoliciesType:
+	case gaugeWithPoliciesListType:
 		it.decodeGauge()
 	default:
 		it.setErr(fmt.Errorf("unrecognized metric with policies type %v", objType))
 		return
 	}
-	it.decodeVersionedPolicies()
+	it.decodePoliciesList()
 	it.skip(numActualFields - numExpectedFields)
 }
 
@@ -219,37 +222,64 @@ func (it *unaggregatedIterator) decodeGauge() {
 	it.skip(numActualFields - numExpectedFields)
 }
 
-func (it *unaggregatedIterator) decodeVersionedPolicies() {
+func (it *unaggregatedIterator) decodePoliciesList() {
 	numActualFields := it.decodeNumObjectFields()
-	versionedPoliciesType := it.decodeObjectType()
-	numExpectedFields, numActualFields, ok := it.checkNumFieldsForTypeWithActual(
-		versionedPoliciesType,
+	policiesListType := it.decodeObjectType()
+	numExpectedFields, ok := it.checkNumFieldsForTypeWithActual(
+		policiesListType,
 		numActualFields,
 	)
 	if !ok {
 		return
 	}
-	version := it.decodeVersion()
-	cutover := it.decodeTime()
-	switch versionedPoliciesType {
-	case defaultVersionedPoliciesType:
-		it.versionedPolicies = policy.DefaultVersionedPolicies(version, cutover)
-		it.skip(numActualFields - numExpectedFields)
-	case customVersionedPoliciesType:
-		numPolicies := it.decodeArrayLen()
-		if cap(it.policies) < numPolicies {
-			it.policies = make([]policy.Policy, 0, numPolicies)
+	switch policiesListType {
+	case defaultPoliciesListType:
+		it.policiesList = policy.DefaultPoliciesList
+	case customPoliciesListType:
+		numStagedPolicies := it.decodeArrayLen()
+		if cap(it.cachedPoliciesList) < numStagedPolicies {
+			it.cachedPoliciesList = make(policy.PoliciesList, 0, numStagedPolicies)
 		} else {
-			it.policies = it.policies[:0]
+			it.cachedPoliciesList = it.cachedPoliciesList[:0]
 		}
-		for i := 0; i < numPolicies; i++ {
-			it.policies = append(it.policies, it.decodePolicy())
+		if len(it.cachedPolicies) < numStagedPolicies {
+			it.cachedPolicies = make([][]policy.Policy, numStagedPolicies)
+		} else {
+			it.cachedPolicies = it.cachedPolicies[:numStagedPolicies]
 		}
-		it.versionedPolicies = policy.CustomVersionedPolicies(version, cutover, it.policies)
-		it.skip(numActualFields - numExpectedFields)
+		for policyIdx := 0; policyIdx < numStagedPolicies; policyIdx++ {
+			decodedStagedPolicies := it.decodeStagedPolicies(policyIdx)
+			it.cachedPoliciesList = append(it.cachedPoliciesList, decodedStagedPolicies)
+		}
+		it.policiesList = it.cachedPoliciesList
 	default:
-		it.setErr(fmt.Errorf("unrecognized versioned policies type: %v", versionedPoliciesType))
+		it.setErr(fmt.Errorf("unrecognized policies list type: %v", policiesListType))
 	}
+	it.skip(numActualFields - numExpectedFields)
+}
+
+// decodeStagedPolicies decodes a staged policies using the cached policies
+// to avoid memory reallocations and returns the decoded staged policies.
+// If an error is encountered during decoding, it is stored in the iterator.
+func (it *unaggregatedIterator) decodeStagedPolicies(policyIdx int) policy.StagedPolicies {
+	numExpectedFields, numActualFields, ok := it.checkNumFieldsForType(stagedPoliciesType)
+	if !ok {
+		return policy.EmptyStagedPolicies
+	}
+	cutoverNs := it.decodeVarint()
+	tombstoned := it.decodeBool()
+	numPolicies := it.decodeArrayLen()
+	if cap(it.cachedPolicies[policyIdx]) < numPolicies {
+		it.cachedPolicies[policyIdx] = make([]policy.Policy, 0, numPolicies)
+	} else {
+		it.cachedPolicies[policyIdx] = it.cachedPolicies[policyIdx][:0]
+	}
+	for i := 0; i < numPolicies; i++ {
+		it.cachedPolicies[policyIdx] = append(it.cachedPolicies[policyIdx], it.decodePolicy())
+	}
+	stagedPolicies := policy.NewStagedPolicies(cutoverNs, tombstoned, it.cachedPolicies[policyIdx])
+	it.skip(numActualFields - numExpectedFields)
+	return stagedPolicies
 }
 
 func (it *unaggregatedIterator) decodeID() metric.ID {

--- a/protocol/msgpack/unaggregated_iterator.go
+++ b/protocol/msgpack/unaggregated_iterator.go
@@ -240,6 +240,9 @@ func (it *unaggregatedIterator) decodePoliciesList() {
 		if cap(it.cachedPoliciesList) < numStagedPolicies {
 			it.cachedPoliciesList = make(policy.PoliciesList, 0, numStagedPolicies)
 		} else {
+			for i := 0; i < len(it.cachedPoliciesList); i++ {
+				it.cachedPoliciesList[i].Reset()
+			}
 			it.cachedPoliciesList = it.cachedPoliciesList[:0]
 		}
 		if len(it.cachedPolicies) < numStagedPolicies {

--- a/protocol/msgpack/unaggregated_iterator_test.go
+++ b/protocol/msgpack/unaggregated_iterator_test.go
@@ -57,7 +57,8 @@ func TestUnaggregatedIteratorDecodeSingleCustomPoliciesListWithAlloc(t *testing.
 	_, pl := it.Value()
 	require.Equal(t, testSingleCustomStagedPoliciesList, pl)
 	require.Equal(t, len(it.cachedPolicies), len(testSingleCustomStagedPoliciesList))
-	require.Equal(t, it.cachedPolicies[0], testSingleCustomStagedPoliciesList[0].Policies())
+	policies, _ := testSingleCustomStagedPoliciesList[0].Policies()
+	require.Equal(t, it.cachedPolicies[0], policies)
 }
 
 func TestUnaggregatedIteratorDecodeSingleCustomPoliciesListNoPoliciesListAlloc(t *testing.T) {
@@ -71,7 +72,8 @@ func TestUnaggregatedIteratorDecodeSingleCustomPoliciesListNoPoliciesListAlloc(t
 	_, pl := it.Value()
 	require.Equal(t, testSingleCustomStagedPoliciesList, pl)
 	require.Equal(t, len(it.cachedPolicies), len(testSingleCustomStagedPoliciesList))
-	require.Equal(t, it.cachedPolicies[0], testSingleCustomStagedPoliciesList[0].Policies())
+	policies, _ := testSingleCustomStagedPoliciesList[0].Policies()
+	require.Equal(t, it.cachedPolicies[0], policies)
 }
 
 func TestUnaggregatedIteratorDecodeSingleCustomPoliciesListNoAlloc(t *testing.T) {
@@ -87,7 +89,8 @@ func TestUnaggregatedIteratorDecodeSingleCustomPoliciesListNoAlloc(t *testing.T)
 	_, pl := it.Value()
 	require.Equal(t, testSingleCustomStagedPoliciesList, pl)
 	require.Equal(t, len(it.cachedPolicies), len(testSingleCustomStagedPoliciesList))
-	require.Equal(t, it.cachedPolicies[0], testSingleCustomStagedPoliciesList[0].Policies())
+	policies, _ := testSingleCustomStagedPoliciesList[0].Policies()
+	require.Equal(t, it.cachedPolicies[0], policies)
 }
 
 func TestUnaggregatedIteratorDecodeMultiCustomPoliciesListWithAlloc(t *testing.T) {
@@ -102,7 +105,8 @@ func TestUnaggregatedIteratorDecodeMultiCustomPoliciesListWithAlloc(t *testing.T
 	require.Equal(t, input, pl)
 	require.Equal(t, len(it.cachedPolicies), len(input))
 	for i := 0; i < len(input); i++ {
-		require.Equal(t, it.cachedPolicies[i], input[i].Policies())
+		policies, _ := input[i].Policies()
+		require.Equal(t, it.cachedPolicies[i], policies)
 	}
 }
 

--- a/protocol/msgpack/unaggregated_iterator_test.go
+++ b/protocol/msgpack/unaggregated_iterator_test.go
@@ -38,40 +38,72 @@ import (
 
 func TestUnaggregatedIteratorDecodeDefaultPoliciesList(t *testing.T) {
 	enc := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
-	enc.encodePoliciesList(testDefaultStagedPolicies)
+	enc.encodePoliciesList(testDefaultStagedPoliciesList)
 	require.NoError(t, enc.err())
 	it := testUnaggregatedIterator(t, enc.Encoder().Buffer()).(*unaggregatedIterator)
 	it.decodePoliciesList()
 	require.NoError(t, it.Err())
 	_, pl := it.Value()
-	require.Equal(t, testDefaultStagedPolicies, pl)
+	require.Equal(t, testDefaultStagedPoliciesList, pl)
 }
 
 func TestUnaggregatedIteratorDecodeSingleCustomPoliciesListWithAlloc(t *testing.T) {
 	enc := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
-	enc.encodePoliciesList(testSingleCustomStagedPolicies)
+	enc.encodePoliciesList(testSingleCustomStagedPoliciesList)
 	require.NoError(t, enc.err())
 	it := testUnaggregatedIterator(t, enc.Encoder().Buffer()).(*unaggregatedIterator)
 	it.decodePoliciesList()
 	require.NoError(t, it.Err())
 	_, pl := it.Value()
-	require.Equal(t, testSingleCustomStagedPolicies, pl)
-	require.Equal(t, len(it.cachedPolicies), len(testSingleCustomStagedPolicies))
-	require.Equal(t, it.cachedPolicies[0], testSingleCustomStagedPolicies[0].Policies())
+	require.Equal(t, testSingleCustomStagedPoliciesList, pl)
+	require.Equal(t, len(it.cachedPolicies), len(testSingleCustomStagedPoliciesList))
+	require.Equal(t, it.cachedPolicies[0], testSingleCustomStagedPoliciesList[0].Policies())
 }
 
-func TestUnaggregatedIteratorDecodeSingleCustomPoliciesNoPoliciesListAlloc(t *testing.T) {
+func TestUnaggregatedIteratorDecodeSingleCustomPoliciesListNoPoliciesListAlloc(t *testing.T) {
 	enc := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
-	enc.encodePoliciesList(testSingleCustomStagedPolicies)
+	enc.encodePoliciesList(testSingleCustomStagedPoliciesList)
 	require.NoError(t, enc.err())
 	it := testUnaggregatedIterator(t, enc.Encoder().Buffer()).(*unaggregatedIterator)
-	it.cachedPoliciesList = make(policy.PoliciesList, len(testSingleCustomStagedPolicies)*3)
+	it.cachedPoliciesList = make(policy.PoliciesList, len(testSingleCustomStagedPoliciesList)*3)
 	it.decodePoliciesList()
 	require.NoError(t, it.Err())
 	_, pl := it.Value()
-	require.Equal(t, testSingleCustomStagedPolicies, pl)
-	require.Equal(t, len(it.cachedPolicies), len(testSingleCustomStagedPolicies))
-	require.Equal(t, it.cachedPolicies[0], testSingleCustomStagedPolicies[0].Policies())
+	require.Equal(t, testSingleCustomStagedPoliciesList, pl)
+	require.Equal(t, len(it.cachedPolicies), len(testSingleCustomStagedPoliciesList))
+	require.Equal(t, it.cachedPolicies[0], testSingleCustomStagedPoliciesList[0].Policies())
+}
+
+func TestUnaggregatedIteratorDecodeSingleCustomPoliciesListNoAlloc(t *testing.T) {
+	enc := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
+	enc.encodePoliciesList(testSingleCustomStagedPoliciesList)
+	require.NoError(t, enc.err())
+	it := testUnaggregatedIterator(t, enc.Encoder().Buffer()).(*unaggregatedIterator)
+	it.cachedPoliciesList = make(policy.PoliciesList, len(testSingleCustomStagedPoliciesList)*3)
+	it.cachedPolicies = make([][]policy.Policy, len(testSingleCustomStagedPoliciesList)*3)
+	it.cachedPolicies[0] = make([]policy.Policy, 32)
+	it.decodePoliciesList()
+	require.NoError(t, it.Err())
+	_, pl := it.Value()
+	require.Equal(t, testSingleCustomStagedPoliciesList, pl)
+	require.Equal(t, len(it.cachedPolicies), len(testSingleCustomStagedPoliciesList))
+	require.Equal(t, it.cachedPolicies[0], testSingleCustomStagedPoliciesList[0].Policies())
+}
+
+func TestUnaggregatedIteratorDecodeMultiCustomPoliciesListWithAlloc(t *testing.T) {
+	input := testMultiCustomStagedPoliciesList
+	enc := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
+	enc.encodePoliciesList(input)
+	require.NoError(t, enc.err())
+	it := testUnaggregatedIterator(t, enc.Encoder().Buffer()).(*unaggregatedIterator)
+	it.decodePoliciesList()
+	require.NoError(t, it.Err())
+	_, pl := it.Value()
+	require.Equal(t, input, pl)
+	require.Equal(t, len(it.cachedPolicies), len(input))
+	for i := 0; i < len(input); i++ {
+		require.Equal(t, it.cachedPolicies[i], input[i].Policies())
+	}
 }
 
 func TestUnaggregatedIteratorDecodeIDDecodeBytesLenError(t *testing.T) {
@@ -264,7 +296,7 @@ func TestUnaggregatedIteratorDecodeBatchTimerWithAllocPoolAlloc(t *testing.T) {
 func TestUnaggregatedIteratorDecodeNewerVersionThanSupported(t *testing.T) {
 	input := metricWithPoliciesList{
 		metric:       testCounter,
-		policiesList: testDefaultStagedPolicies,
+		policiesList: testDefaultStagedPoliciesList,
 	}
 	enc := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
 
@@ -293,7 +325,7 @@ func TestUnaggregatedIteratorDecodeNewerVersionThanSupported(t *testing.T) {
 func TestUnaggregatedIteratorDecodeRootObjectMoreFieldsThanExpected(t *testing.T) {
 	input := metricWithPoliciesList{
 		metric:       testCounter,
-		policiesList: testDefaultStagedPolicies,
+		policiesList: testDefaultStagedPoliciesList,
 	}
 	enc := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
 
@@ -316,7 +348,7 @@ func TestUnaggregatedIteratorDecodeRootObjectMoreFieldsThanExpected(t *testing.T
 func TestUnaggregatedIteratorDecodeCounterWithPoliciesMoreFieldsThanExpected(t *testing.T) {
 	input := metricWithPoliciesList{
 		metric:       testCounter,
-		policiesList: testDefaultStagedPolicies,
+		policiesList: testDefaultStagedPoliciesList,
 	}
 	enc := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
 
@@ -339,7 +371,7 @@ func TestUnaggregatedIteratorDecodeCounterWithPoliciesMoreFieldsThanExpected(t *
 func TestUnaggregatedIteratorDecodeCounterMoreFieldsThanExpected(t *testing.T) {
 	input := metricWithPoliciesList{
 		metric:       testCounter,
-		policiesList: testDefaultStagedPolicies,
+		policiesList: testDefaultStagedPoliciesList,
 	}
 	enc := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
 
@@ -361,7 +393,7 @@ func TestUnaggregatedIteratorDecodeCounterMoreFieldsThanExpected(t *testing.T) {
 func TestUnaggregatedIteratorDecodeBatchTimerMoreFieldsThanExpected(t *testing.T) {
 	input := metricWithPoliciesList{
 		metric:       testBatchTimer,
-		policiesList: testDefaultStagedPolicies,
+		policiesList: testDefaultStagedPoliciesList,
 	}
 	enc := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
 
@@ -386,7 +418,7 @@ func TestUnaggregatedIteratorDecodeBatchTimerMoreFieldsThanExpected(t *testing.T
 func TestUnaggregatedIteratorDecodeGaugeMoreFieldsThanExpected(t *testing.T) {
 	input := metricWithPoliciesList{
 		metric:       testGauge,
-		policiesList: testDefaultStagedPolicies,
+		policiesList: testDefaultStagedPoliciesList,
 	}
 	enc := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
 
@@ -483,7 +515,7 @@ func TestUnaggregatedIteratorDecodePolicyMoreFieldsThanExpected(t *testing.T) {
 func TestUnaggregatedIteratorDecodePoliciesListMoreFieldsThanExpected(t *testing.T) {
 	input := metricWithPoliciesList{
 		metric:       testGauge,
-		policiesList: testSingleCustomStagedPolicies,
+		policiesList: testSingleCustomStagedPoliciesList,
 	}
 	enc := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
 
@@ -508,7 +540,7 @@ func TestUnaggregatedIteratorDecodePoliciesListMoreFieldsThanExpected(t *testing
 func TestUnaggregatedIteratorDecodeCounterFewerFieldsThanExpected(t *testing.T) {
 	input := metricWithPoliciesList{
 		metric:       testCounter,
-		policiesList: testDefaultStagedPolicies,
+		policiesList: testDefaultStagedPoliciesList,
 	}
 	enc := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
 
@@ -579,5 +611,5 @@ func validateUnaggregatedDecodeResults(
 		})
 	}
 	require.Equal(t, expectedErr, it.Err())
-	validateMetricsWithPolicies(t, expectedResults, results)
+	validateMetricsWithPoliciesList(t, expectedResults, results)
 }

--- a/protocol/msgpack/unaggregated_iterator_test.go
+++ b/protocol/msgpack/unaggregated_iterator_test.go
@@ -56,7 +56,7 @@ func TestUnaggregatedIteratorDecodeSingleCustomPoliciesListWithAlloc(t *testing.
 	require.NoError(t, it.Err())
 	_, pl := it.Value()
 	require.Equal(t, testSingleCustomStagedPoliciesList, pl)
-	require.Equal(t, len(it.cachedPolicies), len(testSingleCustomStagedPoliciesList))
+	require.True(t, len(it.cachedPolicies) >= len(testSingleCustomStagedPoliciesList))
 	policies, _ := testSingleCustomStagedPoliciesList[0].Policies()
 	require.Equal(t, it.cachedPolicies[0], policies)
 }
@@ -71,7 +71,7 @@ func TestUnaggregatedIteratorDecodeSingleCustomPoliciesListNoPoliciesListAlloc(t
 	require.NoError(t, it.Err())
 	_, pl := it.Value()
 	require.Equal(t, testSingleCustomStagedPoliciesList, pl)
-	require.Equal(t, len(it.cachedPolicies), len(testSingleCustomStagedPoliciesList))
+	require.True(t, len(it.cachedPolicies) >= len(testSingleCustomStagedPoliciesList))
 	policies, _ := testSingleCustomStagedPoliciesList[0].Policies()
 	require.Equal(t, it.cachedPolicies[0], policies)
 }
@@ -88,7 +88,7 @@ func TestUnaggregatedIteratorDecodeSingleCustomPoliciesListNoAlloc(t *testing.T)
 	require.NoError(t, it.Err())
 	_, pl := it.Value()
 	require.Equal(t, testSingleCustomStagedPoliciesList, pl)
-	require.Equal(t, len(it.cachedPolicies), len(testSingleCustomStagedPoliciesList))
+	require.True(t, len(it.cachedPolicies) >= len(testSingleCustomStagedPoliciesList))
 	policies, _ := testSingleCustomStagedPoliciesList[0].Policies()
 	require.Equal(t, it.cachedPolicies[0], policies)
 }
@@ -103,7 +103,7 @@ func TestUnaggregatedIteratorDecodeMultiCustomPoliciesListWithAlloc(t *testing.T
 	require.NoError(t, it.Err())
 	_, pl := it.Value()
 	require.Equal(t, input, pl)
-	require.Equal(t, len(it.cachedPolicies), len(input))
+	require.True(t, len(it.cachedPolicies) >= len(input))
 	for i := 0; i < len(input); i++ {
 		policies, _ := input[i].Policies()
 		require.Equal(t, it.cachedPolicies[i], policies)

--- a/protocol/msgpack/unaggregated_iterator_test.go
+++ b/protocol/msgpack/unaggregated_iterator_test.go
@@ -36,40 +36,42 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestUnaggregatedIteratorDecodeDefaultPolicies(t *testing.T) {
+func TestUnaggregatedIteratorDecodeDefaultPoliciesList(t *testing.T) {
 	enc := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
-	enc.encodeVersionedPolicies(testDefaultVersionedPolicies)
+	enc.encodePoliciesList(testDefaultStagedPolicies)
 	require.NoError(t, enc.err())
 	it := testUnaggregatedIterator(t, enc.Encoder().Buffer()).(*unaggregatedIterator)
-	it.decodeVersionedPolicies()
+	it.decodePoliciesList()
 	require.NoError(t, it.Err())
-	_, vp := it.Value()
-	require.Equal(t, testDefaultVersionedPolicies, vp)
+	_, pl := it.Value()
+	require.Equal(t, testDefaultStagedPolicies, pl)
 }
 
-func TestUnaggregatedIteratorDecodeCustomPoliciesWithAlloc(t *testing.T) {
+func TestUnaggregatedIteratorDecodeSingleCustomPoliciesListWithAlloc(t *testing.T) {
 	enc := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
-	enc.encodeVersionedPolicies(testCustomVersionedPolicies)
+	enc.encodePoliciesList(testSingleCustomStagedPolicies)
 	require.NoError(t, enc.err())
 	it := testUnaggregatedIterator(t, enc.Encoder().Buffer()).(*unaggregatedIterator)
-	it.decodeVersionedPolicies()
+	it.decodePoliciesList()
 	require.NoError(t, it.Err())
-	_, vp := it.Value()
-	require.Equal(t, testCustomVersionedPolicies, vp)
-	require.Equal(t, len(it.policies), len(testCustomVersionedPolicies.Policies()))
+	_, pl := it.Value()
+	require.Equal(t, testSingleCustomStagedPolicies, pl)
+	require.Equal(t, len(it.cachedPolicies), len(testSingleCustomStagedPolicies))
+	require.Equal(t, it.cachedPolicies[0], testSingleCustomStagedPolicies[0].Policies())
 }
 
-func TestUnaggregatedIteratorDecodeCustomPoliciesNoAlloc(t *testing.T) {
+func TestUnaggregatedIteratorDecodeSingleCustomPoliciesNoPoliciesListAlloc(t *testing.T) {
 	enc := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
-	enc.encodeVersionedPolicies(testCustomVersionedPolicies)
+	enc.encodePoliciesList(testSingleCustomStagedPolicies)
 	require.NoError(t, enc.err())
 	it := testUnaggregatedIterator(t, enc.Encoder().Buffer()).(*unaggregatedIterator)
-	it.policies = make([]policy.Policy, len(testCustomVersionedPolicies.Policies())*3)
-	it.decodeVersionedPolicies()
+	it.cachedPoliciesList = make(policy.PoliciesList, len(testSingleCustomStagedPolicies)*3)
+	it.decodePoliciesList()
 	require.NoError(t, it.Err())
-	_, vp := it.Value()
-	require.Equal(t, testCustomVersionedPolicies, vp)
-	require.Equal(t, len(it.policies), len(testCustomVersionedPolicies.Policies()))
+	_, pl := it.Value()
+	require.Equal(t, testSingleCustomStagedPolicies, pl)
+	require.Equal(t, len(it.cachedPolicies), len(testSingleCustomStagedPolicies))
+	require.Equal(t, it.cachedPolicies[0], testSingleCustomStagedPolicies[0].Policies())
 }
 
 func TestUnaggregatedIteratorDecodeIDDecodeBytesLenError(t *testing.T) {
@@ -260,9 +262,9 @@ func TestUnaggregatedIteratorDecodeBatchTimerWithAllocPoolAlloc(t *testing.T) {
 }
 
 func TestUnaggregatedIteratorDecodeNewerVersionThanSupported(t *testing.T) {
-	input := metricWithPolicies{
-		metric:            testCounter,
-		versionedPolicies: testDefaultVersionedPolicies,
+	input := metricWithPoliciesList{
+		metric:       testCounter,
+		policiesList: testDefaultStagedPolicies,
 	}
 	enc := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
 
@@ -272,16 +274,16 @@ func TestUnaggregatedIteratorDecodeNewerVersionThanSupported(t *testing.T) {
 		enc.encodeNumObjectFields(numFieldsForType(rootObjectType))
 		enc.encodeObjectType(objType)
 	}
-	require.NoError(t, testUnaggregatedEncode(t, enc, input.metric, input.versionedPolicies))
+	require.NoError(t, testUnaggregatedEncode(t, enc, input.metric, input.policiesList))
 
 	// Now restore the encode top-level function and encode another counter.
 	enc.encodeRootObjectFn = enc.encodeRootObject
-	require.NoError(t, testUnaggregatedEncode(t, enc, input.metric, input.versionedPolicies))
+	require.NoError(t, testUnaggregatedEncode(t, enc, input.metric, input.policiesList))
 
 	// Check that we skipped the first counter and successfully decoded the second counter.
 	it := testUnaggregatedIterator(t, bytes.NewBuffer(enc.Encoder().Bytes()))
 	it.(*unaggregatedIterator).ignoreHigherVersion = true
-	validateUnaggregatedDecodeResults(t, it, []metricWithPolicies{input}, io.EOF)
+	validateUnaggregatedDecodeResults(t, it, []metricWithPoliciesList{input}, io.EOF)
 
 	it.Reset(bytes.NewBuffer(enc.Encoder().Bytes()))
 	it.(*unaggregatedIterator).ignoreHigherVersion = false
@@ -289,9 +291,9 @@ func TestUnaggregatedIteratorDecodeNewerVersionThanSupported(t *testing.T) {
 }
 
 func TestUnaggregatedIteratorDecodeRootObjectMoreFieldsThanExpected(t *testing.T) {
-	input := metricWithPolicies{
-		metric:            testCounter,
-		versionedPolicies: testDefaultVersionedPolicies,
+	input := metricWithPoliciesList{
+		metric:       testCounter,
+		policiesList: testDefaultStagedPolicies,
 	}
 	enc := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
 
@@ -301,43 +303,43 @@ func TestUnaggregatedIteratorDecodeRootObjectMoreFieldsThanExpected(t *testing.T
 		enc.encodeNumObjectFields(numFieldsForType(rootObjectType) + 1)
 		enc.encodeObjectType(objType)
 	}
-	testUnaggregatedEncode(t, enc, input.metric, input.versionedPolicies)
+	testUnaggregatedEncode(t, enc, input.metric, input.policiesList)
 	enc.encodeVarint(0)
 	require.NoError(t, enc.err())
 
 	it := testUnaggregatedIterator(t, enc.Encoder().Buffer())
 
 	// Check that we successfully decoded the counter.
-	validateUnaggregatedDecodeResults(t, it, []metricWithPolicies{input}, io.EOF)
+	validateUnaggregatedDecodeResults(t, it, []metricWithPoliciesList{input}, io.EOF)
 }
 
 func TestUnaggregatedIteratorDecodeCounterWithPoliciesMoreFieldsThanExpected(t *testing.T) {
-	input := metricWithPolicies{
-		metric:            testCounter,
-		versionedPolicies: testDefaultVersionedPolicies,
+	input := metricWithPoliciesList{
+		metric:       testCounter,
+		policiesList: testDefaultStagedPolicies,
 	}
 	enc := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
 
 	// Pretend we added an extra int field to the counter with policies object.
-	enc.encodeCounterWithPoliciesFn = func(cp unaggregated.CounterWithPolicies) {
-		enc.encodeNumObjectFields(numFieldsForType(counterWithPoliciesType) + 1)
+	enc.encodeCounterWithPoliciesListFn = func(cp unaggregated.CounterWithPoliciesList) {
+		enc.encodeNumObjectFields(numFieldsForType(counterWithPoliciesListType) + 1)
 		enc.encodeCounterFn(cp.Counter)
-		enc.encodeVersionedPoliciesFn(cp.VersionedPolicies)
+		enc.encodePoliciesListFn(cp.PoliciesList)
 		enc.encodeVarint(0)
 	}
-	testUnaggregatedEncode(t, enc, input.metric, input.versionedPolicies)
+	testUnaggregatedEncode(t, enc, input.metric, input.policiesList)
 	require.NoError(t, enc.err())
 
 	it := testUnaggregatedIterator(t, enc.Encoder().Buffer())
 
 	// Check that we successfully decoded the counter.
-	validateUnaggregatedDecodeResults(t, it, []metricWithPolicies{input}, io.EOF)
+	validateUnaggregatedDecodeResults(t, it, []metricWithPoliciesList{input}, io.EOF)
 }
 
 func TestUnaggregatedIteratorDecodeCounterMoreFieldsThanExpected(t *testing.T) {
-	input := metricWithPolicies{
-		metric:            testCounter,
-		versionedPolicies: testDefaultVersionedPolicies,
+	input := metricWithPoliciesList{
+		metric:       testCounter,
+		policiesList: testDefaultStagedPolicies,
 	}
 	enc := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
 
@@ -348,18 +350,18 @@ func TestUnaggregatedIteratorDecodeCounterMoreFieldsThanExpected(t *testing.T) {
 		enc.encodeVarint(int64(c.Value))
 		enc.encodeVarint(0)
 	}
-	require.NoError(t, testUnaggregatedEncode(t, enc, input.metric, input.versionedPolicies))
+	require.NoError(t, testUnaggregatedEncode(t, enc, input.metric, input.policiesList))
 
 	it := testUnaggregatedIterator(t, enc.Encoder().Buffer())
 
 	// Check that we successfully decoded the counter.
-	validateUnaggregatedDecodeResults(t, it, []metricWithPolicies{input}, io.EOF)
+	validateUnaggregatedDecodeResults(t, it, []metricWithPoliciesList{input}, io.EOF)
 }
 
 func TestUnaggregatedIteratorDecodeBatchTimerMoreFieldsThanExpected(t *testing.T) {
-	input := metricWithPolicies{
-		metric:            testBatchTimer,
-		versionedPolicies: testDefaultVersionedPolicies,
+	input := metricWithPoliciesList{
+		metric:       testBatchTimer,
+		policiesList: testDefaultStagedPolicies,
 	}
 	enc := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
 
@@ -373,18 +375,18 @@ func TestUnaggregatedIteratorDecodeBatchTimerMoreFieldsThanExpected(t *testing.T
 		}
 		enc.encodeVarint(0)
 	}
-	require.NoError(t, testUnaggregatedEncode(t, enc, input.metric, input.versionedPolicies))
+	require.NoError(t, testUnaggregatedEncode(t, enc, input.metric, input.policiesList))
 
 	it := testUnaggregatedIterator(t, enc.Encoder().Buffer())
 
 	// Check that we successfully decoded the batch timer.
-	validateUnaggregatedDecodeResults(t, it, []metricWithPolicies{input}, io.EOF)
+	validateUnaggregatedDecodeResults(t, it, []metricWithPoliciesList{input}, io.EOF)
 }
 
 func TestUnaggregatedIteratorDecodeGaugeMoreFieldsThanExpected(t *testing.T) {
-	input := metricWithPolicies{
-		metric:            testGauge,
-		versionedPolicies: testDefaultVersionedPolicies,
+	input := metricWithPoliciesList{
+		metric:       testGauge,
+		policiesList: testDefaultStagedPolicies,
 	}
 	enc := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
 
@@ -395,64 +397,70 @@ func TestUnaggregatedIteratorDecodeGaugeMoreFieldsThanExpected(t *testing.T) {
 		enc.encodeFloat64(g.Value)
 		enc.encodeVarint(0)
 	}
-	require.NoError(t, testUnaggregatedEncode(t, enc, input.metric, input.versionedPolicies))
+	require.NoError(t, testUnaggregatedEncode(t, enc, input.metric, input.policiesList))
 
 	it := testUnaggregatedIterator(t, enc.Encoder().Buffer())
 
 	// Check that we successfully decoded the gauge.
-	validateUnaggregatedDecodeResults(t, it, []metricWithPolicies{input}, io.EOF)
+	validateUnaggregatedDecodeResults(t, it, []metricWithPoliciesList{input}, io.EOF)
 }
 
 func TestUnaggregatedIteratorDecodePolicyWithCustomResolution(t *testing.T) {
-	input := metricWithPolicies{
+	input := metricWithPoliciesList{
 		metric: testGauge,
-		versionedPolicies: policy.CustomVersionedPolicies(
-			1,
-			time.Now(),
-			[]policy.Policy{
-				policy.NewPolicy(3*time.Second, xtime.Second, time.Hour),
-			},
-		),
+		policiesList: policy.PoliciesList{
+			policy.NewStagedPolicies(
+				time.Now().UnixNano(),
+				false,
+				[]policy.Policy{
+					policy.NewPolicy(3*time.Second, xtime.Second, time.Hour),
+				},
+			),
+		},
 	}
 	enc := testUnaggregatedEncoder(t)
-	require.NoError(t, testUnaggregatedEncode(t, enc, input.metric, input.versionedPolicies))
+	require.NoError(t, testUnaggregatedEncode(t, enc, input.metric, input.policiesList))
 
 	it := testUnaggregatedIterator(t, enc.Encoder().Buffer())
 
 	// Check that we successfully decoded the policy.
-	validateUnaggregatedDecodeResults(t, it, []metricWithPolicies{input}, io.EOF)
+	validateUnaggregatedDecodeResults(t, it, []metricWithPoliciesList{input}, io.EOF)
 }
 
 func TestUnaggregatedIteratorDecodePolicyWithCustomRetention(t *testing.T) {
-	input := metricWithPolicies{
+	input := metricWithPoliciesList{
 		metric: testGauge,
-		versionedPolicies: policy.CustomVersionedPolicies(
-			1,
-			time.Now(),
-			[]policy.Policy{
-				policy.NewPolicy(time.Second, xtime.Second, 289*time.Hour),
-			},
-		),
+		policiesList: policy.PoliciesList{
+			policy.NewStagedPolicies(
+				time.Now().UnixNano(),
+				false,
+				[]policy.Policy{
+					policy.NewPolicy(time.Second, xtime.Second, 289*time.Hour),
+				},
+			),
+		},
 	}
 	enc := testUnaggregatedEncoder(t)
-	require.NoError(t, testUnaggregatedEncode(t, enc, input.metric, input.versionedPolicies))
+	require.NoError(t, testUnaggregatedEncode(t, enc, input.metric, input.policiesList))
 
 	it := testUnaggregatedIterator(t, enc.Encoder().Buffer())
 
 	// Check that we successfully decoded the policy.
-	validateUnaggregatedDecodeResults(t, it, []metricWithPolicies{input}, io.EOF)
+	validateUnaggregatedDecodeResults(t, it, []metricWithPoliciesList{input}, io.EOF)
 }
 
 func TestUnaggregatedIteratorDecodePolicyMoreFieldsThanExpected(t *testing.T) {
-	input := metricWithPolicies{
+	input := metricWithPoliciesList{
 		metric: testGauge,
-		versionedPolicies: policy.CustomVersionedPolicies(
-			1,
-			time.Now(),
-			[]policy.Policy{
-				policy.NewPolicy(time.Second, xtime.Second, time.Hour),
-			},
-		),
+		policiesList: policy.PoliciesList{
+			policy.NewStagedPolicies(
+				time.Now().UnixNano(),
+				true,
+				[]policy.Policy{
+					policy.NewPolicy(time.Second, xtime.Second, time.Hour),
+				},
+			),
+		},
 	}
 	enc := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
 	baseEncoder := enc.encoderBase.(*baseEncoder)
@@ -464,52 +472,43 @@ func TestUnaggregatedIteratorDecodePolicyMoreFieldsThanExpected(t *testing.T) {
 		baseEncoder.encodeRetention(p.Retention())
 		baseEncoder.encodeVarint(0)
 	}
-	require.NoError(t, testUnaggregatedEncode(t, enc, input.metric, input.versionedPolicies))
+	require.NoError(t, testUnaggregatedEncode(t, enc, input.metric, input.policiesList))
 
 	it := testUnaggregatedIterator(t, enc.Encoder().Buffer())
 
 	// Check that we successfully decoded the policy.
-	validateUnaggregatedDecodeResults(t, it, []metricWithPolicies{input}, io.EOF)
+	validateUnaggregatedDecodeResults(t, it, []metricWithPoliciesList{input}, io.EOF)
 }
 
-func TestUnaggregatedIteratorDecodeVersionedPoliciesMoreFieldsThanExpected(t *testing.T) {
-	input := metricWithPolicies{
-		metric: testGauge,
-		versionedPolicies: policy.CustomVersionedPolicies(
-			1,
-			time.Now(),
-			[]policy.Policy{
-				policy.NewPolicy(time.Second, xtime.Second, time.Hour),
-			},
-		),
+func TestUnaggregatedIteratorDecodePoliciesListMoreFieldsThanExpected(t *testing.T) {
+	input := metricWithPoliciesList{
+		metric:       testGauge,
+		policiesList: testSingleCustomStagedPolicies,
 	}
 	enc := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
 
 	// Pretend we added an extra int field to the policy object.
-	enc.encodeVersionedPoliciesFn = func(vp policy.VersionedPolicies) {
-		enc.encodeNumObjectFields(numFieldsForType(customVersionedPoliciesType) + 1)
-		enc.encodeObjectType(customVersionedPoliciesType)
-		enc.encodeVersion(vp.Version)
-		enc.encodeTime(vp.Cutover)
-		policies := vp.Policies()
-		enc.encodeArrayLen(len(policies))
-		for _, policy := range policies {
-			enc.encodePolicy(policy)
+	enc.encodePoliciesListFn = func(pl policy.PoliciesList) {
+		enc.encodeNumObjectFields(numFieldsForType(customPoliciesListType) + 1)
+		enc.encodeObjectType(customPoliciesListType)
+		enc.encodeArrayLen(len(pl))
+		for _, sp := range pl {
+			enc.encodeStagedPolicies(sp)
 		}
 		enc.encodeVarint(0)
 	}
-	require.NoError(t, testUnaggregatedEncode(t, enc, input.metric, input.versionedPolicies))
+	require.NoError(t, testUnaggregatedEncode(t, enc, input.metric, input.policiesList))
 
 	it := testUnaggregatedIterator(t, enc.Encoder().Buffer())
 
 	// Check that we successfully decoded the policy.
-	validateUnaggregatedDecodeResults(t, it, []metricWithPolicies{input}, io.EOF)
+	validateUnaggregatedDecodeResults(t, it, []metricWithPoliciesList{input}, io.EOF)
 }
 
 func TestUnaggregatedIteratorDecodeCounterFewerFieldsThanExpected(t *testing.T) {
-	input := metricWithPolicies{
-		metric:            testCounter,
-		versionedPolicies: testDefaultVersionedPolicies,
+	input := metricWithPoliciesList{
+		metric:       testCounter,
+		policiesList: testDefaultStagedPolicies,
 	}
 	enc := testUnaggregatedEncoder(t).(*unaggregatedEncoder)
 
@@ -518,7 +517,7 @@ func TestUnaggregatedIteratorDecodeCounterFewerFieldsThanExpected(t *testing.T) 
 		enc.encodeNumObjectFields(numFieldsForType(counterType) - 1)
 		enc.encodeID(c.ID)
 	}
-	require.NoError(t, testUnaggregatedEncode(t, enc, input.metric, input.versionedPolicies))
+	require.NoError(t, testUnaggregatedEncode(t, enc, input.metric, input.policiesList))
 
 	it := testUnaggregatedIterator(t, enc.Encoder().Buffer())
 
@@ -554,12 +553,12 @@ func TestUnaggregatedIteratorClose(t *testing.T) {
 }
 
 func TestUnaggregatedIteratorDecodeInvalidTimeUnit(t *testing.T) {
-	input := metricWithPolicies{
-		metric:            testCounter,
-		versionedPolicies: testVersionedPoliciesWithInvalidTimeUnit,
+	input := metricWithPoliciesList{
+		metric:       testCounter,
+		policiesList: testStagedPoliciesWithInvalidTimeUnit,
 	}
 	enc := testUnaggregatedEncoder(t)
-	require.NoError(t, testUnaggregatedEncode(t, enc, input.metric, input.versionedPolicies))
+	require.NoError(t, testUnaggregatedEncode(t, enc, input.metric, input.policiesList))
 	it := testUnaggregatedIterator(t, enc.Encoder().Buffer())
 	validateUnaggregatedDecodeResults(t, it, nil, errors.New("invalid precision unknown"))
 }
@@ -567,16 +566,16 @@ func TestUnaggregatedIteratorDecodeInvalidTimeUnit(t *testing.T) {
 func validateUnaggregatedDecodeResults(
 	t *testing.T,
 	it UnaggregatedIterator,
-	expectedResults []metricWithPolicies,
+	expectedResults []metricWithPoliciesList,
 	expectedErr error,
 ) {
-	var results []metricWithPolicies
+	var results []metricWithPoliciesList
 	for it.Next() {
-		value, policies := it.Value()
-		policies = toVersionedPolicies(t, policies)
-		results = append(results, metricWithPolicies{
-			metric:            value,
-			versionedPolicies: policies,
+		value, policiesList := it.Value()
+		policiesList = toPoliciesList(t, policiesList)
+		results = append(results, metricWithPoliciesList{
+			metric:       value,
+			policiesList: policiesList,
 		})
 	}
 	require.Equal(t, expectedErr, it.Err())

--- a/protocol/msgpack/unaggregated_roundtrip_test.go
+++ b/protocol/msgpack/unaggregated_roundtrip_test.go
@@ -54,9 +54,9 @@ var (
 		GaugeVal: 123.456,
 	}
 
-	testDefaultStagedPolicies = policy.DefaultPoliciesList
+	testDefaultStagedPoliciesList = policy.DefaultPoliciesList
 
-	testSingleCustomStagedPolicies = policy.PoliciesList{
+	testSingleCustomStagedPoliciesList = policy.PoliciesList{
 		policy.NewStagedPolicies(
 			time.Now().UnixNano(),
 			false,
@@ -64,6 +64,25 @@ var (
 				policy.NewPolicy(20*time.Second, xtime.Second, 6*time.Hour),
 				policy.NewPolicy(time.Minute, xtime.Minute, 2*24*time.Hour),
 				policy.NewPolicy(10*time.Minute, xtime.Minute, 25*24*time.Hour),
+			},
+		),
+	}
+
+	testMultiCustomStagedPoliciesList = policy.PoliciesList{
+		policy.NewStagedPolicies(
+			time.Now().UnixNano(),
+			false,
+			[]policy.Policy{
+				policy.NewPolicy(20*time.Second, xtime.Second, 6*time.Hour),
+				policy.NewPolicy(time.Minute, xtime.Minute, 2*24*time.Hour),
+				policy.NewPolicy(10*time.Minute, xtime.Minute, 25*24*time.Hour),
+			},
+		),
+		policy.NewStagedPolicies(
+			time.Now().Add(time.Minute).UnixNano(),
+			true,
+			[]policy.Policy{
+				policy.NewPolicy(time.Second, xtime.Second, time.Hour),
 			},
 		),
 	}
@@ -78,22 +97,22 @@ var (
 		),
 	}
 
-	testInputWithAllTypesAndDefaultPolicies = []metricWithPoliciesList{
+	testInputWithAllTypesAndDefaultPoliciesList = []metricWithPoliciesList{
 		{
 			metric:       testCounter,
-			policiesList: testDefaultStagedPolicies,
+			policiesList: testDefaultStagedPoliciesList,
 		},
 		{
 			metric:       testBatchTimer,
-			policiesList: testDefaultStagedPolicies,
+			policiesList: testDefaultStagedPoliciesList,
 		},
 		{
 			metric:       testGauge,
-			policiesList: testDefaultStagedPolicies,
+			policiesList: testDefaultStagedPoliciesList,
 		},
 	}
 
-	testInputWithAllTypesAndSingleCustomPolicies = []metricWithPoliciesList{
+	testInputWithAllTypesAndSingleCustomPoliciesList = []metricWithPoliciesList{
 		// Retain this metric at 20 second resolution for 6 hours,
 		// then 1 minute for 2 days, then 10 minutes for 25 days.
 		{
@@ -137,35 +156,101 @@ var (
 			},
 		},
 	}
+
+	testInputWithAllTypesAndMultiCustomPoliciesList = []metricWithPoliciesList{
+		{
+			metric: testBatchTimer,
+			policiesList: policy.PoliciesList{
+				policy.NewStagedPolicies(
+					time.Now().UnixNano(),
+					false,
+					[]policy.Policy{
+						policy.NewPolicy(20*time.Second, xtime.Second, 6*time.Hour),
+						policy.NewPolicy(time.Minute, xtime.Minute, 2*24*time.Hour),
+						policy.NewPolicy(10*time.Minute, xtime.Minute, 25*24*time.Hour),
+					},
+				),
+				policy.NewStagedPolicies(
+					time.Now().Add(time.Minute).UnixNano(),
+					true,
+					[]policy.Policy{
+						policy.NewPolicy(time.Second, xtime.Second, time.Hour),
+					},
+				),
+			},
+		},
+		{
+			metric: testCounter,
+			policiesList: policy.PoliciesList{
+				policy.NewStagedPolicies(
+					time.Now().UnixNano(),
+					true,
+					[]policy.Policy{
+						policy.NewPolicy(time.Second, xtime.Second, time.Hour),
+					},
+				),
+				policy.NewStagedPolicies(
+					time.Now().Add(time.Hour).UnixNano(),
+					false,
+					[]policy.Policy{
+						policy.NewPolicy(10*time.Minute, xtime.Minute, 45*24*time.Hour),
+					},
+				),
+			},
+		},
+		{
+			metric: testGauge,
+			policiesList: policy.PoliciesList{
+				policy.NewStagedPolicies(
+					time.Now().UnixNano(),
+					false,
+					[]policy.Policy{
+						policy.NewPolicy(10*time.Minute, xtime.Minute, 45*24*time.Hour),
+					},
+				),
+				policy.NewStagedPolicies(
+					time.Now().Add(time.Nanosecond).UnixNano(),
+					false,
+					[]policy.Policy{
+						policy.NewPolicy(5*time.Minute, xtime.Minute, 36*time.Hour),
+					},
+				),
+			},
+		},
+	}
 )
 
-func TestUnaggregatedEncodeDecodeCounterWithDefaultPolicies(t *testing.T) {
+func TestUnaggregatedEncodeDecodeCounterWithDefaultPoliciesList(t *testing.T) {
 	validateUnaggregatedRoundtrip(t, metricWithPoliciesList{
 		metric:       testCounter,
-		policiesList: testDefaultStagedPolicies,
+		policiesList: testDefaultStagedPoliciesList,
 	})
 }
 
-func TestUnaggregatedEncodeDecodeBatchTimerWithDefaultPolicies(t *testing.T) {
+func TestUnaggregatedEncodeDecodeBatchTimerWithDefaultPoliciesList(t *testing.T) {
 	validateUnaggregatedRoundtrip(t, metricWithPoliciesList{
 		metric:       testBatchTimer,
-		policiesList: testDefaultStagedPolicies,
+		policiesList: testDefaultStagedPoliciesList,
 	})
 }
 
-func TestUnaggregatedEncodeDecodeGaugeWithDefaultPolicies(t *testing.T) {
+func TestUnaggregatedEncodeDecodeGaugeWithDefaultPoliciesList(t *testing.T) {
 	validateUnaggregatedRoundtrip(t, metricWithPoliciesList{
 		metric:       testGauge,
-		policiesList: testDefaultStagedPolicies,
+		policiesList: testDefaultStagedPoliciesList,
 	})
 }
 
-func TestUnaggregatedEncodeDecodeAllTypesWithDefaultPolicies(t *testing.T) {
-	validateUnaggregatedRoundtrip(t, testInputWithAllTypesAndDefaultPolicies...)
+func TestUnaggregatedEncodeDecodeAllTypesWithDefaultPoliciesList(t *testing.T) {
+	validateUnaggregatedRoundtrip(t, testInputWithAllTypesAndDefaultPoliciesList...)
 }
 
-func TestUnaggregatedEncodeDecodeAllTypesWithCustomPolicies(t *testing.T) {
-	validateUnaggregatedRoundtrip(t, testInputWithAllTypesAndSingleCustomPolicies...)
+func TestUnaggregatedEncodeDecodeAllTypesWithSingleCustomPoliciesList(t *testing.T) {
+	validateUnaggregatedRoundtrip(t, testInputWithAllTypesAndSingleCustomPoliciesList...)
+}
+
+func TestUnaggregatedEncodeDecodeAllTypesWithMultiCustomPoliciesList(t *testing.T) {
+	validateUnaggregatedRoundtrip(t, testInputWithAllTypesAndMultiCustomPoliciesList...)
 }
 
 func TestUnaggregatedEncodeDecodeStress(t *testing.T) {
@@ -173,7 +258,7 @@ func TestUnaggregatedEncodeDecodeStress(t *testing.T) {
 	numMetrics := 10000
 	allMetrics := []unaggregated.MetricUnion{testCounter, testBatchTimer, testGauge}
 	allPolicies := []policy.PoliciesList{
-		testDefaultStagedPolicies,
+		testDefaultStagedPoliciesList,
 		policy.PoliciesList{
 			policy.NewStagedPolicies(
 				time.Now().UnixNano(),
@@ -182,6 +267,29 @@ func TestUnaggregatedEncodeDecodeStress(t *testing.T) {
 					policy.NewPolicy(time.Second, xtime.Second, 6*time.Hour),
 					policy.NewPolicy(time.Minute, xtime.Minute, 2*24*time.Hour),
 				},
+			),
+		},
+		policy.PoliciesList{
+			policy.NewStagedPolicies(
+				time.Now().UnixNano(),
+				false,
+				[]policy.Policy{
+					policy.NewPolicy(20*time.Second, xtime.Second, 6*time.Hour),
+					policy.NewPolicy(time.Minute, xtime.Minute, 2*24*time.Hour),
+					policy.NewPolicy(10*time.Minute, xtime.Minute, 25*24*time.Hour),
+				},
+			),
+			policy.NewStagedPolicies(
+				time.Now().Add(time.Minute).UnixNano(),
+				true,
+				[]policy.Policy{
+					policy.NewPolicy(time.Second, xtime.Second, time.Hour),
+				},
+			),
+			policy.NewStagedPolicies(
+				time.Now().Add(time.Minute).UnixNano(),
+				false,
+				[]policy.Policy{},
 			),
 		},
 	}
@@ -275,6 +383,15 @@ func compareUnaggregatedMetric(t *testing.T, expected unaggregated.MetricUnion, 
 	}
 }
 
+func comparedPoliciesList(t *testing.T, expected policy.PoliciesList, actual policy.PoliciesList) {
+	require.Equal(t, len(expected), len(actual))
+	for i := 0; i < len(expected); i++ {
+		require.Equal(t, expected[i].CutoverNs, actual[i].CutoverNs)
+		require.Equal(t, expected[i].Tombstoned, actual[i].Tombstoned)
+		require.Equal(t, expected[i].Policies(), actual[i].Policies())
+	}
+}
+
 func validateUnaggregatedRoundtrip(t *testing.T, inputs ...metricWithPoliciesList) {
 	encoder := testUnaggregatedEncoder(t)
 	it := testUnaggregatedIterator(t, nil)
@@ -313,14 +430,14 @@ func validateUnaggregatedRoundtripWithEncoderAndIterator(
 
 	// Assert the results match expectations.
 	require.Equal(t, io.EOF, it.Err())
-	validateMetricsWithPolicies(t, inputs, results)
+	validateMetricsWithPoliciesList(t, inputs, results)
 }
 
-func validateMetricsWithPolicies(t *testing.T, inputs, results []metricWithPoliciesList) {
+func validateMetricsWithPoliciesList(t *testing.T, inputs, results []metricWithPoliciesList) {
 	require.Equal(t, len(inputs), len(results))
 	for i := 0; i < len(inputs); i++ {
 		compareUnaggregatedMetric(t, inputs[i].metric, results[i].metric)
-		require.Equal(t, inputs[i].policiesList, results[i].policiesList)
+		comparedPoliciesList(t, inputs[i].policiesList, results[i].policiesList)
 	}
 }
 

--- a/protocol/msgpack/unaggregated_roundtrip_test.go
+++ b/protocol/msgpack/unaggregated_roundtrip_test.go
@@ -54,102 +54,109 @@ var (
 		GaugeVal: 123.456,
 	}
 
-	testDefaultVersionedPolicies = policy.DefaultVersionedPolicies(
-		policy.DefaultPolicyVersion,
-		time.Now(),
-	)
+	testDefaultStagedPolicies = policy.DefaultPoliciesList
 
-	testCustomVersionedPolicies = policy.CustomVersionedPolicies(
-		2,
-		time.Now(),
-		[]policy.Policy{
-			policy.NewPolicy(20*time.Second, xtime.Second, 6*time.Hour),
-			policy.NewPolicy(time.Minute, xtime.Minute, 2*24*time.Hour),
-			policy.NewPolicy(10*time.Minute, xtime.Minute, 25*24*time.Hour),
-		},
-	)
+	testSingleCustomStagedPolicies = policy.PoliciesList{
+		policy.NewStagedPolicies(
+			time.Now().UnixNano(),
+			false,
+			[]policy.Policy{
+				policy.NewPolicy(20*time.Second, xtime.Second, 6*time.Hour),
+				policy.NewPolicy(time.Minute, xtime.Minute, 2*24*time.Hour),
+				policy.NewPolicy(10*time.Minute, xtime.Minute, 25*24*time.Hour),
+			},
+		),
+	}
 
-	testVersionedPoliciesWithInvalidTimeUnit = policy.CustomVersionedPolicies(
-		1,
-		time.Now(),
-		[]policy.Policy{
-			policy.NewPolicy(time.Second, xtime.Unit(100), time.Hour),
-		},
-	)
+	testStagedPoliciesWithInvalidTimeUnit = policy.PoliciesList{
+		policy.NewStagedPolicies(
+			time.Now().UnixNano(),
+			true,
+			[]policy.Policy{
+				policy.NewPolicy(time.Second, xtime.Unit(100), time.Hour),
+			},
+		),
+	}
 
-	testInputWithAllTypesAndDefaultPolicies = []metricWithPolicies{
+	testInputWithAllTypesAndDefaultPolicies = []metricWithPoliciesList{
 		{
-			metric:            testCounter,
-			versionedPolicies: testDefaultVersionedPolicies,
-		},
-		{
-			metric:            testBatchTimer,
-			versionedPolicies: testDefaultVersionedPolicies,
+			metric:       testCounter,
+			policiesList: testDefaultStagedPolicies,
 		},
 		{
-			metric:            testGauge,
-			versionedPolicies: testDefaultVersionedPolicies,
+			metric:       testBatchTimer,
+			policiesList: testDefaultStagedPolicies,
+		},
+		{
+			metric:       testGauge,
+			policiesList: testDefaultStagedPolicies,
 		},
 	}
 
-	testInputWithAllTypesAndCustomPolicies = []metricWithPolicies{
+	testInputWithAllTypesAndSingleCustomPolicies = []metricWithPoliciesList{
 		// Retain this metric at 20 second resolution for 6 hours,
 		// then 1 minute for 2 days, then 10 minutes for 25 days.
 		{
 			metric: testBatchTimer,
-			versionedPolicies: policy.CustomVersionedPolicies(
-				2,
-				time.Now(),
-				[]policy.Policy{
-					policy.NewPolicy(20*time.Second, xtime.Second, 6*time.Hour),
-					policy.NewPolicy(time.Minute, xtime.Minute, 2*24*time.Hour),
-					policy.NewPolicy(10*time.Minute, xtime.Minute, 25*24*time.Hour),
-				},
-			),
+			policiesList: policy.PoliciesList{
+				policy.NewStagedPolicies(
+					time.Now().UnixNano(),
+					false,
+					[]policy.Policy{
+						policy.NewPolicy(20*time.Second, xtime.Second, 6*time.Hour),
+						policy.NewPolicy(time.Minute, xtime.Minute, 2*24*time.Hour),
+						policy.NewPolicy(10*time.Minute, xtime.Minute, 25*24*time.Hour),
+					},
+				),
+			},
 		},
 		// Retain this metric at 1 second resolution for 1 hour.
 		{
 			metric: testCounter,
-			versionedPolicies: policy.CustomVersionedPolicies(
-				1,
-				time.Now(),
-				[]policy.Policy{
-					policy.NewPolicy(time.Second, xtime.Second, time.Hour),
-				},
-			),
+			policiesList: policy.PoliciesList{
+				policy.NewStagedPolicies(
+					time.Now().UnixNano(),
+					true,
+					[]policy.Policy{
+						policy.NewPolicy(time.Second, xtime.Second, time.Hour),
+					},
+				),
+			},
 		},
 		// Retain this metric at 10 minute resolution for 45 days.
 		{
 			metric: testGauge,
-			versionedPolicies: policy.CustomVersionedPolicies(
-				2,
-				time.Now(),
-				[]policy.Policy{
-					policy.NewPolicy(10*time.Minute, xtime.Minute, 45*24*time.Hour),
-				},
-			),
+			policiesList: policy.PoliciesList{
+				policy.NewStagedPolicies(
+					time.Now().UnixNano(),
+					false,
+					[]policy.Policy{
+						policy.NewPolicy(10*time.Minute, xtime.Minute, 45*24*time.Hour),
+					},
+				),
+			},
 		},
 	}
 )
 
 func TestUnaggregatedEncodeDecodeCounterWithDefaultPolicies(t *testing.T) {
-	validateUnaggregatedRoundtrip(t, metricWithPolicies{
-		metric:            testCounter,
-		versionedPolicies: testDefaultVersionedPolicies,
+	validateUnaggregatedRoundtrip(t, metricWithPoliciesList{
+		metric:       testCounter,
+		policiesList: testDefaultStagedPolicies,
 	})
 }
 
 func TestUnaggregatedEncodeDecodeBatchTimerWithDefaultPolicies(t *testing.T) {
-	validateUnaggregatedRoundtrip(t, metricWithPolicies{
-		metric:            testBatchTimer,
-		versionedPolicies: testDefaultVersionedPolicies,
+	validateUnaggregatedRoundtrip(t, metricWithPoliciesList{
+		metric:       testBatchTimer,
+		policiesList: testDefaultStagedPolicies,
 	})
 }
 
 func TestUnaggregatedEncodeDecodeGaugeWithDefaultPolicies(t *testing.T) {
-	validateUnaggregatedRoundtrip(t, metricWithPolicies{
-		metric:            testGauge,
-		versionedPolicies: testDefaultVersionedPolicies,
+	validateUnaggregatedRoundtrip(t, metricWithPoliciesList{
+		metric:       testGauge,
+		policiesList: testDefaultStagedPolicies,
 	})
 }
 
@@ -158,51 +165,53 @@ func TestUnaggregatedEncodeDecodeAllTypesWithDefaultPolicies(t *testing.T) {
 }
 
 func TestUnaggregatedEncodeDecodeAllTypesWithCustomPolicies(t *testing.T) {
-	validateUnaggregatedRoundtrip(t, testInputWithAllTypesAndCustomPolicies...)
+	validateUnaggregatedRoundtrip(t, testInputWithAllTypesAndSingleCustomPolicies...)
 }
 
 func TestUnaggregatedEncodeDecodeStress(t *testing.T) {
 	numIter := 10
 	numMetrics := 10000
 	allMetrics := []unaggregated.MetricUnion{testCounter, testBatchTimer, testGauge}
-	allPolicies := []policy.VersionedPolicies{
-		testDefaultVersionedPolicies,
-		policy.CustomVersionedPolicies(
-			2,
-			time.Now(),
-			[]policy.Policy{
-				policy.NewPolicy(time.Second, xtime.Second, 6*time.Hour),
-				policy.NewPolicy(time.Minute, xtime.Minute, 2*24*time.Hour),
-			},
-		),
+	allPolicies := []policy.PoliciesList{
+		testDefaultStagedPolicies,
+		policy.PoliciesList{
+			policy.NewStagedPolicies(
+				time.Now().UnixNano(),
+				false,
+				[]policy.Policy{
+					policy.NewPolicy(time.Second, xtime.Second, 6*time.Hour),
+					policy.NewPolicy(time.Minute, xtime.Minute, 2*24*time.Hour),
+				},
+			),
+		},
 	}
 
 	encoder := testUnaggregatedEncoder(t)
 	iterator := testUnaggregatedIterator(t, nil)
 	for i := 0; i < numIter; i++ {
-		var inputs []metricWithPolicies
+		var inputs []metricWithPoliciesList
 		for j := 0; j < numMetrics; j++ {
 			m := allMetrics[rand.Int63n(int64(len(allMetrics)))]
 			p := allPolicies[rand.Int63n(int64(len(allPolicies)))]
-			inputs = append(inputs, metricWithPolicies{metric: m, versionedPolicies: p})
+			inputs = append(inputs, metricWithPoliciesList{metric: m, policiesList: p})
 		}
 		validateUnaggregatedRoundtripWithEncoderAndIterator(t, encoder, iterator, inputs...)
 	}
 }
 
-type metricWithPolicies struct {
-	metric            unaggregated.MetricUnion
-	versionedPolicies policy.VersionedPolicies
+type metricWithPoliciesList struct {
+	metric       unaggregated.MetricUnion
+	policiesList policy.PoliciesList
 }
 
 func testCapturingBaseEncoder(encoder encoderBase) *[]interface{} {
 	baseEncoder := encoder.(*baseEncoder)
 
 	var result []interface{}
-	baseEncoder.encodeTimeFn = func(value time.Time) {
+	baseEncoder.encodeVarintFn = func(value int64) {
 		result = append(result, value)
 	}
-	baseEncoder.encodeVarintFn = func(value int64) {
+	baseEncoder.encodeBoolFn = func(value bool) {
 		result = append(result, value)
 	}
 	baseEncoder.encodeFloat64Fn = func(value float64) {
@@ -230,22 +239,22 @@ func testUnaggregatedIterator(t *testing.T, reader io.Reader) UnaggregatedIterat
 	return NewUnaggregatedIterator(reader, opts)
 }
 
-func testUnaggregatedEncode(t *testing.T, encoder UnaggregatedEncoder, m unaggregated.MetricUnion, p policy.VersionedPolicies) error {
+func testUnaggregatedEncode(t *testing.T, encoder UnaggregatedEncoder, m unaggregated.MetricUnion, pl policy.PoliciesList) error {
 	switch m.Type {
 	case unaggregated.CounterType:
-		return encoder.EncodeCounterWithPolicies(unaggregated.CounterWithPolicies{
-			Counter:           m.Counter(),
-			VersionedPolicies: p,
+		return encoder.EncodeCounterWithPoliciesList(unaggregated.CounterWithPoliciesList{
+			Counter:      m.Counter(),
+			PoliciesList: pl,
 		})
 	case unaggregated.BatchTimerType:
-		return encoder.EncodeBatchTimerWithPolicies(unaggregated.BatchTimerWithPolicies{
-			BatchTimer:        m.BatchTimer(),
-			VersionedPolicies: p,
+		return encoder.EncodeBatchTimerWithPoliciesList(unaggregated.BatchTimerWithPoliciesList{
+			BatchTimer:   m.BatchTimer(),
+			PoliciesList: pl,
 		})
 	case unaggregated.GaugeType:
-		return encoder.EncodeGaugeWithPolicies(unaggregated.GaugeWithPolicies{
-			Gauge:             m.Gauge(),
-			VersionedPolicies: p,
+		return encoder.EncodeGaugeWithPoliciesList(unaggregated.GaugeWithPoliciesList{
+			Gauge:        m.Gauge(),
+			PoliciesList: pl,
 		})
 	default:
 		return fmt.Errorf("unrecognized metric type %v", m.Type)
@@ -266,7 +275,7 @@ func compareUnaggregatedMetric(t *testing.T, expected unaggregated.MetricUnion, 
 	}
 }
 
-func validateUnaggregatedRoundtrip(t *testing.T, inputs ...metricWithPolicies) {
+func validateUnaggregatedRoundtrip(t *testing.T, inputs ...metricWithPoliciesList) {
 	encoder := testUnaggregatedEncoder(t)
 	it := testUnaggregatedIterator(t, nil)
 	validateUnaggregatedRoundtripWithEncoderAndIterator(t, encoder, it, inputs...)
@@ -276,29 +285,29 @@ func validateUnaggregatedRoundtripWithEncoderAndIterator(
 	t *testing.T,
 	encoder UnaggregatedEncoder,
 	it UnaggregatedIterator,
-	inputs ...metricWithPolicies,
+	inputs ...metricWithPoliciesList,
 ) {
-	var results []metricWithPolicies
+	var results []metricWithPoliciesList
 
 	// Encode the batch of metrics.
 	encoder.Reset(NewBufferedEncoder())
 	for _, input := range inputs {
-		testUnaggregatedEncode(t, encoder, input.metric, input.versionedPolicies)
+		testUnaggregatedEncode(t, encoder, input.metric, input.policiesList)
 	}
 
 	// Decode the batch of metrics.
 	byteStream := bytes.NewBuffer(encoder.Encoder().Bytes())
 	it.Reset(byteStream)
 	for it.Next() {
-		m, p := it.Value()
+		m, pl := it.Value()
 
-		// Make a copy of cached policies because it becomes invalid
+		// Make a copy of cached policies list because it becomes invalid
 		// on the next Next() call.
-		p = toVersionedPolicies(t, p)
+		pl = toPoliciesList(t, pl)
 
-		results = append(results, metricWithPolicies{
-			metric:            m,
-			versionedPolicies: p,
+		results = append(results, metricWithPoliciesList{
+			metric:       m,
+			policiesList: pl,
 		})
 	}
 
@@ -307,27 +316,29 @@ func validateUnaggregatedRoundtripWithEncoderAndIterator(
 	validateMetricsWithPolicies(t, inputs, results)
 }
 
-func validateMetricsWithPolicies(t *testing.T, inputs, results []metricWithPolicies) {
+func validateMetricsWithPolicies(t *testing.T, inputs, results []metricWithPoliciesList) {
 	require.Equal(t, len(inputs), len(results))
 	for i := 0; i < len(inputs); i++ {
 		compareUnaggregatedMetric(t, inputs[i].metric, results[i].metric)
-		require.Equal(t, inputs[i].versionedPolicies, results[i].versionedPolicies)
+		require.Equal(t, inputs[i].policiesList, results[i].policiesList)
 	}
 }
 
-func toVersionedPolicies(t *testing.T, p policy.VersionedPolicies) policy.VersionedPolicies {
-	var (
-		policies          []policy.Policy
-		versionedPolicies policy.VersionedPolicies
-	)
-	versionedPolicies = p
-	if versionedPolicies.IsDefault() {
-		return versionedPolicies
-	}
-	policies = make([]policy.Policy, len(p.Policies()))
+func toStagedPolicies(t *testing.T, p policy.StagedPolicies) policy.StagedPolicies {
+	policies := make([]policy.Policy, len(p.Policies()))
 	for i, policy := range p.Policies() {
 		policies[i] = policy
 	}
-	versionedPolicies = policy.CustomVersionedPolicies(p.Version, p.Cutover, policies)
-	return versionedPolicies
+	return policy.NewStagedPolicies(p.CutoverNs, p.Tombstoned, policies)
+}
+
+func toPoliciesList(t *testing.T, pl policy.PoliciesList) policy.PoliciesList {
+	if pl.IsDefault() {
+		return policy.DefaultPoliciesList
+	}
+	policiesList := make(policy.PoliciesList, 0, len(pl))
+	for i := 0; i < len(pl); i++ {
+		policiesList = append(policiesList, toStagedPolicies(t, pl[i]))
+	}
+	return policiesList
 }

--- a/protocol/msgpack/wire_format.md
+++ b/protocol/msgpack/wire_format.md
@@ -5,24 +5,24 @@
   * Number of root object fields
   * Root object type
   * Root object (can be one of the following):
-    * CounterWithPolicies
-    * BatchTimerWithPolicies
-    * GaugeWithPolicies
+    * CounterWithPoliciesList
+    * BatchTimerWithPoliciesList
+    * GaugeWithPoliciesList
 
-* CounterWithPolicies object
-  * Number of CounterWithPolicies fields
+* CounterWithPoliciesList object
+  * Number of CounterWithPoliciesList fields
   * Counter object
-  * VersionedPolicies object
+  * PoliciesList object
 
-* BatchTimerWithPolicies object
-  * Number of BatchTimerWithPolicies fields
+* BatchTimerWithPoliciesList object
+  * Number of BatchTimerWithPoliciesList fields
   * BatchTimer object
-  * VersionedPolicies object
+  * PoliciesList object
 
-* GaugeWithPolicies object
-  * Number of GaugeWithPolicies fields
+* GaugeWithPoliciesList object
+  * Number of GaugeWithPoliciesList fields
   * Gauge object
-  * VersionedPolicies object
+  * PoliciesList object
 
 * Counter object
   * Number of Counter fields
@@ -39,16 +39,20 @@
   * Gauge ID
   * Gauge value
 
-* VersionedPolicies object
-  * Number of VersionedPolicies fields
-  * Versioned Policies (can be one of the following)
-    * DefaultVersionedPolicies
-      * Versioned Policies type
-    * CustomVersionedPolicies
-      * Versioned Policies type
-      * Version
-      * Cutover
-      * List of Policy objects
+* PoliciesList object
+  * Number of PoliciesList fields
+  * PoliciesList (can be one of the following)
+    * DefaultPoliciesList
+      * PoliciesList type
+    * CustomPoliciesList
+      * PoliciesList type
+      * List of StagedPolicies objects
+
+* StagedPolicies object
+  * Number of StagedPolicies fields
+  * Cutover
+  * Tombstoned
+  * List of Policy objects
 
 * Policy object
   * Number of Policy fields

--- a/rules/mapping.go
+++ b/rules/mapping.go
@@ -36,11 +36,11 @@ var (
 // mappingRuleSnapshot defines a rule snapshot such that if a metric matches the
 // provided filters, it is aggregated and retained under the provided set of policies.
 type mappingRuleSnapshot struct {
-	name       string
-	tombstoned bool
-	cutoverNs  int64
-	filter     filters.Filter
-	policies   []policy.Policy
+	name         string
+	tombstoned   bool
+	cutoverNanos int64
+	filter       filters.Filter
+	policies     []policy.Policy
 }
 
 func newMappingRuleSnapshot(
@@ -59,11 +59,11 @@ func newMappingRuleSnapshot(
 		return nil, err
 	}
 	return &mappingRuleSnapshot{
-		name:       r.Name,
-		tombstoned: r.Tombstoned,
-		cutoverNs:  r.CutoverTime,
-		filter:     filter,
-		policies:   policies,
+		name:         r.Name,
+		tombstoned:   r.Tombstoned,
+		cutoverNanos: r.CutoverTime,
+		filter:       filter,
+		policies:     policies,
 	}, nil
 }
 
@@ -95,19 +95,19 @@ func newMappingRule(
 }
 
 // ActiveSnapshot returns the latest snapshot whose cutover time is earlier than or
-// equal to timeNs, or nil if not found.
-func (mc *mappingRule) ActiveSnapshot(timeNs int64) *mappingRuleSnapshot {
-	idx := mc.activeIndex(timeNs)
+// equal to timeNanos, or nil if not found.
+func (mc *mappingRule) ActiveSnapshot(timeNanos int64) *mappingRuleSnapshot {
+	idx := mc.activeIndex(timeNanos)
 	if idx < 0 {
 		return nil
 	}
 	return mc.snapshots[idx]
 }
 
-// ActiveRule returns the rule containing snapshots that's in effect at time timeNs
-// and all future snapshots after time timeNs.
-func (mc *mappingRule) ActiveRule(timeNs int64) *mappingRule {
-	idx := mc.activeIndex(timeNs)
+// ActiveRule returns the rule containing snapshots that's in effect at time timeNanos
+// and all future snapshots after time timeNanos.
+func (mc *mappingRule) ActiveRule(timeNanos int64) *mappingRule {
+	idx := mc.activeIndex(timeNanos)
 	// If there are no snapshots that are currently in effect, it means either all
 	// snapshots are in the future, or there are no snapshots.
 	if idx < 0 {
@@ -116,9 +116,9 @@ func (mc *mappingRule) ActiveRule(timeNs int64) *mappingRule {
 	return &mappingRule{uuid: mc.uuid, snapshots: mc.snapshots[idx:]}
 }
 
-func (mc *mappingRule) activeIndex(timeNs int64) int {
+func (mc *mappingRule) activeIndex(timeNanos int64) int {
 	idx := len(mc.snapshots) - 1
-	for idx >= 0 && mc.snapshots[idx].cutoverNs > timeNs {
+	for idx >= 0 && mc.snapshots[idx].cutoverNanos > timeNanos {
 		idx--
 	}
 	return idx

--- a/rules/mapping_test.go
+++ b/rules/mapping_test.go
@@ -103,23 +103,23 @@ func TestNewMappingRule(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "12669817-13ae-40e6-ba2f-33087b262c68", mr.uuid)
 	expectedSnapshots := []struct {
-		name       string
-		tombstoned bool
-		cutoverNs  int64
-		policies   []policy.Policy
+		name         string
+		tombstoned   bool
+		cutoverNanos int64
+		policies     []policy.Policy
 	}{
 		{
-			name:       "foo",
-			tombstoned: false,
-			cutoverNs:  12345,
+			name:         "foo",
+			tombstoned:   false,
+			cutoverNanos: 12345,
 			policies: []policy.Policy{
 				policy.NewPolicy(10*time.Second, xtime.Second, 24*time.Hour),
 			},
 		},
 		{
-			name:       "bar",
-			tombstoned: true,
-			cutoverNs:  67890,
+			name:         "bar",
+			tombstoned:   true,
+			cutoverNanos: 67890,
 			policies: []policy.Policy{
 				policy.NewPolicy(time.Minute, xtime.Minute, 24*time.Hour),
 				policy.NewPolicy(5*time.Minute, xtime.Minute, 48*time.Hour),
@@ -129,7 +129,7 @@ func TestNewMappingRule(t *testing.T) {
 	for i, snapshot := range expectedSnapshots {
 		require.Equal(t, snapshot.name, mr.snapshots[i].name)
 		require.Equal(t, snapshot.tombstoned, mr.snapshots[i].tombstoned)
-		require.Equal(t, snapshot.cutoverNs, mr.snapshots[i].cutoverNs)
+		require.Equal(t, snapshot.cutoverNanos, mr.snapshots[i].cutoverNanos)
 		require.Equal(t, snapshot.policies, mr.snapshots[i].policies)
 	}
 }

--- a/rules/result.go
+++ b/rules/result.go
@@ -21,6 +21,7 @@
 package rules
 
 import (
+	"bytes"
 	"time"
 
 	"github.com/m3db/m3metrics/policy"
@@ -28,35 +29,36 @@ import (
 
 var (
 	// EmptyMatchResult is the result when no matches were found.
-	EmptyMatchResult = NewMatchResult(0, 0, timeNsMax, nil, nil)
+	EmptyMatchResult = NewMatchResult(timeNsMax, policy.DefaultPoliciesList, nil)
 )
 
-// RollupResult contains the rollup metric id and the associated policies.
+// RollupResult contains the rollup metric id and the associated policies list.
 type RollupResult struct {
-	ID       []byte
-	Policies []policy.Policy
+	ID           []byte
+	PoliciesList policy.PoliciesList
 }
+
+// RollupResultsByIDAsc sorts rollup results by id in ascending order.
+type RollupResultsByIDAsc []RollupResult
+
+func (a RollupResultsByIDAsc) Len() int           { return len(a) }
+func (a RollupResultsByIDAsc) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a RollupResultsByIDAsc) Less(i, j int) bool { return bytes.Compare(a[i].ID, a[j].ID) < 0 }
 
 // MatchResult represents a match result.
 type MatchResult struct {
-	version    int
-	cutoverNs  int64
 	expireAtNs int64
-	mappings   []policy.Policy
+	mappings   policy.PoliciesList
 	rollups    []RollupResult
 }
 
 // NewMatchResult creates a new match result.
 func NewMatchResult(
-	version int,
-	cutoverNs int64,
 	expireAtNs int64,
-	mappings []policy.Policy,
+	mappings policy.PoliciesList,
 	rollups []RollupResult,
 ) MatchResult {
 	return MatchResult{
-		version:    version,
-		cutoverNs:  cutoverNs,
 		expireAtNs: expireAtNs,
 		mappings:   mappings,
 		rollups:    rollups,
@@ -66,26 +68,31 @@ func NewMatchResult(
 // HasExpired returns whether the match result has expired for a given time.
 func (r *MatchResult) HasExpired(t time.Time) bool { return r.expireAtNs <= t.UnixNano() }
 
-// NumRollups returns the number of rollup result associated with the given id.
+// NumRollups returns the number of rollup metrics.
 func (r *MatchResult) NumRollups() int { return len(r.rollups) }
 
-// Mappings returns the mapping policies for the given id.
-func (r *MatchResult) Mappings() policy.VersionedPolicies {
-	return r.versionedPolicies(r.mappings)
+// MappingsAt returns the active mapping policies at a given time.
+func (r *MatchResult) MappingsAt(t time.Time) policy.PoliciesList {
+	return activePoliciesAt(r.mappings, t)
 }
 
-// Rollups returns the rollup metric id and corresponding policies at a given index.
-func (r *MatchResult) Rollups(idx int) ([]byte, policy.VersionedPolicies) {
+// RollupsAt returns the rollup metric id and corresponding policies at a given index and time.
+func (r *MatchResult) RollupsAt(idx int, t time.Time) RollupResult {
 	rollup := r.rollups[idx]
-	return rollup.ID, r.versionedPolicies(rollup.Policies)
+	return RollupResult{
+		ID:           rollup.ID,
+		PoliciesList: activePoliciesAt(rollup.PoliciesList, t),
+	}
 }
 
-// TODO(xichen): change versioned policies to use int64 instead.
-func (r *MatchResult) versionedPolicies(policies []policy.Policy) policy.VersionedPolicies {
-	// NB(xichen): if there are no policies for this id, we fall
-	// back to the default mapping policies.
-	if len(policies) == 0 {
-		return policy.DefaultVersionedPolicies(r.version, time.Unix(0, r.cutoverNs))
+// activePolicies returns the active policies at a given time, assuming
+// the input policies are sorted by cutover time in ascending order.
+func activePoliciesAt(policies policy.PoliciesList, t time.Time) policy.PoliciesList {
+	timeNs := t.UnixNano()
+	for idx := len(policies) - 1; idx >= 0; idx-- {
+		if policies[idx].CutoverNs <= timeNs {
+			return policies[idx:]
+		}
 	}
-	return policy.CustomVersionedPolicies(r.version, time.Unix(0, r.cutoverNs), policies)
+	return policies
 }

--- a/rules/result.go
+++ b/rules/result.go
@@ -29,7 +29,7 @@ import (
 
 var (
 	// EmptyMatchResult is the result when no matches were found.
-	EmptyMatchResult = NewMatchResult(timeNsMax, policy.DefaultPoliciesList, nil)
+	EmptyMatchResult = NewMatchResult(timeNanosMax, policy.DefaultPoliciesList, nil)
 )
 
 // RollupResult contains the rollup metric id and the associated policies list.
@@ -47,26 +47,26 @@ func (a RollupResultsByIDAsc) Less(i, j int) bool { return bytes.Compare(a[i].ID
 
 // MatchResult represents a match result.
 type MatchResult struct {
-	expireAtNs int64
-	mappings   policy.PoliciesList
-	rollups    []RollupResult
+	expireAtNanos int64
+	mappings      policy.PoliciesList
+	rollups       []RollupResult
 }
 
 // NewMatchResult creates a new match result.
 func NewMatchResult(
-	expireAtNs int64,
+	expireAtNanos int64,
 	mappings policy.PoliciesList,
 	rollups []RollupResult,
 ) MatchResult {
 	return MatchResult{
-		expireAtNs: expireAtNs,
-		mappings:   mappings,
-		rollups:    rollups,
+		expireAtNanos: expireAtNanos,
+		mappings:      mappings,
+		rollups:       rollups,
 	}
 }
 
 // HasExpired returns whether the match result has expired for a given time.
-func (r *MatchResult) HasExpired(t time.Time) bool { return r.expireAtNs <= t.UnixNano() }
+func (r *MatchResult) HasExpired(t time.Time) bool { return r.expireAtNanos <= t.UnixNano() }
 
 // NumRollups returns the number of rollup metrics.
 func (r *MatchResult) NumRollups() int { return len(r.rollups) }
@@ -88,9 +88,9 @@ func (r *MatchResult) RollupsAt(idx int, t time.Time) RollupResult {
 // activePolicies returns the active policies at a given time, assuming
 // the input policies are sorted by cutover time in ascending order.
 func activePoliciesAt(policies policy.PoliciesList, t time.Time) policy.PoliciesList {
-	timeNs := t.UnixNano()
+	timeNanos := t.UnixNano()
 	for idx := len(policies) - 1; idx >= 0; idx-- {
-		if policies[idx].CutoverNs <= timeNs {
+		if policies[idx].CutoverNanos <= timeNanos {
 			return policies[idx:]
 		}
 	}

--- a/rules/result_test.go
+++ b/rules/result_test.go
@@ -38,7 +38,7 @@ func TestMatchResultHasExpired(t *testing.T) {
 
 func TestMatchResult(t *testing.T) {
 	var (
-		testExpireAtNs     = int64(67890)
+		testExpireAtNanos  = int64(67890)
 		testResultMappings = policy.PoliciesList{
 			policy.NewStagedPolicies(
 				12345,
@@ -137,7 +137,7 @@ func TestMatchResult(t *testing.T) {
 		},
 	}
 
-	res := NewMatchResult(testExpireAtNs, testResultMappings, testResultRollups)
+	res := NewMatchResult(testExpireAtNanos, testResultMappings, testResultRollups)
 	for _, input := range inputs {
 		require.Equal(t, input.expectedMappings, res.MappingsAt(input.matchAt))
 		require.Equal(t, len(input.expectedRollups), res.NumRollups())

--- a/rules/rollup.go
+++ b/rules/rollup.go
@@ -97,11 +97,11 @@ func (t *rollupTarget) clone() rollupTarget {
 // rollupRuleSnapshot defines a rule snapshot such that if a metric matches the
 // provided filters, it is rolled up using the provided list of rollup targets.
 type rollupRuleSnapshot struct {
-	name       string
-	tombstoned bool
-	cutoverNs  int64
-	filter     filters.Filter
-	targets    []rollupTarget
+	name         string
+	tombstoned   bool
+	cutoverNanos int64
+	filter       filters.Filter
+	targets      []rollupTarget
 }
 
 func newRollupRuleSnapshot(
@@ -124,11 +124,11 @@ func newRollupRuleSnapshot(
 		return nil, err
 	}
 	return &rollupRuleSnapshot{
-		name:       r.Name,
-		tombstoned: r.Tombstoned,
-		cutoverNs:  r.CutoverTime,
-		filter:     filter,
-		targets:    targets,
+		name:         r.Name,
+		tombstoned:   r.Tombstoned,
+		cutoverNanos: r.CutoverTime,
+		filter:       filter,
+		targets:      targets,
 	}, nil
 }
 
@@ -160,28 +160,28 @@ func newRollupRule(
 }
 
 // ActiveSnapshot returns the latest rule snapshot whose cutover time is earlier
-// than or equal to timeNs, or nil if not found.
-func (rc *rollupRule) ActiveSnapshot(timeNs int64) *rollupRuleSnapshot {
-	idx := rc.activeIndex(timeNs)
+// than or equal to timeNanos, or nil if not found.
+func (rc *rollupRule) ActiveSnapshot(timeNanos int64) *rollupRuleSnapshot {
+	idx := rc.activeIndex(timeNanos)
 	if idx < 0 {
 		return nil
 	}
 	return rc.snapshots[idx]
 }
 
-// ActiveRule returns the rule containing snapshots that's in effect at time timeNs
-// and all future rules after time timeNs.
-func (rc *rollupRule) ActiveRule(timeNs int64) *rollupRule {
-	idx := rc.activeIndex(timeNs)
+// ActiveRule returns the rule containing snapshots that's in effect at time timeNanos
+// and all future rules after time timeNanos.
+func (rc *rollupRule) ActiveRule(timeNanos int64) *rollupRule {
+	idx := rc.activeIndex(timeNanos)
 	if idx < 0 {
 		return rc
 	}
 	return &rollupRule{uuid: rc.uuid, snapshots: rc.snapshots[idx:]}
 }
 
-func (rc *rollupRule) activeIndex(timeNs int64) int {
+func (rc *rollupRule) activeIndex(timeNanos int64) int {
 	idx := len(rc.snapshots) - 1
-	for idx >= 0 && rc.snapshots[idx].cutoverNs > timeNs {
+	for idx >= 0 && rc.snapshots[idx].cutoverNanos > timeNanos {
 		idx--
 	}
 	return idx

--- a/rules/rollup_test.go
+++ b/rules/rollup_test.go
@@ -169,15 +169,15 @@ func TestRollupRuleValidSchema(t *testing.T) {
 	require.Equal(t, "12669817-13ae-40e6-ba2f-33087b262c68", rr.uuid)
 
 	expectedSnapshots := []struct {
-		name       string
-		tombstoned bool
-		cutoverNs  int64
-		targets    []rollupTarget
+		name         string
+		tombstoned   bool
+		cutoverNanos int64
+		targets      []rollupTarget
 	}{
 		{
-			name:       "foo",
-			tombstoned: false,
-			cutoverNs:  12345,
+			name:         "foo",
+			tombstoned:   false,
+			cutoverNanos: 12345,
 			targets: []rollupTarget{
 				{
 					Name: b("rName1"),
@@ -189,9 +189,9 @@ func TestRollupRuleValidSchema(t *testing.T) {
 			},
 		},
 		{
-			name:       "bar",
-			tombstoned: true,
-			cutoverNs:  67890,
+			name:         "bar",
+			tombstoned:   true,
+			cutoverNanos: 67890,
 			targets: []rollupTarget{
 				{
 					Name: b("rName1"),
@@ -207,7 +207,7 @@ func TestRollupRuleValidSchema(t *testing.T) {
 	for i, snapshot := range expectedSnapshots {
 		require.Equal(t, snapshot.name, rr.snapshots[i].name)
 		require.Equal(t, snapshot.tombstoned, rr.snapshots[i].tombstoned)
-		require.Equal(t, snapshot.cutoverNs, rr.snapshots[i].cutoverNs)
+		require.Equal(t, snapshot.cutoverNanos, rr.snapshots[i].cutoverNanos)
 		require.Equal(t, snapshot.targets, rr.snapshots[i].targets)
 	}
 }

--- a/rules/ruleset.go
+++ b/rules/ruleset.go
@@ -394,6 +394,8 @@ func resolvePolicies(policies []policy.Policy) []policy.Policy {
 	return policies[:curr+1]
 }
 
+// mergeMappingResults assumes the policies contained in currMappingResults
+// are sorted by cutover time in time ascending order.
 func mergeMappingResults(
 	currMappingResults policy.PoliciesList,
 	nextMappingPolicies policy.StagedPolicies,
@@ -406,6 +408,8 @@ func mergeMappingResults(
 	return currMappingResults
 }
 
+// mergeRollupResults assumes both currRollupResult and nextRollupResult
+// are sorted by the ids of roll up results in ascending order.
 func mergeRollupResults(
 	currRollupResults []RollupResult,
 	nextRollupResults []RollupResult,

--- a/rules/ruleset_test.go
+++ b/rules/ruleset_test.go
@@ -36,10 +36,10 @@ import (
 func TestActiveRuleSetMatchMappingRules(t *testing.T) {
 	inputs := []testMappingsData{
 		{
-			id:         "mtagName1=mtagValue1",
-			matchFrom:  time.Unix(0, 25000),
-			matchTo:    time.Unix(0, 25001),
-			expireAtNs: 30000,
+			id:            "mtagName1=mtagValue1",
+			matchFrom:     time.Unix(0, 25000),
+			matchTo:       time.Unix(0, 25001),
+			expireAtNanos: 30000,
 			result: policy.PoliciesList{
 				policy.NewStagedPolicies(
 					22000,
@@ -53,10 +53,10 @@ func TestActiveRuleSetMatchMappingRules(t *testing.T) {
 			},
 		},
 		{
-			id:         "mtagName1=mtagValue1",
-			matchFrom:  time.Unix(0, 35000),
-			matchTo:    time.Unix(0, 35001),
-			expireAtNs: 100000,
+			id:            "mtagName1=mtagValue1",
+			matchFrom:     time.Unix(0, 35000),
+			matchTo:       time.Unix(0, 35001),
+			expireAtNanos: 100000,
 			result: policy.PoliciesList{
 				policy.NewStagedPolicies(
 					35000,
@@ -69,10 +69,10 @@ func TestActiveRuleSetMatchMappingRules(t *testing.T) {
 			},
 		},
 		{
-			id:         "mtagName1=mtagValue2",
-			matchFrom:  time.Unix(0, 25000),
-			matchTo:    time.Unix(0, 25001),
-			expireAtNs: 30000,
+			id:            "mtagName1=mtagValue2",
+			matchFrom:     time.Unix(0, 25000),
+			matchTo:       time.Unix(0, 25001),
+			expireAtNanos: 30000,
 			result: policy.PoliciesList{
 				policy.NewStagedPolicies(
 					24000,
@@ -84,17 +84,17 @@ func TestActiveRuleSetMatchMappingRules(t *testing.T) {
 			},
 		},
 		{
-			id:         "mtagName1=mtagValue3",
-			matchFrom:  time.Unix(0, 25000),
-			matchTo:    time.Unix(0, 25001),
-			expireAtNs: 30000,
-			result:     policy.DefaultPoliciesList,
+			id:            "mtagName1=mtagValue3",
+			matchFrom:     time.Unix(0, 25000),
+			matchTo:       time.Unix(0, 25001),
+			expireAtNanos: 30000,
+			result:        policy.DefaultPoliciesList,
 		},
 		{
-			id:         "mtagName1=mtagValue1",
-			matchFrom:  time.Unix(0, 10000),
-			matchTo:    time.Unix(0, 40000),
-			expireAtNs: 100000,
+			id:            "mtagName1=mtagValue1",
+			matchFrom:     time.Unix(0, 10000),
+			matchTo:       time.Unix(0, 40000),
+			expireAtNanos: 100000,
 			result: policy.PoliciesList{
 				policy.NewStagedPolicies(
 					10000,
@@ -131,12 +131,12 @@ func TestActiveRuleSetMatchMappingRules(t *testing.T) {
 			},
 		},
 		{
-			id:         "mtagName1=mtagValue2",
-			matchFrom:  time.Unix(0, 10000),
-			matchTo:    time.Unix(0, 40000),
-			expireAtNs: 100000,
+			id:            "mtagName1=mtagValue2",
+			matchFrom:     time.Unix(0, 10000),
+			matchTo:       time.Unix(0, 40000),
+			expireAtNanos: 100000,
 			result: policy.PoliciesList{
-				policy.EmptyStagedPolicies,
+				policy.DefaultStagedPolicies,
 				policy.NewStagedPolicies(
 					24000,
 					false,
@@ -159,7 +159,7 @@ func TestActiveRuleSetMatchMappingRules(t *testing.T) {
 	require.Equal(t, expectedCutovers, as.cutoverTimesAsc)
 	for _, input := range inputs {
 		res := as.MatchAll(b(input.id), input.matchFrom, input.matchTo)
-		require.Equal(t, input.expireAtNs, res.expireAtNs)
+		require.Equal(t, input.expireAtNanos, res.expireAtNanos)
 		require.Equal(t, input.result, res.MappingsAt(time.Unix(0, 0)))
 	}
 }
@@ -167,10 +167,10 @@ func TestActiveRuleSetMatchMappingRules(t *testing.T) {
 func TestActiveRuleSetMatchRollupRules(t *testing.T) {
 	inputs := []testRollupResultsData{
 		{
-			id:         "rtagName1=rtagValue1,rtagName2=rtagValue2,rtagName3=rtagValue3",
-			matchFrom:  time.Unix(0, 25000),
-			matchTo:    time.Unix(0, 25001),
-			expireAtNs: 30000,
+			id:            "rtagName1=rtagValue1,rtagName2=rtagValue2,rtagName3=rtagValue3",
+			matchFrom:     time.Unix(0, 25000),
+			matchTo:       time.Unix(0, 25001),
+			expireAtNanos: 30000,
 			result: []RollupResult{
 				{
 					ID: b("rName1|rtagName1=rtagValue1,rtagName2=rtagValue2"),
@@ -201,10 +201,10 @@ func TestActiveRuleSetMatchRollupRules(t *testing.T) {
 			},
 		},
 		{
-			id:         "rtagName1=rtagValue2",
-			matchFrom:  time.Unix(0, 25000),
-			matchTo:    time.Unix(0, 25001),
-			expireAtNs: 30000,
+			id:            "rtagName1=rtagValue2",
+			matchFrom:     time.Unix(0, 25000),
+			matchTo:       time.Unix(0, 25001),
+			expireAtNanos: 30000,
 			result: []RollupResult{
 				{
 					ID: b("rName3|rtagName1=rtagValue2"),
@@ -221,17 +221,17 @@ func TestActiveRuleSetMatchRollupRules(t *testing.T) {
 			},
 		},
 		{
-			id:         "rtagName5=rtagValue5",
-			matchFrom:  time.Unix(0, 25000),
-			matchTo:    time.Unix(0, 25001),
-			expireAtNs: 30000,
-			result:     []RollupResult{},
+			id:            "rtagName5=rtagValue5",
+			matchFrom:     time.Unix(0, 25000),
+			matchTo:       time.Unix(0, 25001),
+			expireAtNanos: 30000,
+			result:        []RollupResult{},
 		},
 		{
-			id:         "rtagName1=rtagValue1,rtagName2=rtagValue2,rtagName3=rtagValue3",
-			matchFrom:  time.Unix(0, 10000),
-			matchTo:    time.Unix(0, 40000),
-			expireAtNs: 100000,
+			id:            "rtagName1=rtagValue1,rtagName2=rtagValue2,rtagName3=rtagValue3",
+			matchFrom:     time.Unix(0, 10000),
+			matchTo:       time.Unix(0, 40000),
+			expireAtNanos: 100000,
 			result: []RollupResult{
 				{
 					ID: b("rName1|rtagName1=rtagValue1,rtagName2=rtagValue2"),
@@ -319,7 +319,7 @@ func TestActiveRuleSetMatchRollupRules(t *testing.T) {
 	require.Equal(t, expectedCutovers, as.cutoverTimesAsc)
 	for _, input := range inputs {
 		res := as.MatchAll(b(input.id), input.matchFrom, input.matchTo)
-		require.Equal(t, input.expireAtNs, res.expireAtNs)
+		require.Equal(t, input.expireAtNanos, res.expireAtNanos)
 		require.Equal(t, len(input.result), res.NumRollups())
 		for i := 0; i < len(input.result); i++ {
 			rollup := res.RollupsAt(i, time.Unix(0, 0))
@@ -348,7 +348,7 @@ func TestRuleSetProperties(t *testing.T) {
 	require.Equal(t, "ruleset", ruleSet.uuid)
 	require.Equal(t, []byte("namespace"), ruleSet.Namespace())
 	require.Equal(t, 1, ruleSet.Version())
-	require.Equal(t, int64(34923), ruleSet.CutoverNs())
+	require.Equal(t, int64(34923), ruleSet.CutoverNanos())
 	require.Equal(t, false, ruleSet.TombStoned())
 }
 
@@ -371,10 +371,10 @@ func TestRuleSetActiveSet(t *testing.T) {
 			activeSetTime: time.Unix(0, 0),
 			mappingInputs: []testMappingsData{
 				{
-					id:         "mtagName1=mtagValue1",
-					matchFrom:  time.Unix(0, 25000),
-					matchTo:    time.Unix(0, 25001),
-					expireAtNs: 30000,
+					id:            "mtagName1=mtagValue1",
+					matchFrom:     time.Unix(0, 25000),
+					matchTo:       time.Unix(0, 25001),
+					expireAtNanos: 30000,
 					result: policy.PoliciesList{
 						policy.NewStagedPolicies(
 							22000,
@@ -388,10 +388,10 @@ func TestRuleSetActiveSet(t *testing.T) {
 					},
 				},
 				{
-					id:         "mtagName1=mtagValue1",
-					matchFrom:  time.Unix(0, 35000),
-					matchTo:    time.Unix(0, 35001),
-					expireAtNs: 100000,
+					id:            "mtagName1=mtagValue1",
+					matchFrom:     time.Unix(0, 35000),
+					matchTo:       time.Unix(0, 35001),
+					expireAtNanos: 100000,
 					result: policy.PoliciesList{
 						policy.NewStagedPolicies(
 							35000,
@@ -404,10 +404,10 @@ func TestRuleSetActiveSet(t *testing.T) {
 					},
 				},
 				{
-					id:         "mtagName1=mtagValue2",
-					matchFrom:  time.Unix(0, 25000),
-					matchTo:    time.Unix(0, 25001),
-					expireAtNs: 30000,
+					id:            "mtagName1=mtagValue2",
+					matchFrom:     time.Unix(0, 25000),
+					matchTo:       time.Unix(0, 25001),
+					expireAtNanos: 30000,
 					result: policy.PoliciesList{
 						policy.NewStagedPolicies(
 							24000,
@@ -419,19 +419,19 @@ func TestRuleSetActiveSet(t *testing.T) {
 					},
 				},
 				{
-					id:         "mtagName1=mtagValue3",
-					matchFrom:  time.Unix(0, 25000),
-					matchTo:    time.Unix(0, 25001),
-					expireAtNs: 30000,
-					result:     policy.DefaultPoliciesList,
+					id:            "mtagName1=mtagValue3",
+					matchFrom:     time.Unix(0, 25000),
+					matchTo:       time.Unix(0, 25001),
+					expireAtNanos: 30000,
+					result:        policy.DefaultPoliciesList,
 				},
 			},
 			rollupInputs: []testRollupResultsData{
 				{
-					id:         "rtagName1=rtagValue1,rtagName2=rtagValue2,rtagName3=rtagValue3",
-					matchFrom:  time.Unix(0, 25000),
-					matchTo:    time.Unix(0, 25001),
-					expireAtNs: 30000,
+					id:            "rtagName1=rtagValue1,rtagName2=rtagValue2,rtagName3=rtagValue3",
+					matchFrom:     time.Unix(0, 25000),
+					matchTo:       time.Unix(0, 25001),
+					expireAtNanos: 30000,
 					result: []RollupResult{
 						{
 							ID: b("rName1|rtagName1=rtagValue1,rtagName2=rtagValue2"),
@@ -462,10 +462,10 @@ func TestRuleSetActiveSet(t *testing.T) {
 					},
 				},
 				{
-					id:         "rtagName1=rtagValue2",
-					matchFrom:  time.Unix(0, 25000),
-					matchTo:    time.Unix(0, 25001),
-					expireAtNs: 30000,
+					id:            "rtagName1=rtagValue2",
+					matchFrom:     time.Unix(0, 25000),
+					matchTo:       time.Unix(0, 25001),
+					expireAtNanos: 30000,
 					result: []RollupResult{
 						{
 							ID: b("rName3|rtagName1=rtagValue2"),
@@ -482,11 +482,11 @@ func TestRuleSetActiveSet(t *testing.T) {
 					},
 				},
 				{
-					id:         "rtagName5=rtagValue5",
-					matchFrom:  time.Unix(0, 25000),
-					matchTo:    time.Unix(0, 25001),
-					expireAtNs: 30000,
-					result:     []RollupResult{},
+					id:            "rtagName5=rtagValue5",
+					matchFrom:     time.Unix(0, 25000),
+					matchTo:       time.Unix(0, 25001),
+					expireAtNanos: 30000,
+					result:        []RollupResult{},
 				},
 			},
 		},
@@ -494,10 +494,10 @@ func TestRuleSetActiveSet(t *testing.T) {
 			activeSetTime: time.Unix(0, 30000),
 			mappingInputs: []testMappingsData{
 				{
-					id:         "mtagName1=mtagValue1",
-					matchFrom:  time.Unix(0, 35000),
-					matchTo:    time.Unix(0, 35001),
-					expireAtNs: 100000,
+					id:            "mtagName1=mtagValue1",
+					matchFrom:     time.Unix(0, 35000),
+					matchTo:       time.Unix(0, 35001),
+					expireAtNanos: 100000,
 					result: policy.PoliciesList{
 						policy.NewStagedPolicies(
 							35000,
@@ -510,10 +510,10 @@ func TestRuleSetActiveSet(t *testing.T) {
 					},
 				},
 				{
-					id:         "mtagName1=mtagValue2",
-					matchFrom:  time.Unix(0, 35000),
-					matchTo:    time.Unix(0, 35001),
-					expireAtNs: 100000,
+					id:            "mtagName1=mtagValue2",
+					matchFrom:     time.Unix(0, 35000),
+					matchTo:       time.Unix(0, 35001),
+					expireAtNanos: 100000,
 					result: policy.PoliciesList{
 						policy.NewStagedPolicies(
 							35000,
@@ -525,19 +525,19 @@ func TestRuleSetActiveSet(t *testing.T) {
 					},
 				},
 				{
-					id:         "mtagName1=mtagValue3",
-					matchFrom:  time.Unix(0, 35000),
-					matchTo:    time.Unix(0, 35001),
-					expireAtNs: 100000,
-					result:     policy.DefaultPoliciesList,
+					id:            "mtagName1=mtagValue3",
+					matchFrom:     time.Unix(0, 35000),
+					matchTo:       time.Unix(0, 35001),
+					expireAtNanos: 100000,
+					result:        policy.DefaultPoliciesList,
 				},
 			},
 			rollupInputs: []testRollupResultsData{
 				{
-					id:         "rtagName1=rtagValue1,rtagName2=rtagValue2,rtagName3=rtagValue3",
-					matchFrom:  time.Unix(0, 35000),
-					matchTo:    time.Unix(0, 35001),
-					expireAtNs: 100000,
+					id:            "rtagName1=rtagValue1,rtagName2=rtagValue2,rtagName3=rtagValue3",
+					matchFrom:     time.Unix(0, 35000),
+					matchTo:       time.Unix(0, 35001),
+					expireAtNanos: 100000,
 					result: []RollupResult{
 						{
 							ID: b("rName1|rtagName1=rtagValue1,rtagName2=rtagValue2"),
@@ -555,10 +555,10 @@ func TestRuleSetActiveSet(t *testing.T) {
 					},
 				},
 				{
-					id:         "rtagName1=rtagValue2",
-					matchFrom:  time.Unix(0, 35000),
-					matchTo:    time.Unix(0, 35001),
-					expireAtNs: 100000,
+					id:            "rtagName1=rtagValue2",
+					matchFrom:     time.Unix(0, 35000),
+					matchTo:       time.Unix(0, 35001),
+					expireAtNanos: 100000,
 					result: []RollupResult{
 						{
 							ID: b("rName3|rtagName1=rtagValue2"),
@@ -575,11 +575,11 @@ func TestRuleSetActiveSet(t *testing.T) {
 					},
 				},
 				{
-					id:         "rtagName5=rtagValue5",
-					matchFrom:  time.Unix(0, 35000),
-					matchTo:    time.Unix(0, 35001),
-					expireAtNs: 100000,
-					result:     []RollupResult{},
+					id:            "rtagName5=rtagValue5",
+					matchFrom:     time.Unix(0, 35000),
+					matchTo:       time.Unix(0, 35001),
+					expireAtNanos: 100000,
+					result:        []RollupResult{},
 				},
 			},
 		},
@@ -587,10 +587,10 @@ func TestRuleSetActiveSet(t *testing.T) {
 			activeSetTime: time.Unix(0, 200000),
 			mappingInputs: []testMappingsData{
 				{
-					id:         "mtagName1=mtagValue1",
-					matchFrom:  time.Unix(0, 250000),
-					matchTo:    time.Unix(0, 250001),
-					expireAtNs: timeNsMax,
+					id:            "mtagName1=mtagValue1",
+					matchFrom:     time.Unix(0, 250000),
+					matchTo:       time.Unix(0, 250001),
+					expireAtNanos: timeNanosMax,
 					result: policy.PoliciesList{
 						policy.NewStagedPolicies(
 							100000,
@@ -602,10 +602,10 @@ func TestRuleSetActiveSet(t *testing.T) {
 					},
 				},
 				{
-					id:         "mtagName1=mtagValue2",
-					matchFrom:  time.Unix(0, 250000),
-					matchTo:    time.Unix(0, 250001),
-					expireAtNs: timeNsMax,
+					id:            "mtagName1=mtagValue2",
+					matchFrom:     time.Unix(0, 250000),
+					matchTo:       time.Unix(0, 250001),
+					expireAtNanos: timeNanosMax,
 					result: policy.PoliciesList{
 						policy.NewStagedPolicies(
 							35000,
@@ -617,19 +617,19 @@ func TestRuleSetActiveSet(t *testing.T) {
 					},
 				},
 				{
-					id:         "mtagName1=mtagValue3",
-					matchFrom:  time.Unix(0, 250000),
-					matchTo:    time.Unix(0, 250001),
-					expireAtNs: timeNsMax,
-					result:     policy.DefaultPoliciesList,
+					id:            "mtagName1=mtagValue3",
+					matchFrom:     time.Unix(0, 250000),
+					matchTo:       time.Unix(0, 250001),
+					expireAtNanos: timeNanosMax,
+					result:        policy.DefaultPoliciesList,
 				},
 			},
 			rollupInputs: []testRollupResultsData{
 				{
-					id:         "rtagName1=rtagValue1,rtagName2=rtagValue2,rtagName3=rtagValue3",
-					matchFrom:  time.Unix(0, 250000),
-					matchTo:    time.Unix(0, 250001),
-					expireAtNs: timeNsMax,
+					id:            "rtagName1=rtagValue1,rtagName2=rtagValue2,rtagName3=rtagValue3",
+					matchFrom:     time.Unix(0, 250000),
+					matchTo:       time.Unix(0, 250001),
+					expireAtNanos: timeNanosMax,
 					result: []RollupResult{
 						{
 							ID: b("rName1|rtagName1=rtagValue1,rtagName2=rtagValue2"),
@@ -659,10 +659,10 @@ func TestRuleSetActiveSet(t *testing.T) {
 					},
 				},
 				{
-					id:         "rtagName1=rtagValue2",
-					matchFrom:  time.Unix(0, 250000),
-					matchTo:    time.Unix(0, 250001),
-					expireAtNs: timeNsMax,
+					id:            "rtagName1=rtagValue2",
+					matchFrom:     time.Unix(0, 250000),
+					matchTo:       time.Unix(0, 250001),
+					expireAtNanos: timeNanosMax,
 					result: []RollupResult{
 						{
 							ID: b("rName3|rtagName1=rtagValue2"),
@@ -679,11 +679,11 @@ func TestRuleSetActiveSet(t *testing.T) {
 					},
 				},
 				{
-					id:         "rtagName5=rtagValue5",
-					matchFrom:  time.Unix(0, 250000),
-					matchTo:    time.Unix(0, 250001),
-					expireAtNs: timeNsMax,
-					result:     []RollupResult{},
+					id:            "rtagName5=rtagValue5",
+					matchFrom:     time.Unix(0, 250000),
+					matchTo:       time.Unix(0, 250001),
+					expireAtNanos: timeNanosMax,
+					result:        []RollupResult{},
 				},
 			},
 		},
@@ -693,12 +693,12 @@ func TestRuleSetActiveSet(t *testing.T) {
 		as := newRuleSet.ActiveSet(inputs.activeSetTime)
 		for _, input := range inputs.mappingInputs {
 			res := as.MatchAll(b(input.id), input.matchFrom, input.matchTo)
-			require.Equal(t, input.expireAtNs, res.expireAtNs)
+			require.Equal(t, input.expireAtNanos, res.expireAtNanos)
 			require.Equal(t, input.result, res.MappingsAt(time.Unix(0, 0)))
 		}
 		for _, input := range inputs.rollupInputs {
 			res := as.MatchAll(b(input.id), input.matchFrom, input.matchTo)
-			require.Equal(t, input.expireAtNs, res.expireAtNs)
+			require.Equal(t, input.expireAtNanos, res.expireAtNanos)
 			require.Equal(t, len(input.result), res.NumRollups())
 			for i := 0; i < len(input.result); i++ {
 				rollup := res.RollupsAt(i, time.Unix(0, 0))
@@ -728,19 +728,19 @@ func testMappingRules(t *testing.T) []*mappingRule {
 		uuid: "mappingRule1",
 		snapshots: []*mappingRuleSnapshot{
 			&mappingRuleSnapshot{
-				name:       "mappingRule1.snapshot1",
-				tombstoned: false,
-				cutoverNs:  10000,
-				filter:     filter1,
+				name:         "mappingRule1.snapshot1",
+				tombstoned:   false,
+				cutoverNanos: 10000,
+				filter:       filter1,
 				policies: []policy.Policy{
 					policy.NewPolicy(10*time.Second, xtime.Second, 24*time.Hour),
 				},
 			},
 			&mappingRuleSnapshot{
-				name:       "mappingRule1.snapshot2",
-				tombstoned: false,
-				cutoverNs:  20000,
-				filter:     filter1,
+				name:         "mappingRule1.snapshot2",
+				tombstoned:   false,
+				cutoverNanos: 20000,
+				filter:       filter1,
 				policies: []policy.Policy{
 					policy.NewPolicy(10*time.Second, xtime.Second, 6*time.Hour),
 					policy.NewPolicy(5*time.Minute, xtime.Minute, 48*time.Hour),
@@ -748,10 +748,10 @@ func testMappingRules(t *testing.T) []*mappingRule {
 				},
 			},
 			&mappingRuleSnapshot{
-				name:       "mappingRule1.snapshot3",
-				tombstoned: false,
-				cutoverNs:  30000,
-				filter:     filter1,
+				name:         "mappingRule1.snapshot3",
+				tombstoned:   false,
+				cutoverNanos: 30000,
+				filter:       filter1,
 				policies: []policy.Policy{
 					policy.NewPolicy(30*time.Second, xtime.Second, 6*time.Hour),
 				},
@@ -763,30 +763,30 @@ func testMappingRules(t *testing.T) []*mappingRule {
 		uuid: "mappingRule2",
 		snapshots: []*mappingRuleSnapshot{
 			&mappingRuleSnapshot{
-				name:       "mappingRule2.snapshot1",
-				tombstoned: false,
-				cutoverNs:  15000,
-				filter:     filter1,
+				name:         "mappingRule2.snapshot1",
+				tombstoned:   false,
+				cutoverNanos: 15000,
+				filter:       filter1,
 				policies: []policy.Policy{
 					policy.NewPolicy(10*time.Second, xtime.Second, 12*time.Hour),
 				},
 			},
 			&mappingRuleSnapshot{
-				name:       "mappingRule2.snapshot2",
-				tombstoned: false,
-				cutoverNs:  22000,
-				filter:     filter1,
+				name:         "mappingRule2.snapshot2",
+				tombstoned:   false,
+				cutoverNanos: 22000,
+				filter:       filter1,
 				policies: []policy.Policy{
 					policy.NewPolicy(10*time.Second, xtime.Second, 2*time.Hour),
 					policy.NewPolicy(time.Minute, xtime.Minute, time.Hour),
 				},
 			},
 			&mappingRuleSnapshot{
-				name:       "mappingRule2.snapshot3",
-				tombstoned: true,
-				cutoverNs:  35000,
-				filter:     filter1,
-				policies:   []policy.Policy{},
+				name:         "mappingRule2.snapshot3",
+				tombstoned:   true,
+				cutoverNanos: 35000,
+				filter:       filter1,
+				policies:     []policy.Policy{},
 			},
 		},
 	}
@@ -795,10 +795,10 @@ func testMappingRules(t *testing.T) []*mappingRule {
 		uuid: "mappingRule3",
 		snapshots: []*mappingRuleSnapshot{
 			&mappingRuleSnapshot{
-				name:       "mappingRule3.snapshot1",
-				tombstoned: false,
-				cutoverNs:  22000,
-				filter:     filter1,
+				name:         "mappingRule3.snapshot1",
+				tombstoned:   false,
+				cutoverNanos: 22000,
+				filter:       filter1,
 				policies: []policy.Policy{
 					policy.NewPolicy(10*time.Second, xtime.Second, 12*time.Hour),
 					policy.NewPolicy(time.Minute, xtime.Minute, 24*time.Hour),
@@ -806,10 +806,10 @@ func testMappingRules(t *testing.T) []*mappingRule {
 				},
 			},
 			&mappingRuleSnapshot{
-				name:       "mappingRule3.snapshot2",
-				tombstoned: false,
-				cutoverNs:  34000,
-				filter:     filter1,
+				name:         "mappingRule3.snapshot2",
+				tombstoned:   false,
+				cutoverNanos: 34000,
+				filter:       filter1,
 				policies: []policy.Policy{
 					policy.NewPolicy(10*time.Second, xtime.Second, 2*time.Hour),
 					policy.NewPolicy(time.Minute, xtime.Minute, time.Hour),
@@ -822,10 +822,10 @@ func testMappingRules(t *testing.T) []*mappingRule {
 		uuid: "mappingRule4",
 		snapshots: []*mappingRuleSnapshot{
 			&mappingRuleSnapshot{
-				name:       "mappingRule4.snapshot1",
-				tombstoned: false,
-				cutoverNs:  24000,
-				filter:     filter2,
+				name:         "mappingRule4.snapshot1",
+				tombstoned:   false,
+				cutoverNanos: 24000,
+				filter:       filter2,
 				policies: []policy.Policy{
 					policy.NewPolicy(10*time.Second, xtime.Second, 24*time.Hour),
 				},
@@ -837,10 +837,10 @@ func testMappingRules(t *testing.T) []*mappingRule {
 		uuid: "mappingRule5",
 		snapshots: []*mappingRuleSnapshot{
 			&mappingRuleSnapshot{
-				name:       "mappingRule5.snapshot1",
-				tombstoned: false,
-				cutoverNs:  100000,
-				filter:     filter1,
+				name:         "mappingRule5.snapshot1",
+				tombstoned:   false,
+				cutoverNanos: 100000,
+				filter:       filter1,
 				policies: []policy.Policy{
 					policy.NewPolicy(10*time.Second, xtime.Second, 24*time.Hour),
 				},
@@ -874,10 +874,10 @@ func testRollupRules(t *testing.T) []*rollupRule {
 		uuid: "rollupRule1",
 		snapshots: []*rollupRuleSnapshot{
 			&rollupRuleSnapshot{
-				name:       "rollupRule1.snapshot1",
-				tombstoned: false,
-				cutoverNs:  10000,
-				filter:     filter1,
+				name:         "rollupRule1.snapshot1",
+				tombstoned:   false,
+				cutoverNanos: 10000,
+				filter:       filter1,
 				targets: []rollupTarget{
 					{
 						Name: b("rName1"),
@@ -889,10 +889,10 @@ func testRollupRules(t *testing.T) []*rollupRule {
 				},
 			},
 			&rollupRuleSnapshot{
-				name:       "rollupRule1.snapshot2",
-				tombstoned: false,
-				cutoverNs:  20000,
-				filter:     filter1,
+				name:         "rollupRule1.snapshot2",
+				tombstoned:   false,
+				cutoverNanos: 20000,
+				filter:       filter1,
 				targets: []rollupTarget{
 					{
 						Name: b("rName1"),
@@ -906,10 +906,10 @@ func testRollupRules(t *testing.T) []*rollupRule {
 				},
 			},
 			&rollupRuleSnapshot{
-				name:       "rollupRule1.snapshot3",
-				tombstoned: false,
-				cutoverNs:  30000,
-				filter:     filter1,
+				name:         "rollupRule1.snapshot3",
+				tombstoned:   false,
+				cutoverNanos: 30000,
+				filter:       filter1,
 				targets: []rollupTarget{
 					{
 						Name: b("rName1"),
@@ -927,10 +927,10 @@ func testRollupRules(t *testing.T) []*rollupRule {
 		uuid: "rollupRule2",
 		snapshots: []*rollupRuleSnapshot{
 			&rollupRuleSnapshot{
-				name:       "rollupRule2.snapshot1",
-				tombstoned: false,
-				cutoverNs:  15000,
-				filter:     filter1,
+				name:         "rollupRule2.snapshot1",
+				tombstoned:   false,
+				cutoverNanos: 15000,
+				filter:       filter1,
 				targets: []rollupTarget{
 					{
 						Name: b("rName1"),
@@ -942,10 +942,10 @@ func testRollupRules(t *testing.T) []*rollupRule {
 				},
 			},
 			&rollupRuleSnapshot{
-				name:       "rollupRule2.snapshot2",
-				tombstoned: false,
-				cutoverNs:  22000,
-				filter:     filter1,
+				name:         "rollupRule2.snapshot2",
+				tombstoned:   false,
+				cutoverNanos: 22000,
+				filter:       filter1,
 				targets: []rollupTarget{
 					{
 						Name: b("rName1"),
@@ -958,10 +958,10 @@ func testRollupRules(t *testing.T) []*rollupRule {
 				},
 			},
 			&rollupRuleSnapshot{
-				name:       "rollupRule2.snapshot3",
-				tombstoned: false,
-				cutoverNs:  35000,
-				filter:     filter1,
+				name:         "rollupRule2.snapshot3",
+				tombstoned:   false,
+				cutoverNanos: 35000,
+				filter:       filter1,
 				targets: []rollupTarget{
 					{
 						Name: b("rName1"),
@@ -979,10 +979,10 @@ func testRollupRules(t *testing.T) []*rollupRule {
 		uuid: "rollupRule3",
 		snapshots: []*rollupRuleSnapshot{
 			&rollupRuleSnapshot{
-				name:       "rollupRule3.snapshot1",
-				tombstoned: false,
-				cutoverNs:  22000,
-				filter:     filter1,
+				name:         "rollupRule3.snapshot1",
+				tombstoned:   false,
+				cutoverNanos: 22000,
+				filter:       filter1,
 				targets: []rollupTarget{
 					{
 						Name: b("rName1"),
@@ -1003,10 +1003,10 @@ func testRollupRules(t *testing.T) []*rollupRule {
 				},
 			},
 			&rollupRuleSnapshot{
-				name:       "rollupRule3.snapshot2",
-				tombstoned: false,
-				cutoverNs:  34000,
-				filter:     filter1,
+				name:         "rollupRule3.snapshot2",
+				tombstoned:   false,
+				cutoverNanos: 34000,
+				filter:       filter1,
 				targets: []rollupTarget{
 					{
 						Name: b("rName1"),
@@ -1019,11 +1019,11 @@ func testRollupRules(t *testing.T) []*rollupRule {
 				},
 			},
 			&rollupRuleSnapshot{
-				name:       "rollupRule3.snapshot3",
-				tombstoned: true,
-				cutoverNs:  38000,
-				filter:     filter1,
-				targets:    []rollupTarget{},
+				name:         "rollupRule3.snapshot3",
+				tombstoned:   true,
+				cutoverNanos: 38000,
+				filter:       filter1,
+				targets:      []rollupTarget{},
 			},
 		},
 	}
@@ -1032,10 +1032,10 @@ func testRollupRules(t *testing.T) []*rollupRule {
 		uuid: "rollupRule4",
 		snapshots: []*rollupRuleSnapshot{
 			&rollupRuleSnapshot{
-				name:       "rollupRule4.snapshot1",
-				tombstoned: false,
-				cutoverNs:  24000,
-				filter:     filter2,
+				name:         "rollupRule4.snapshot1",
+				tombstoned:   false,
+				cutoverNanos: 24000,
+				filter:       filter2,
 				targets: []rollupTarget{
 					{
 						Name: b("rName3"),
@@ -1053,10 +1053,10 @@ func testRollupRules(t *testing.T) []*rollupRule {
 		uuid: "rollupRule5",
 		snapshots: []*rollupRuleSnapshot{
 			&rollupRuleSnapshot{
-				name:       "rollupRule5.snapshot1",
-				tombstoned: false,
-				cutoverNs:  100000,
-				filter:     filter1,
+				name:         "rollupRule5.snapshot1",
+				tombstoned:   false,
+				cutoverNanos: 100000,
+				filter:       filter1,
 				targets: []rollupTarget{
 					{
 						Name: b("rName3"),
@@ -1712,19 +1712,19 @@ func testRollupRulesConfig() []*schema.RollupRule {
 }
 
 type testMappingsData struct {
-	id         string
-	matchFrom  time.Time
-	matchTo    time.Time
-	expireAtNs int64
-	result     policy.PoliciesList
+	id            string
+	matchFrom     time.Time
+	matchTo       time.Time
+	expireAtNanos int64
+	result        policy.PoliciesList
 }
 
 type testRollupResultsData struct {
-	id         string
-	matchFrom  time.Time
-	matchTo    time.Time
-	expireAtNs int64
-	result     []RollupResult
+	id            string
+	matchFrom     time.Time
+	matchTo       time.Time
+	expireAtNanos int64
+	result        []RollupResult
 }
 
 func b(v string) []byte {


### PR DESCRIPTION
cc @jeromefroe @cw9 @robskillington @martin-mao @prateek 

This PR adds APIs to match an id against rules for a given time range, in which case the match result may contain more than one policies matched at different times within the time range. The main use case here is to handle clock skews between the collector and the aggregation tier. Specifically when collector matches metric IDs against rules at time T, it finds the matching result within [T-Tcs, T+Tcs) where Tcs is the max clock skew across all collectors, sends the match result to the aggregation tier, and let the aggregation tier decide which policies it should use since the aggregation tier's clock is considered the source of truth.

As a result, the PR also adds APIs to msgpack encode a list of staged policies and send that across the wire due to possible rule matches at multiple times within the time range.

This PR also includes a change to encode times as int64s using the epoch nanoseconds, which is sufficient for our usecases and more space efficient.