### PR TITLE
Add APIs to encode / decode metrics without policies

### DIFF
--- a/protocol/msgpack/types.go
+++ b/protocol/msgpack/types.go
@@ -200,6 +200,15 @@ type iteratorBase interface {
 
 // UnaggregatedEncoder is an encoder for encoding different types of unaggregated metrics.
 type UnaggregatedEncoder interface {
+	// EncodeCounter encodes a counter.
+	EncodeCounter(c unaggregated.Counter) error
+
+	// EncodeBatchTimer encodes a batch timer.
+	EncodeBatchTimer(bt unaggregated.BatchTimer) error
+
+	// EncodeGauge encodes a gauge.
+	EncodeGauge(g unaggregated.Gauge) error
+
 	// EncodeCounterWithPoliciesList encodes a counter with applicable policies list.
 	EncodeCounterWithPoliciesList(cp unaggregated.CounterWithPoliciesList) error
 
@@ -221,9 +230,13 @@ type UnaggregatedIterator interface {
 	// Next returns true if there are more items to decode.
 	Next() bool
 
-	// Value returns the current metric and applicable policies list.
+	// Metric returns the current metric.
 	// The returned value remains valid until the next Next() call.
-	Value() (unaggregated.MetricUnion, policy.PoliciesList)
+	Metric() unaggregated.MetricUnion
+
+	// PoliciesList returns the current applicable policies list.
+	// The returned value remains valid until the next Next() call.
+	PoliciesList() policy.PoliciesList
 
 	// Err returns the error encountered during decoding, if any.
 	Err() error

--- a/protocol/msgpack/unaggregated_encoder.go
+++ b/protocol/msgpack/unaggregated_encoder.go
@@ -69,6 +69,33 @@ func NewUnaggregatedEncoder(encoder BufferedEncoder) UnaggregatedEncoder {
 func (enc *unaggregatedEncoder) Encoder() BufferedEncoder      { return enc.encoder() }
 func (enc *unaggregatedEncoder) Reset(encoder BufferedEncoder) { enc.reset(encoder) }
 
+func (enc *unaggregatedEncoder) EncodeCounter(c unaggregated.Counter) error {
+	if err := enc.err(); err != nil {
+		return err
+	}
+	enc.encodeRootObjectFn(counterType)
+	enc.encodeCounterFn(c)
+	return enc.err()
+}
+
+func (enc *unaggregatedEncoder) EncodeBatchTimer(bt unaggregated.BatchTimer) error {
+	if err := enc.err(); err != nil {
+		return err
+	}
+	enc.encodeRootObjectFn(batchTimerType)
+	enc.encodeBatchTimerFn(bt)
+	return enc.err()
+}
+
+func (enc *unaggregatedEncoder) EncodeGauge(g unaggregated.Gauge) error {
+	if err := enc.err(); err != nil {
+		return err
+	}
+	enc.encodeRootObjectFn(gaugeType)
+	enc.encodeGaugeFn(g)
+	return enc.err()
+}
+
 func (enc *unaggregatedEncoder) EncodeCounterWithPoliciesList(cp unaggregated.CounterWithPoliciesList) error {
 	if err := enc.err(); err != nil {
 		return err


### PR DESCRIPTION
cc @robskillington @cw9 @jeromefroe @prateek 

This PR adds APIs to encode and decode metrics without policies so we can batch encode values sent from prod collectors to proxy collectors.