### PR TITLE
Move ID interface to m3metrics and add m3 id implementation

### DIFF
--- a/filters/filter_benchmark_test.go
+++ b/filters/filter_benchmark_test.go
@@ -24,6 +24,8 @@ import (
 	"bytes"
 	"fmt"
 	"testing"
+
+	"github.com/m3db/m3metrics/metric/id"
 )
 
 var (
@@ -64,7 +66,7 @@ func BenchmarkEquityFilterByValue(b *testing.B) {
 }
 
 func BenchmarkTagsFilterOne(b *testing.B) {
-	filter, _ := NewTagsFilter(testTagsFilterMapOne, NewMockSortedTagIterator, Conjunction)
+	filter, _ := NewTagsFilter(testTagsFilterMapOne, Conjunction, testTagsFilterOptions())
 	benchTagsFilter(b, testFlatID, filter)
 }
 
@@ -73,7 +75,7 @@ func BenchmarkMapTagsFilterOne(b *testing.B) {
 }
 
 func BenchmarkTagsFilterThree(b *testing.B) {
-	filter, _ := NewTagsFilter(testTagsFilterMapThree, NewMockSortedTagIterator, Conjunction)
+	filter, _ := NewTagsFilter(testTagsFilterMapThree, Conjunction, testTagsFilterOptions())
 	benchTagsFilter(b, testFlatID, filter)
 }
 
@@ -225,10 +227,10 @@ func (f testEqualityFilter) Matches(id []byte) bool {
 
 type testMapTagsFilter struct {
 	filters map[string]Filter
-	iterFn  NewSortedTagIteratorFn
+	iterFn  id.SortedTagIteratorFn
 }
 
-func newTestMapTagsFilter(tagFilters map[string]string, iterFn NewSortedTagIteratorFn) Filter {
+func newTestMapTagsFilter(tagFilters map[string]string, iterFn id.SortedTagIteratorFn) Filter {
 	filters := make(map[string]Filter, len(tagFilters))
 	for name, value := range tagFilters {
 		filter, _ := NewFilter([]byte(value))

--- a/filters/mock_filter.go
+++ b/filters/mock_filter.go
@@ -22,6 +22,8 @@ package filters
 
 import (
 	"strings"
+
+	"github.com/m3db/m3metrics/metric/id"
 )
 
 const (
@@ -45,8 +47,8 @@ type mockSortedTagIterator struct {
 	pairs []mockTagPair
 }
 
-func idToMockTagPairs(id []byte) []mockTagPair {
-	tagPairs := strings.Split(string(id), mockTagPairSeparator)
+func tagsToPairs(tags []byte) []mockTagPair {
+	tagPairs := strings.Split(string(tags), mockTagPairSeparator)
 	var pairs []mockTagPair
 	for _, pair := range tagPairs {
 		p := strings.Split(pair, mockTagValueSeparator)
@@ -56,9 +58,15 @@ func idToMockTagPairs(id []byte) []mockTagPair {
 }
 
 // NewMockSortedTagIterator creates a mock SortedTagIterator based on given ID.
-func NewMockSortedTagIterator(id []byte) SortedTagIterator {
-	pairs := idToMockTagPairs(id)
+func NewMockSortedTagIterator(tags []byte) id.SortedTagIterator {
+	pairs := tagsToPairs(tags)
 	return &mockSortedTagIterator{idx: -1, pairs: pairs}
+}
+
+func (it *mockSortedTagIterator) Reset(tags []byte) {
+	it.idx = -1
+	it.err = nil
+	it.pairs = tagsToPairs(tags)
 }
 
 func (it *mockSortedTagIterator) Next() bool {

--- a/filters/tags_filter.go
+++ b/filters/tags_filter.go
@@ -47,7 +47,7 @@ func (tn tagFiltersByNameAsc) Less(i, j int) bool { return bytes.Compare(tn[i].n
 // TagsFilterOptions provide a set of tag filter options.
 type TagsFilterOptions struct {
 	// Name of the name tag.
-	NameTagName []byte
+	NameTagKey []byte
 
 	// Function to extract name and tags from an id.
 	NameAndTagsFn id.NameAndTagsFn
@@ -80,7 +80,7 @@ func NewTagsFilter(
 			return nil, err
 		}
 		bName := []byte(name)
-		if bytes.Equal(opts.NameTagName, bName) {
+		if bytes.Equal(opts.NameTagKey, bName) {
 			nameFilter = valFilter
 		} else {
 			tagFilters = append(tagFilters, tagFilter{
@@ -103,7 +103,7 @@ func (f *tagsFilter) String() string {
 	var buf bytes.Buffer
 	numTagFilters := len(f.tagFilters)
 	if f.nameFilter != nil {
-		buf.WriteString(fmt.Sprintf("%s:%s", f.opts.NameTagName, f.nameFilter.String()))
+		buf.WriteString(fmt.Sprintf("%s:%s", f.opts.NameTagKey, f.nameFilter.String()))
 		if numTagFilters > 0 {
 			buf.WriteString(separator)
 		}

--- a/filters/tags_filter.go
+++ b/filters/tags_filter.go
@@ -24,26 +24,9 @@ import (
 	"bytes"
 	"fmt"
 	"sort"
+
+	"github.com/m3db/m3metrics/metric/id"
 )
-
-// SortedTagIterator iterates over a set of tag names and values
-// sorted by tag names in ascending order.
-type SortedTagIterator interface {
-	// Next returns true if there are more tag names and values.
-	Next() bool
-
-	// Current returns the current tag name and value.
-	Current() ([]byte, []byte)
-
-	// Err returns any errors encountered.
-	Err() error
-
-	// Close closes the iterator.
-	Close()
-}
-
-// NewSortedTagIteratorFn creates a tag iterator given an id.
-type NewSortedTagIteratorFn func(id []byte) SortedTagIterator
 
 // tagFilter is a filter associated with a given tag.
 type tagFilter struct {
@@ -61,42 +44,73 @@ func (tn tagFiltersByNameAsc) Len() int           { return len(tn) }
 func (tn tagFiltersByNameAsc) Swap(i, j int)      { tn[i], tn[j] = tn[j], tn[i] }
 func (tn tagFiltersByNameAsc) Less(i, j int) bool { return bytes.Compare(tn[i].name, tn[j].name) < 0 }
 
-// tagsFilter contains a list of tag filters.
-type tagsFilter struct {
-	filters []tagFilter
-	iterFn  NewSortedTagIteratorFn
-	op      LogicalOp
+// TagsFilterOptions provide a set of tag filter options.
+type TagsFilterOptions struct {
+	// Name of the name tag.
+	NameTagName []byte
+
+	// Function to extract name and tags from an id.
+	NameAndTagsFn id.NameAndTagsFn
+
+	// Function to create a new sorted tag iterator from id tags.
+	SortedTagIteratorFn id.SortedTagIteratorFn
 }
 
-// NewTagsFilter create a new tags filter.
-func NewTagsFilter(tagFilters map[string]string, iterFn NewSortedTagIteratorFn, op LogicalOp) (Filter, error) {
-	filters := make([]tagFilter, 0, len(tagFilters))
-	for name, value := range tagFilters {
+// tagsFilter contains a list of tag filters.
+type tagsFilter struct {
+	nameFilter Filter
+	tagFilters []tagFilter
+	op         LogicalOp
+	opts       TagsFilterOptions
+}
+
+// NewTagsFilter creates a new tags filter.
+func NewTagsFilter(
+	filters map[string]string,
+	op LogicalOp,
+	opts TagsFilterOptions,
+) (Filter, error) {
+	var (
+		nameFilter Filter
+		tagFilters = make([]tagFilter, 0, len(filters))
+	)
+	for name, value := range filters {
 		valFilter, err := NewFilter([]byte(value))
 		if err != nil {
 			return nil, err
 		}
-
-		filters = append(filters, tagFilter{
-			name:        []byte(name),
-			valueFilter: valFilter,
-		})
+		bName := []byte(name)
+		if bytes.Equal(opts.NameTagName, bName) {
+			nameFilter = valFilter
+		} else {
+			tagFilters = append(tagFilters, tagFilter{
+				name:        bName,
+				valueFilter: valFilter,
+			})
+		}
 	}
-	sort.Sort(tagFiltersByNameAsc(filters))
+	sort.Sort(tagFiltersByNameAsc(tagFilters))
 	return &tagsFilter{
-		filters: filters,
-		iterFn:  iterFn,
-		op:      op,
+		nameFilter: nameFilter,
+		tagFilters: tagFilters,
+		op:         op,
+		opts:       opts,
 	}, nil
 }
 
 func (f *tagsFilter) String() string {
 	separator := " " + string(f.op) + " "
 	var buf bytes.Buffer
-	numFilters := len(f.filters)
-	for i := 0; i < numFilters; i++ {
-		buf.WriteString(f.filters[i].String())
-		if i < numFilters-1 {
+	numTagFilters := len(f.tagFilters)
+	if f.nameFilter != nil {
+		buf.WriteString(fmt.Sprintf("%s:%s", f.opts.NameTagName, f.nameFilter.String()))
+		if numTagFilters > 0 {
+			buf.WriteString(separator)
+		}
+	}
+	for i := 0; i < numTagFilters; i++ {
+		buf.WriteString(f.tagFilters[i].String())
+		if i < numTagFilters-1 {
 			buf.WriteString(separator)
 		}
 	}
@@ -104,17 +118,26 @@ func (f *tagsFilter) String() string {
 }
 
 func (f *tagsFilter) Matches(id []byte) bool {
-	if len(f.filters) == 0 {
+	if f.nameFilter == nil && len(f.tagFilters) == 0 {
 		return true
 	}
-	iter := f.iterFn(id)
+
+	name, tags, err := f.opts.NameAndTagsFn(id)
+	if err != nil {
+		return false
+	}
+	if f.nameFilter != nil && !f.nameFilter.Matches(name) {
+		return false
+	}
+
+	iter := f.opts.SortedTagIteratorFn(tags)
 	defer iter.Close()
 
 	currIdx := 0
-	for iter.Next() && currIdx < len(f.filters) {
+	for iter.Next() && currIdx < len(f.tagFilters) {
 		name, value := iter.Current()
 
-		comparison := bytes.Compare(name, f.filters[currIdx].name)
+		comparison := bytes.Compare(name, f.tagFilters[currIdx].name)
 		if comparison < 0 {
 			continue
 		}
@@ -125,23 +148,23 @@ func (f *tagsFilter) Matches(id []byte) bool {
 				return false
 			}
 
-			// Iterate filters for the OR case.
+			// Iterate tagFilters for the OR case.
 			currIdx++
-			for currIdx < len(f.filters) && bytes.Compare(name, f.filters[currIdx].name) > 0 {
+			for currIdx < len(f.tagFilters) && bytes.Compare(name, f.tagFilters[currIdx].name) > 0 {
 				currIdx++
 			}
 
-			if currIdx == len(f.filters) {
-				// Past all filters.
+			if currIdx == len(f.tagFilters) {
+				// Past all tagFilters.
 				return false
 			}
 
-			if bytes.Compare(name, f.filters[currIdx].name) < 0 {
+			if bytes.Compare(name, f.tagFilters[currIdx].name) < 0 {
 				continue
 			}
 		}
 
-		match := f.filters[currIdx].valueFilter.Matches(value)
+		match := f.tagFilters[currIdx].valueFilter.Matches(value)
 		if match && f.op == Disjunction {
 			return true
 		}
@@ -157,5 +180,5 @@ func (f *tagsFilter) Matches(id []byte) bool {
 		return false
 	}
 
-	return currIdx == len(f.filters)
+	return currIdx == len(f.tagFilters)
 }

--- a/filters/tags_filter.go
+++ b/filters/tags_filter.go
@@ -126,8 +126,14 @@ func (f *tagsFilter) Matches(id []byte) bool {
 	if err != nil {
 		return false
 	}
-	if f.nameFilter != nil && !f.nameFilter.Matches(name) {
-		return false
+	if f.nameFilter != nil {
+		match := f.nameFilter.Matches(name)
+		if match && f.op == Disjunction {
+			return true
+		}
+		if !match && f.op == Conjunction {
+			return false
+		}
 	}
 
 	iter := f.opts.SortedTagIteratorFn(tags)

--- a/filters/tags_filter_test.go
+++ b/filters/tags_filter_test.go
@@ -84,7 +84,7 @@ func TestTagsFilterString(t *testing.T) {
 
 func testTagsFilterOptions() TagsFilterOptions {
 	return TagsFilterOptions{
-		NameTagName:         []byte("name"),
+		NameTagKey:          []byte("name"),
 		NameAndTagsFn:       func(b []byte) ([]byte, []byte, error) { return nil, b, nil },
 		SortedTagIteratorFn: NewMockSortedTagIterator,
 	}

--- a/filters/tags_filter_test.go
+++ b/filters/tags_filter_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestEmptyTagsFilterMatches(t *testing.T) {
-	f, err := NewTagsFilter(nil, NewMockSortedTagIterator, Conjunction)
+	f, err := NewTagsFilter(nil, Conjunction, testTagsFilterOptions())
 	require.NoError(t, err)
 	require.True(t, f.Matches([]byte("foo")))
 }
@@ -37,7 +37,7 @@ func TestTagsFilterMatches(t *testing.T) {
 		"tagName1": "tagValue1",
 		"tagName2": "tagValue2",
 	}
-	f, err := NewTagsFilter(filters, NewMockSortedTagIterator, Conjunction)
+	f, err := NewTagsFilter(filters, Conjunction, testTagsFilterOptions())
 	inputs := []mockFilterData{
 		{val: "tagName1=tagValue1,tagName2=tagValue2", match: true},
 		{val: "tagName0=tagValue0,tagName1=tagValue1,tagName2=tagValue2,tagName3=tagValue3", match: true},
@@ -50,7 +50,7 @@ func TestTagsFilterMatches(t *testing.T) {
 		require.Equal(t, input.match, f.Matches([]byte(input.val)))
 	}
 
-	f, err = NewTagsFilter(filters, NewMockSortedTagIterator, Disjunction)
+	f, err = NewTagsFilter(filters, Disjunction, testTagsFilterOptions())
 	inputs = []mockFilterData{
 		{val: "tagName1=tagValue1,tagName2=tagValue2", match: true},
 		{val: "tagName0=tagValue0,tagName1=tagValue1,tagName2=tagValue2,tagName3=tagValue3", match: true},
@@ -73,11 +73,19 @@ func TestTagsFilterString(t *testing.T) {
 		"tagName1": "tagValue1",
 		"tagName2": "tagValue2",
 	}
-	f, err := NewTagsFilter(filters, NewMockSortedTagIterator, Conjunction)
+	f, err := NewTagsFilter(filters, Conjunction, testTagsFilterOptions())
 	require.NoError(t, err)
 	require.Equal(t, `tagName1:Equals("tagValue1") && tagName2:Equals("tagValue2")`, f.String())
 
-	f, err = NewTagsFilter(filters, NewMockSortedTagIterator, Disjunction)
+	f, err = NewTagsFilter(filters, Disjunction, testTagsFilterOptions())
 	require.NoError(t, err)
 	require.Equal(t, `tagName1:Equals("tagValue1") || tagName2:Equals("tagValue2")`, f.String())
+}
+
+func testTagsFilterOptions() TagsFilterOptions {
+	return TagsFilterOptions{
+		NameTagName:         []byte("name"),
+		NameAndTagsFn:       func(b []byte) ([]byte, []byte, error) { return nil, b, nil },
+		SortedTagIteratorFn: NewMockSortedTagIterator,
+	}
 }

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 1da188c97d69803d7b0bb67a6e66b738eab076612e2d5a2f38c3b8f5c70421b8
-updated: 2017-05-07T19:11:45.678596443-04:00
+hash: 07a1a24c24370b50b8cb4f21bdd6fd9b1b787f00c87b1f3f95715f93d84594f2
+updated: 2017-05-09T23:04:21.133965573-04:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
@@ -16,12 +16,13 @@ imports:
   subpackages:
   - proto
 - name: github.com/m3db/m3x
-  version: 2a4b2eeb25be253ed5c57255e1c72bde13257d34
+  version: bd6be18ffb184691512eb442561b16a59c15d797
   subpackages:
   - checked
   - instrument
   - log
   - pool
+  - process
   - time
 - name: github.com/pmezard/go-difflib
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,7 +1,7 @@
 package: github.com/m3db/m3metrics
 import:
 - package: github.com/m3db/m3x
-  version: 2a4b2eeb25be253ed5c57255e1c72bde13257d34
+  version: bd6be18ffb184691512eb442561b16a59c15d797
   subpackages:
   - pool
   - time

--- a/metric/aggregated/types.go
+++ b/metric/aggregated/types.go
@@ -24,13 +24,13 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/m3db/m3metrics/metric"
+	"github.com/m3db/m3metrics/metric/id"
 	"github.com/m3db/m3metrics/policy"
 )
 
 // Metric is a metric, which is essentially a named value at certain time.
 type Metric struct {
-	metric.ID
+	ID        id.RawID
 	TimeNanos int64
 	Value     float64
 }
@@ -47,7 +47,7 @@ func (m Metric) String() string {
 
 // ChunkedMetric is a metric with a chunked ID.
 type ChunkedMetric struct {
-	metric.ChunkedID
+	id.ChunkedID
 	TimeNanos int64
 	Value     float64
 }
@@ -56,7 +56,7 @@ type ChunkedMetric struct {
 // a metric object).
 type RawMetric interface {
 	// ID is the metric identifier.
-	ID() (metric.ID, error)
+	ID() (id.RawID, error)
 
 	// TimeNanos is the metric timestamp in nanoseconds.
 	TimeNanos() (int64, error)

--- a/metric/id/id.go
+++ b/metric/id/id.go
@@ -32,7 +32,7 @@ type ID interface {
 }
 
 // NameAndTagsFn returns the name and the tag pairs given an id.
-type NameAndTagsFn func(id []byte) ([]byte, []byte, error)
+type NameAndTagsFn func(id []byte) (name []byte, tags []byte, err error)
 
 // NewIDFn creates a new metric ID based on the metric name and metric tag pairs.
 type NewIDFn func(name []byte, tags []TagPair) []byte

--- a/metric/id/id.go
+++ b/metric/id/id.go
@@ -18,17 +18,30 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package metric
+package id
 
 import "fmt"
 
-// ID is the metric id.
-// TODO(xichen): make ID a union of numeric ID and bytes-backed IDs
-// so we can compress IDs on a per-connection basis.
-type ID []byte
+// ID is a metric id.
+type ID interface {
+	// Bytes returns the raw bytes for this id.
+	Bytes() []byte
 
-// String is the string representation of an id.
-func (id ID) String() string { return string(id) }
+	// TagValue looks up the tag value for a tag name.
+	TagValue(tagName []byte) ([]byte, bool)
+}
+
+// NameAndTagsFn returns the name and the tag pairs given an id.
+type NameAndTagsFn func(id []byte) ([]byte, []byte, error)
+
+// NewIDFn creates a new metric ID based on the metric name and metric tag pairs.
+type NewIDFn func(name []byte, tags []TagPair) []byte
+
+// RawID is the raw metric id.
+type RawID []byte
+
+// String is the string representation of a raw id.
+func (rid RawID) String() string { return string(rid) }
 
 // ChunkedID is a three-part id.
 type ChunkedID struct {

--- a/metric/id/m3/id.go
+++ b/metric/id/m3/id.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Uber Technologies, Inc.
+// Copyright (c) 2017 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -33,7 +33,7 @@ package m3
 
 import (
 	"bytes"
-	"fmt"
+	"errors"
 	"sort"
 
 	"github.com/m3db/m3metrics/metric/id"
@@ -46,7 +46,7 @@ const (
 )
 
 var (
-	errInvalidM3Metric = fmt.Errorf("invalid m3 metric")
+	errInvalidM3Metric = errors.New("invalid m3 metric")
 	m3Prefix           = []byte("m3+")
 	rollupTagPair      = id.TagPair{
 		Name:  []byte("m3_rollup"),
@@ -173,7 +173,7 @@ func (it *sortedTagIterator) Next() bool {
 	}
 	it.tagName = it.sortedTagPairs[it.idx:nameSplitterIdx]
 	it.tagValue = it.sortedTagPairs[nameSplitterIdx+1 : pairSplitterIdx]
-	it.idx = pairSplitterIdx
+	it.idx = pairSplitterIdx + 1
 	return true
 }
 

--- a/metric/id/m3/id.go
+++ b/metric/id/m3/id.go
@@ -1,0 +1,197 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package m3 describes m3 metric id information.
+//
+// Each M3 metric id contains a metric name and a set of tag pairs. In particular,
+// it conforms to the following format:
+//
+// m3+<metric_name>+tagName1=tagValue1,tagName2=tagValue2,...tagNameN=tagValueN,
+//
+// Where the tag names are sorted alphabetically in ascending order.
+//
+// An example m3 metrid id is as follows:
+// m3+response_code+env=bar,service=foo,status=404,type=counters
+package m3
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+
+	"github.com/m3db/m3metrics/metric/id"
+)
+
+const (
+	componentSplitter = '+'
+	tagNameSplitter   = '='
+	tagPairSplitter   = ','
+)
+
+var (
+	errInvalidM3Metric = fmt.Errorf("invalid m3 metric")
+	m3Prefix           = []byte("m3+")
+	nameTagName        = []byte("name")
+	rollupTagPair      = id.TagPair{
+		Name:  []byte("m3_rollup"),
+		Value: []byte("true"),
+	}
+)
+
+// NewRollupID generates a new rollup id given the new metric name
+// and a list of tag pairs. Note that tagPairs are mutated in place.
+func NewRollupID(name []byte, tagPairs []id.TagPair) []byte {
+	var buf bytes.Buffer
+
+	// Adding rollup tag pair to the list of tag pairs.
+	tagPairs = append(tagPairs, rollupTagPair)
+	sort.Sort(id.TagPairsByNameAsc(tagPairs))
+
+	buf.Write(m3Prefix)
+	buf.Write(name)
+	buf.WriteByte(componentSplitter)
+	for i, p := range tagPairs {
+		buf.Write(p.Name)
+		buf.WriteByte(tagNameSplitter)
+		buf.Write(p.Value)
+		if i < len(tagPairs)-1 {
+			buf.WriteByte(tagPairSplitter)
+		}
+	}
+
+	return buf.Bytes()
+}
+
+// TODO(xichen): pool the mids.
+type mid struct {
+	id     []byte
+	iterFn id.SortedTagIteratorFn
+}
+
+// NewID creates a new m3 metric id.
+func NewID(id []byte, iterFn id.SortedTagIteratorFn) id.ID {
+	return mid{id: id, iterFn: iterFn}
+}
+
+func (id mid) Bytes() []byte { return id.id }
+
+func (id mid) TagValue(tagName []byte) ([]byte, bool) {
+	_, tagPairs, err := NameAndTags(id.Bytes())
+	if err != nil {
+		return nil, false
+	}
+
+	it := id.iterFn(tagPairs)
+	defer it.Close()
+
+	for it.Next() {
+		n, v := it.Current()
+		if bytes.Equal(tagName, n) {
+			return v, true
+		}
+	}
+	return nil, false
+}
+
+// NameAndTags returns the name and the tags of the given id.
+func NameAndTags(id []byte) ([]byte, []byte, error) {
+	firstSplitterIdx := bytes.IndexByte(id, componentSplitter)
+	if !bytes.Equal(m3Prefix, id[:firstSplitterIdx+1]) {
+		return nil, nil, errInvalidM3Metric
+	}
+	secondSplitterIdx := bytes.IndexByte(id[firstSplitterIdx+1:], componentSplitter)
+	if secondSplitterIdx == -1 {
+		return nil, nil, errInvalidM3Metric
+	}
+	secondSplitterIdx = firstSplitterIdx + 1 + secondSplitterIdx
+	name := id[firstSplitterIdx+1 : secondSplitterIdx]
+	tags := id[secondSplitterIdx+1:]
+	return name, tags, nil
+}
+
+type sortedTagIterator struct {
+	tagPairs []byte
+	idx      int
+	tagName  []byte
+	tagValue []byte
+	err      error
+	pool     id.SortedTagIteratorPool
+}
+
+// NewSortedTagIterator creates a new sorted tag iterator.
+func NewSortedTagIterator(tagPairs []byte) id.SortedTagIterator {
+	return NewPooledSortedTagIterator(tagPairs, nil)
+}
+
+// NewPooledSortedTagIterator creates a new pooled sorted tag iterator.
+func NewPooledSortedTagIterator(tagPairs []byte, pool id.SortedTagIteratorPool) id.SortedTagIterator {
+	it := &sortedTagIterator{pool: pool}
+	it.Reset(tagPairs)
+	return it
+}
+
+func (it *sortedTagIterator) Reset(tagPairs []byte) {
+	it.tagPairs = tagPairs
+	it.idx = 0
+	it.tagName = nil
+	it.tagValue = nil
+	it.err = nil
+}
+
+func (it *sortedTagIterator) Next() bool {
+	if it.err != nil || it.idx >= len(it.tagPairs) {
+		return false
+	}
+	nameSplitterIdx := bytes.IndexByte(it.tagPairs[it.idx:], tagNameSplitter)
+	if nameSplitterIdx == -1 {
+		it.err = errInvalidM3Metric
+		return false
+	}
+	nameSplitterIdx = it.idx + nameSplitterIdx
+	pairSplitterIdx := bytes.IndexByte(it.tagPairs[nameSplitterIdx+1:], tagPairSplitter)
+	if pairSplitterIdx != -1 {
+		pairSplitterIdx = nameSplitterIdx + 1 + pairSplitterIdx
+	} else {
+		pairSplitterIdx = len(it.tagPairs)
+	}
+	it.tagName = it.tagPairs[it.idx:nameSplitterIdx]
+	it.tagValue = it.tagPairs[nameSplitterIdx+1 : pairSplitterIdx]
+	it.idx = pairSplitterIdx
+	return true
+}
+
+func (it *sortedTagIterator) Current() ([]byte, []byte) {
+	return it.tagName, it.tagValue
+}
+
+func (it *sortedTagIterator) Err() error {
+	return it.err
+}
+
+func (it *sortedTagIterator) Close() {
+	it.tagPairs = nil
+	it.idx = 0
+	it.tagName = nil
+	it.tagValue = nil
+	it.err = nil
+	if it.pool != nil {
+		it.pool.Put(it)
+	}
+}

--- a/metric/id/m3/id_test.go
+++ b/metric/id/m3/id_test.go
@@ -1,0 +1,172 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package m3
+
+import (
+	"testing"
+
+	"github.com/m3db/m3metrics/metric/id"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewRollupID(t *testing.T) {
+	var (
+		name     = []byte("foo")
+		tagPairs = []id.TagPair{
+			{Name: []byte("tagName1"), Value: []byte("tagValue1")},
+			{Name: []byte("tagName2"), Value: []byte("tagValue2")},
+			{Name: []byte("tagName0"), Value: []byte("tagValue0")},
+		}
+	)
+	expected := []byte("m3+foo+m3_rollup=true,tagName0=tagValue0,tagName1=tagValue1,tagName2=tagValue2")
+	require.Equal(t, expected, NewRollupID(name, tagPairs))
+}
+
+func TestMetricIDTagValue(t *testing.T) {
+	iterPool := id.NewSortedTagIteratorPool(nil)
+	iterPool.Init(func() id.SortedTagIterator {
+		return NewPooledSortedTagIterator(nil, iterPool)
+	})
+	inputs := []struct {
+		id            id.ID
+		tagName       []byte
+		expectedValue []byte
+		expectedFound bool
+	}{
+		{
+			id:            NewID([]byte("m3+foo+tagName1=tagValue1,tagName2=tagValue2"), iterPool),
+			tagName:       []byte("tagName1"),
+			expectedValue: []byte("tagValue1"),
+			expectedFound: true,
+		},
+		{
+			id:            NewID([]byte("m3+foo+tagName1=tagValue1,tagName2=tagValue2"), iterPool),
+			tagName:       []byte("tagName2"),
+			expectedValue: []byte("tagValue2"),
+			expectedFound: true,
+		},
+		{
+			id:            NewID([]byte("m3+foo+tagName1=tagValue1,tagName2=tagValue2"), iterPool),
+			tagName:       []byte("tagName3"),
+			expectedValue: nil,
+			expectedFound: false,
+		},
+		{
+			id:            NewID([]byte("illformed+tagName1=tagValue1,tagName2=tagValue2"), iterPool),
+			tagName:       []byte("tagName1"),
+			expectedValue: nil,
+			expectedFound: false,
+		},
+	}
+	for _, input := range inputs {
+		value, found := input.id.TagValue(input.tagName)
+		require.Equal(t, input.expectedValue, value)
+		require.Equal(t, input.expectedFound, found)
+	}
+}
+
+func TestNameAndTags(t *testing.T) {
+	inputs := []struct {
+		id           []byte
+		expectedName []byte
+		expectedTags []byte
+		expectedErr  error
+	}{
+		{
+			id:           []byte("m3+foo+tagName1=tagValue1"),
+			expectedName: []byte("foo"),
+			expectedTags: []byte("tagName1=tagValue1"),
+			expectedErr:  nil,
+		},
+		{
+			id:           []byte("m3+foo+tagName1=tagValue1,tagName2=tagValue2"),
+			expectedName: []byte("foo"),
+			expectedTags: []byte("tagName1=tagValue1,tagName2=tagValue2"),
+			expectedErr:  nil,
+		},
+		{
+			id:           []byte("illformed"),
+			expectedName: nil,
+			expectedTags: nil,
+			expectedErr:  errInvalidM3Metric,
+		},
+		{
+			id:           []byte("m3+illformed"),
+			expectedName: nil,
+			expectedTags: nil,
+			expectedErr:  errInvalidM3Metric,
+		},
+		{
+			id:           []byte("m3+illformed+tagName1,"),
+			expectedName: []byte("illformed"),
+			expectedTags: []byte("tagName1,"),
+			expectedErr:  nil,
+		},
+	}
+	for _, input := range inputs {
+		name, tags, err := NameAndTags(input.id)
+		require.Equal(t, input.expectedName, name)
+		require.Equal(t, input.expectedTags, tags)
+		require.Equal(t, input.expectedErr, err)
+	}
+}
+
+func TestSortedTagIterator(t *testing.T) {
+	inputs := []struct {
+		sortedTagPairs []byte
+		expectedPairs  []id.TagPair
+		expectedErr    error
+	}{
+		{
+			sortedTagPairs: []byte("tagName1=tagValue1"),
+			expectedPairs: []id.TagPair{
+				{Name: []byte("tagName1"), Value: []byte("tagValue1")},
+			},
+			expectedErr: nil,
+		},
+		{
+			sortedTagPairs: []byte("tagName1=tagValue1,tagName2=tagValue2,tagName3=tagValue3"),
+			expectedPairs: []id.TagPair{
+				{Name: []byte("tagName1"), Value: []byte("tagValue1")},
+				{Name: []byte("tagName2"), Value: []byte("tagValue2")},
+				{Name: []byte("tagName3"), Value: []byte("tagValue3")},
+			},
+			expectedErr: nil,
+		},
+		{
+			sortedTagPairs: []byte("tagName1"),
+			expectedPairs:  nil,
+			expectedErr:    errInvalidM3Metric,
+		},
+	}
+
+	for _, input := range inputs {
+		it := NewSortedTagIterator(input.sortedTagPairs)
+		var result []id.TagPair
+		for it.Next() {
+			name, value := it.Current()
+			result = append(result, id.TagPair{Name: name, Value: value})
+		}
+		require.Equal(t, input.expectedErr, it.Err())
+		require.Equal(t, input.expectedPairs, result)
+	}
+}

--- a/metric/id/tag.go
+++ b/metric/id/tag.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Uber Technologies, Inc.
+// Copyright (c) 2017 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal

--- a/metric/id/tag.go
+++ b/metric/id/tag.go
@@ -45,11 +45,10 @@ func (tp TagPairsByNameAsc) Less(i, j int) bool {
 // SortedTagIteratorFn creates a new sorted tag iterator given id tag pairs.
 type SortedTagIteratorFn func(tagPairs []byte) SortedTagIterator
 
-// SortedTagIterator iterates over a set of tag names and values
-// sorted by tag names in ascending order.
+// SortedTagIterator iterates over a set of tag pairs sorted by tag names.
 type SortedTagIterator interface {
 	// Reset resets the iterator.
-	Reset(tagPairs []byte)
+	Reset(sortedTagPairs []byte)
 
 	// Next returns true if there are more tag names and values.
 	Next() bool

--- a/metric/id/tag.go
+++ b/metric/id/tag.go
@@ -1,0 +1,103 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package id
+
+import (
+	"bytes"
+
+	"github.com/m3db/m3x/pool"
+)
+
+// TagPair contains a tag name and a tag value.
+type TagPair struct {
+	Name  []byte
+	Value []byte
+}
+
+// TagPairsByNameAsc sorts the tag pairs by tag names in ascending order.
+type TagPairsByNameAsc []TagPair
+
+func (tp TagPairsByNameAsc) Len() int      { return len(tp) }
+func (tp TagPairsByNameAsc) Swap(i, j int) { tp[i], tp[j] = tp[j], tp[i] }
+
+func (tp TagPairsByNameAsc) Less(i, j int) bool {
+	return bytes.Compare(tp[i].Name, tp[j].Name) < 0
+}
+
+// SortedTagIteratorFn creates a new sorted tag iterator given id tag pairs.
+type SortedTagIteratorFn func(tagPairs []byte) SortedTagIterator
+
+// SortedTagIterator iterates over a set of tag names and values
+// sorted by tag names in ascending order.
+type SortedTagIterator interface {
+	// Reset resets the iterator.
+	Reset(tagPairs []byte)
+
+	// Next returns true if there are more tag names and values.
+	Next() bool
+
+	// Current returns the current tag name and value.
+	Current() ([]byte, []byte)
+
+	// Err returns any errors encountered.
+	Err() error
+
+	// Close closes the iterator.
+	Close()
+}
+
+// SortedTagIteratorAlloc allocates a new sorted tag iterator.
+type SortedTagIteratorAlloc func() SortedTagIterator
+
+// SortedTagIteratorPool is a pool of sorted tag iterators.
+type SortedTagIteratorPool interface {
+	// Init initializes the iterator pool.
+	Init(alloc SortedTagIteratorAlloc)
+
+	// Get gets an iterator from the pool.
+	Get() SortedTagIterator
+
+	// Put returns an iterator to the pool.
+	Put(value SortedTagIterator)
+}
+
+type sortedTagIteratorPool struct {
+	pool pool.ObjectPool
+}
+
+// NewSortedTagIteratorPool creates a new pool for sorted tag iterators.
+func NewSortedTagIteratorPool(opts pool.ObjectPoolOptions) SortedTagIteratorPool {
+	return &sortedTagIteratorPool{pool: pool.NewObjectPool(opts)}
+}
+
+func (p *sortedTagIteratorPool) Init(alloc SortedTagIteratorAlloc) {
+	p.pool.Init(func() interface{} {
+		return alloc()
+	})
+}
+
+func (p *sortedTagIteratorPool) Get() SortedTagIterator {
+	return p.pool.Get().(SortedTagIterator)
+}
+
+func (p *sortedTagIteratorPool) Put(it SortedTagIterator) {
+	p.pool.Put(it)
+}

--- a/metric/id/tag_test.go
+++ b/metric/id/tag_test.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package id
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTagPairsByNameAsc(t *testing.T) {
+	inputs := []TagPair{
+		{Name: []byte("baz"), Value: []byte("first")},
+		{Name: []byte("foo"), Value: []byte("second")},
+		{Name: []byte("bar"), Value: []byte("third")},
+	}
+	expected := []TagPair{inputs[2], inputs[0], inputs[1]}
+	sort.Sort(TagPairsByNameAsc(inputs))
+	require.Equal(t, expected, inputs)
+}

--- a/metric/unaggregated/types.go
+++ b/metric/unaggregated/types.go
@@ -23,7 +23,7 @@ package unaggregated
 import (
 	"fmt"
 
-	"github.com/m3db/m3metrics/metric"
+	"github.com/m3db/m3metrics/metric/id"
 	"github.com/m3db/m3metrics/policy"
 	"github.com/m3db/m3x/pool"
 )
@@ -54,19 +54,19 @@ func (t Type) String() string {
 
 // Counter is a counter containing the counter ID and the counter value.
 type Counter struct {
-	ID    metric.ID
+	ID    id.RawID
 	Value int64
 }
 
 // BatchTimer is a timer containing the timer ID and a list of timer values.
 type BatchTimer struct {
-	ID     metric.ID
+	ID     id.RawID
 	Values []float64
 }
 
 // Gauge is a gauge containing the gauge ID and the value at certain time.
 type Gauge struct {
-	ID    metric.ID
+	ID    id.RawID
 	Value float64
 }
 
@@ -96,7 +96,7 @@ type GaugeWithPoliciesList struct {
 // NB(xichen): possibly use refcounting to replace explicit ownership tracking.
 type MetricUnion struct {
 	Type          Type
-	ID            metric.ID
+	ID            id.RawID
 	CounterVal    int64
 	BatchTimerVal []float64
 	GaugeVal      float64

--- a/protocol/msgpack/aggregated_encoder.go
+++ b/protocol/msgpack/aggregated_encoder.go
@@ -102,7 +102,7 @@ func (enc *aggregatedEncoder) encodeRootObject(objType objectType) {
 func (enc *aggregatedEncoder) encodeMetricAsRaw(m aggregated.Metric) []byte {
 	enc.buf.resetData()
 	enc.encodeMetricProlog()
-	enc.buf.encodeID(m.ID)
+	enc.buf.encodeRawID(m.ID)
 	enc.buf.encodeVarint(m.TimeNanos)
 	enc.buf.encodeFloat64(m.Value)
 	return enc.buf.encoder().Bytes()

--- a/protocol/msgpack/aggregated_roundtrip_test.go
+++ b/protocol/msgpack/aggregated_roundtrip_test.go
@@ -27,8 +27,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/m3db/m3metrics/metric"
 	"github.com/m3db/m3metrics/metric/aggregated"
+	"github.com/m3db/m3metrics/metric/id"
 	"github.com/m3db/m3metrics/policy"
 	"github.com/m3db/m3x/time"
 
@@ -37,12 +37,12 @@ import (
 
 var (
 	testMetric = aggregated.Metric{
-		ID:        metric.ID("foo"),
+		ID:        id.RawID("foo"),
 		TimeNanos: time.Now().UnixNano(),
 		Value:     123.45,
 	}
 	testChunkedMetric = aggregated.ChunkedMetric{
-		ChunkedID: metric.ChunkedID{
+		ChunkedID: id.ChunkedID{
 			Prefix: []byte("foo."),
 			Data:   []byte("bar"),
 			Suffix: []byte(".baz"),
@@ -51,7 +51,7 @@ var (
 		Value:     123.45,
 	}
 	testMetric2 = aggregated.Metric{
-		ID:        metric.ID("bar"),
+		ID:        id.RawID("bar"),
 		TimeNanos: time.Now().UnixNano(),
 		Value:     678.90,
 	}
@@ -136,7 +136,7 @@ func validateAggregatedRoundtripWithEncoderAndIterator(
 			})
 			require.NoError(t, testAggregatedEncode(t, encoder, inputMetric, input.policy))
 		case aggregated.ChunkedMetric:
-			var id metric.ID
+			var id id.RawID
 			id = append(id, inputMetric.ChunkedID.Prefix...)
 			id = append(id, inputMetric.ChunkedID.Data...)
 			id = append(id, inputMetric.ChunkedID.Suffix...)

--- a/protocol/msgpack/base_encoder.go
+++ b/protocol/msgpack/base_encoder.go
@@ -21,7 +21,7 @@
 package msgpack
 
 import (
-	"github.com/m3db/m3metrics/metric"
+	"github.com/m3db/m3metrics/metric/id"
 	"github.com/m3db/m3metrics/policy"
 )
 
@@ -67,7 +67,7 @@ func (enc *baseEncoder) encodePolicy(p policy.Policy)        { enc.encodePolicyF
 func (enc *baseEncoder) encodeVersion(version int)           { enc.encodeVarint(int64(version)) }
 func (enc *baseEncoder) encodeObjectType(objType objectType) { enc.encodeVarint(int64(objType)) }
 func (enc *baseEncoder) encodeNumObjectFields(numFields int) { enc.encodeArrayLen(numFields) }
-func (enc *baseEncoder) encodeID(id metric.ID)               { enc.encodeBytes([]byte(id)) }
+func (enc *baseEncoder) encodeRawID(id id.RawID)             { enc.encodeBytes([]byte(id)) }
 func (enc *baseEncoder) encodeVarint(value int64)            { enc.encodeVarintFn(value) }
 func (enc *baseEncoder) encodeBool(value bool)               { enc.encodeBoolFn(value) }
 func (enc *baseEncoder) encodeFloat64(value float64)         { enc.encodeFloat64Fn(value) }
@@ -80,7 +80,7 @@ func (enc *baseEncoder) reset(encoder BufferedEncoder) {
 	enc.encodeErr = nil
 }
 
-func (enc *baseEncoder) encodeChunkedID(id metric.ChunkedID) {
+func (enc *baseEncoder) encodeChunkedID(id id.ChunkedID) {
 	enc.encodeBytesLen(len(id.Prefix) + len(id.Data) + len(id.Suffix))
 	enc.writeRaw(id.Prefix)
 	enc.writeRaw(id.Data)

--- a/protocol/msgpack/base_iterator.go
+++ b/protocol/msgpack/base_iterator.go
@@ -27,7 +27,7 @@ import (
 	"io"
 	"time"
 
-	"github.com/m3db/m3metrics/metric"
+	"github.com/m3db/m3metrics/metric/id"
 	"github.com/m3db/m3metrics/policy"
 	"github.com/m3db/m3x/time"
 
@@ -170,8 +170,8 @@ func (it *baseIterator) decodeNumObjectFields() int {
 	return int(it.decodeArrayLen())
 }
 
-func (it *baseIterator) decodeID() metric.ID {
-	return metric.ID(it.decodeBytes())
+func (it *baseIterator) decodeRawID() id.RawID {
+	return id.RawID(it.decodeBytes())
 }
 
 // NB(xichen): the underlying msgpack decoder implementation

--- a/protocol/msgpack/raw_metric.go
+++ b/protocol/msgpack/raw_metric.go
@@ -25,8 +25,8 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/m3db/m3metrics/metric"
 	"github.com/m3db/m3metrics/metric/aggregated"
+	"github.com/m3db/m3metrics/metric/id"
 )
 
 var (
@@ -57,7 +57,7 @@ func NewRawMetric(data []byte, readerBufferSize int) aggregated.RawMetric {
 	return m
 }
 
-func (m *rawMetric) ID() (metric.ID, error) {
+func (m *rawMetric) ID() (id.RawID, error) {
 	m.decodeID()
 	if err := m.it.err(); err != nil {
 		return nil, err

--- a/protocol/msgpack/raw_metric_test.go
+++ b/protocol/msgpack/raw_metric_test.go
@@ -26,8 +26,8 @@ import (
 	"io"
 	"testing"
 
-	"github.com/m3db/m3metrics/metric"
 	"github.com/m3db/m3metrics/metric/aggregated"
+	"github.com/m3db/m3metrics/metric/id"
 	"github.com/m3db/m3metrics/policy"
 
 	"github.com/stretchr/testify/require"
@@ -186,9 +186,9 @@ func TestRawMetricNilID(t *testing.T) {
 
 func TestRawMetricReset(t *testing.T) {
 	metrics := []aggregated.Metric{
-		{ID: metric.ID("foo"), TimeNanos: testMetric.TimeNanos, Value: 1.0},
-		{ID: metric.ID("bar"), TimeNanos: testMetric.TimeNanos, Value: 2.3},
-		{ID: metric.ID("baz"), TimeNanos: testMetric.TimeNanos, Value: 4234.234},
+		{ID: id.RawID("foo"), TimeNanos: testMetric.TimeNanos, Value: 1.0},
+		{ID: id.RawID("bar"), TimeNanos: testMetric.TimeNanos, Value: 2.3},
+		{ID: id.RawID("baz"), TimeNanos: testMetric.TimeNanos, Value: 4234.234},
 	}
 	rawMetric := NewRawMetric(nil, 16)
 	for i := 0; i < len(metrics); i++ {
@@ -201,9 +201,9 @@ func TestRawMetricReset(t *testing.T) {
 
 func TestRawMetricRoundtripStress(t *testing.T) {
 	metrics := []aggregated.Metric{
-		{ID: metric.ID("foo"), TimeNanos: testMetric.TimeNanos, Value: 1.0},
-		{ID: metric.ID("bar"), TimeNanos: testMetric.TimeNanos, Value: 2.3},
-		{ID: metric.ID("baz"), TimeNanos: testMetric.TimeNanos, Value: 4234.234},
+		{ID: id.RawID("foo"), TimeNanos: testMetric.TimeNanos, Value: 1.0},
+		{ID: id.RawID("bar"), TimeNanos: testMetric.TimeNanos, Value: 2.3},
+		{ID: id.RawID("baz"), TimeNanos: testMetric.TimeNanos, Value: 4234.234},
 	}
 	var (
 		inputs  []aggregated.Metric
@@ -243,7 +243,7 @@ func (it *mockBaseIterator) decodePolicy() policy.Policy  { return policy.EmptyP
 func (it *mockBaseIterator) decodeVersion() int           { return it.decodeVersionFn() }
 func (it *mockBaseIterator) decodeObjectType() objectType { return unknownType }
 func (it *mockBaseIterator) decodeNumObjectFields() int   { return 0 }
-func (it *mockBaseIterator) decodeID() metric.ID          { return nil }
+func (it *mockBaseIterator) decodeRawID() id.RawID        { return nil }
 func (it *mockBaseIterator) decodeVarint() int64          { return it.decodeVarintFn() }
 func (it *mockBaseIterator) decodeBool() bool             { return false }
 func (it *mockBaseIterator) decodeFloat64() float64       { return it.decodeFloat64Fn() }

--- a/protocol/msgpack/types.go
+++ b/protocol/msgpack/types.go
@@ -24,8 +24,8 @@ import (
 	"bytes"
 	"io"
 
-	"github.com/m3db/m3metrics/metric"
 	"github.com/m3db/m3metrics/metric/aggregated"
+	"github.com/m3db/m3metrics/metric/id"
 	"github.com/m3db/m3metrics/metric/unaggregated"
 	"github.com/m3db/m3metrics/policy"
 	"github.com/m3db/m3x/pool"
@@ -114,11 +114,11 @@ type encoderBase interface {
 	// encodeNumObjectFields encodes the number of object fields.
 	encodeNumObjectFields(numFields int)
 
-	// encodeID encodes an ID.
-	encodeID(id metric.ID)
+	// encodeRawID encodes a raw ID.
+	encodeRawID(id id.RawID)
 
 	// encodeChunkedID encodes a chunked ID.
-	encodeChunkedID(id metric.ChunkedID)
+	encodeChunkedID(id id.ChunkedID)
 
 	// encodeVarint encodes an integer value as varint.
 	encodeVarint(value int64)
@@ -165,8 +165,8 @@ type iteratorBase interface {
 	// decodeNumObjectFields decodes the number of object fields.
 	decodeNumObjectFields() int
 
-	// decodeID decodes an ID.
-	decodeID() metric.ID
+	// decodeRawID decodes a raw ID.
+	decodeRawID() id.RawID
 
 	// decodeVarint decodes a variable-width integer value.
 	decodeVarint() int64

--- a/protocol/msgpack/unaggregated_encoder.go
+++ b/protocol/msgpack/unaggregated_encoder.go
@@ -149,13 +149,13 @@ func (enc *unaggregatedEncoder) encodeGaugeWithPoliciesList(gp unaggregated.Gaug
 
 func (enc *unaggregatedEncoder) encodeCounter(c unaggregated.Counter) {
 	enc.encodeNumObjectFields(numFieldsForType(counterType))
-	enc.encodeID(c.ID)
+	enc.encodeRawID(c.ID)
 	enc.encodeVarint(int64(c.Value))
 }
 
 func (enc *unaggregatedEncoder) encodeBatchTimer(bt unaggregated.BatchTimer) {
 	enc.encodeNumObjectFields(numFieldsForType(batchTimerType))
-	enc.encodeID(bt.ID)
+	enc.encodeRawID(bt.ID)
 	enc.encodeArrayLen(len(bt.Values))
 	for _, v := range bt.Values {
 		enc.encodeFloat64(v)
@@ -164,7 +164,7 @@ func (enc *unaggregatedEncoder) encodeBatchTimer(bt unaggregated.BatchTimer) {
 
 func (enc *unaggregatedEncoder) encodeGauge(g unaggregated.Gauge) {
 	enc.encodeNumObjectFields(numFieldsForType(gaugeType))
-	enc.encodeID(g.ID)
+	enc.encodeRawID(g.ID)
 	enc.encodeFloat64(g.Value)
 }
 

--- a/protocol/msgpack/unaggregated_iterator.go
+++ b/protocol/msgpack/unaggregated_iterator.go
@@ -25,7 +25,7 @@ import (
 	"io"
 	"math"
 
-	"github.com/m3db/m3metrics/metric"
+	"github.com/m3db/m3metrics/metric/id"
 	"github.com/m3db/m3metrics/metric/unaggregated"
 	"github.com/m3db/m3metrics/policy"
 	"github.com/m3db/m3x/pool"
@@ -48,7 +48,7 @@ type unaggregatedIterator struct {
 	closed             bool
 	metric             unaggregated.MetricUnion
 	policiesList       policy.PoliciesList
-	id                 metric.ID
+	id                 id.RawID
 	timerValues        []float64
 	cachedPolicies     [][]policy.Policy
 	cachedPoliciesList policy.PoliciesList
@@ -302,7 +302,7 @@ func (it *unaggregatedIterator) decodeStagedPolicies(policyIdx int) policy.Stage
 	return stagedPolicies
 }
 
-func (it *unaggregatedIterator) decodeID() metric.ID {
+func (it *unaggregatedIterator) decodeID() id.RawID {
 	idLen := it.decodeBytesLen()
 	if it.err() != nil {
 		return nil
@@ -310,7 +310,7 @@ func (it *unaggregatedIterator) decodeID() metric.ID {
 	// NB(xichen): DecodeBytesLen() returns -1 if the byte slice is nil.
 	if idLen == -1 {
 		it.id = it.id[:0]
-		return metric.ID(it.id)
+		return id.RawID(it.id)
 	}
 	if cap(it.id) < idLen {
 		it.id = make([]byte, idLen)

--- a/rules/mapping.go
+++ b/rules/mapping.go
@@ -45,7 +45,7 @@ type mappingRuleSnapshot struct {
 
 func newMappingRuleSnapshot(
 	r *schema.MappingRuleSnapshot,
-	iterFn filters.NewSortedTagIteratorFn,
+	opts filters.TagsFilterOptions,
 ) (*mappingRuleSnapshot, error) {
 	if r == nil {
 		return nil, errNilMappingRuleSnapshotSchema
@@ -54,7 +54,7 @@ func newMappingRuleSnapshot(
 	if err != nil {
 		return nil, err
 	}
-	filter, err := filters.NewTagsFilter(r.TagFilters, iterFn, filters.Conjunction)
+	filter, err := filters.NewTagsFilter(r.TagFilters, filters.Conjunction, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -75,14 +75,14 @@ type mappingRule struct {
 
 func newMappingRule(
 	mc *schema.MappingRule,
-	iterFn filters.NewSortedTagIteratorFn,
+	opts filters.TagsFilterOptions,
 ) (*mappingRule, error) {
 	if mc == nil {
 		return nil, errNilMappingRuleSchema
 	}
 	snapshots := make([]*mappingRuleSnapshot, 0, len(mc.Snapshots))
 	for i := 0; i < len(mc.Snapshots); i++ {
-		mr, err := newMappingRuleSnapshot(mc.Snapshots[i], iterFn)
+		mr, err := newMappingRuleSnapshot(mc.Snapshots[i], opts)
 		if err != nil {
 			return nil, err
 		}

--- a/rules/mapping_test.go
+++ b/rules/mapping_test.go
@@ -89,17 +89,17 @@ var (
 )
 
 func TestMappingRuleSnapshotNilSchema(t *testing.T) {
-	_, err := newMappingRuleSnapshot(nil, nil)
+	_, err := newMappingRuleSnapshot(nil, testTagsFilterOptions())
 	require.Equal(t, err, errNilMappingRuleSnapshotSchema)
 }
 
 func TestNewMappingRuleNilSchema(t *testing.T) {
-	_, err := newMappingRule(nil, nil)
+	_, err := newMappingRule(nil, testTagsFilterOptions())
 	require.Equal(t, err, errNilMappingRuleSchema)
 }
 
 func TestNewMappingRule(t *testing.T) {
-	mr, err := newMappingRule(testMappingRuleSchema, nil)
+	mr, err := newMappingRule(testMappingRuleSchema, testTagsFilterOptions())
 	require.NoError(t, err)
 	require.Equal(t, "12669817-13ae-40e6-ba2f-33087b262c68", mr.uuid)
 	expectedSnapshots := []struct {
@@ -135,31 +135,31 @@ func TestNewMappingRule(t *testing.T) {
 }
 
 func TestMappingRuleActiveSnapshotNotFound(t *testing.T) {
-	mr, err := newMappingRule(testMappingRuleSchema, nil)
+	mr, err := newMappingRule(testMappingRuleSchema, testTagsFilterOptions())
 	require.NoError(t, err)
 	require.Nil(t, mr.ActiveSnapshot(0))
 }
 
 func TestMappingRuleActiveSnapshotFound_Second(t *testing.T) {
-	mr, err := newMappingRule(testMappingRuleSchema, nil)
+	mr, err := newMappingRule(testMappingRuleSchema, testTagsFilterOptions())
 	require.NoError(t, err)
 	require.Equal(t, mr.snapshots[1], mr.ActiveSnapshot(100000))
 }
 
 func TestMappingRuleActiveSnapshotFound_First(t *testing.T) {
-	mr, err := newMappingRule(testMappingRuleSchema, nil)
+	mr, err := newMappingRule(testMappingRuleSchema, testTagsFilterOptions())
 	require.NoError(t, err)
 	require.Equal(t, mr.snapshots[0], mr.ActiveSnapshot(20000))
 }
 
 func TestMappingRuleActiveRuleNotFound(t *testing.T) {
-	mr, err := newMappingRule(testMappingRuleSchema, nil)
+	mr, err := newMappingRule(testMappingRuleSchema, testTagsFilterOptions())
 	require.NoError(t, err)
 	require.Equal(t, mr, mr.ActiveRule(0))
 }
 
 func TestMappingRuleActiveRuleFound_Second(t *testing.T) {
-	mr, err := newMappingRule(testMappingRuleSchema, nil)
+	mr, err := newMappingRule(testMappingRuleSchema, testTagsFilterOptions())
 	require.NoError(t, err)
 	expected := &mappingRule{
 		uuid:      mr.uuid,
@@ -169,7 +169,7 @@ func TestMappingRuleActiveRuleFound_Second(t *testing.T) {
 }
 
 func TestMappingRuleActiveRuleFound_First(t *testing.T) {
-	mr, err := newMappingRule(testMappingRuleSchema, nil)
+	mr, err := newMappingRule(testMappingRuleSchema, testTagsFilterOptions())
 	require.NoError(t, err)
 	require.Equal(t, mr, mr.ActiveRule(20000))
 }

--- a/rules/options.go
+++ b/rules/options.go
@@ -20,29 +20,29 @@
 
 package rules
 
-import "github.com/m3db/m3metrics/filters"
-
-// NewIDFn creates a new metric ID based on the metric name and metric tag pairs.
-type NewIDFn func(name []byte, tags []TagPair) []byte
+import (
+	"github.com/m3db/m3metrics/filters"
+	"github.com/m3db/m3metrics/metric/id"
+)
 
 // Options provide a set of options for rule matching.
 type Options interface {
-	// SetNewSortedTagIteratorFn sets the new sorted tag iterator function.
-	SetNewSortedTagIteratorFn(value filters.NewSortedTagIteratorFn) Options
+	// SetTagsFilterOptions sets the tags filter options.
+	SetTagsFilterOptions(value filters.TagsFilterOptions) Options
 
-	// NewSortedTagIteratorFn returns the new sorted tag iterator function.
-	NewSortedTagIteratorFn() filters.NewSortedTagIteratorFn
+	// TagsFilterOptions returns the tags filter options.
+	TagsFilterOptions() filters.TagsFilterOptions
 
-	// SetNewIDFn sets the new id function.
-	SetNewIDFn(value NewIDFn) Options
+	// SetNewRollupIDFn sets the new rollup id function.
+	SetNewRollupIDFn(value id.NewIDFn) Options
 
-	// NewIDFn returns the new id function.
-	NewIDFn() NewIDFn
+	// NewRollupIDFn returns the new rollup id function.
+	NewRollupIDFn() id.NewIDFn
 }
 
 type options struct {
-	iterFn  filters.NewSortedTagIteratorFn
-	newIDFn NewIDFn
+	tagsFilterOpts filters.TagsFilterOptions
+	newRollupIDFn  id.NewIDFn
 }
 
 // NewOptions creates a new set of options.
@@ -50,22 +50,22 @@ func NewOptions() Options {
 	return &options{}
 }
 
-func (o *options) SetNewSortedTagIteratorFn(value filters.NewSortedTagIteratorFn) Options {
-	opts := o
-	opts.iterFn = value
-	return opts
+func (o *options) SetTagsFilterOptions(value filters.TagsFilterOptions) Options {
+	opts := *o
+	opts.tagsFilterOpts = value
+	return &opts
 }
 
-func (o *options) NewSortedTagIteratorFn() filters.NewSortedTagIteratorFn {
-	return o.iterFn
+func (o *options) TagsFilterOptions() filters.TagsFilterOptions {
+	return o.tagsFilterOpts
 }
 
-func (o *options) SetNewIDFn(value NewIDFn) Options {
-	opts := o
-	opts.newIDFn = value
-	return opts
+func (o *options) SetNewRollupIDFn(value id.NewIDFn) Options {
+	opts := *o
+	opts.newRollupIDFn = value
+	return &opts
 }
 
-func (o *options) NewIDFn() NewIDFn {
-	return o.newIDFn
+func (o *options) NewRollupIDFn() id.NewIDFn {
+	return o.newRollupIDFn
 }

--- a/rules/rollup.go
+++ b/rules/rollup.go
@@ -106,7 +106,7 @@ type rollupRuleSnapshot struct {
 
 func newRollupRuleSnapshot(
 	r *schema.RollupRuleSnapshot,
-	iterFn filters.NewSortedTagIteratorFn,
+	opts filters.TagsFilterOptions,
 ) (*rollupRuleSnapshot, error) {
 	if r == nil {
 		return nil, errNilRollupRuleSnapshotSchema
@@ -119,7 +119,7 @@ func newRollupRuleSnapshot(
 		}
 		targets = append(targets, target)
 	}
-	filter, err := filters.NewTagsFilter(r.TagFilters, iterFn, filters.Conjunction)
+	filter, err := filters.NewTagsFilter(r.TagFilters, filters.Conjunction, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -140,14 +140,14 @@ type rollupRule struct {
 
 func newRollupRule(
 	mc *schema.RollupRule,
-	iterFn filters.NewSortedTagIteratorFn,
+	opts filters.TagsFilterOptions,
 ) (*rollupRule, error) {
 	if mc == nil {
 		return nil, errNilRollupRuleSchema
 	}
 	snapshots := make([]*rollupRuleSnapshot, 0, len(mc.Snapshots))
 	for i := 0; i < len(mc.Snapshots); i++ {
-		mr, err := newRollupRuleSnapshot(mc.Snapshots[i], iterFn)
+		mr, err := newRollupRuleSnapshot(mc.Snapshots[i], opts)
 		if err != nil {
 			return nil, err
 		}

--- a/rules/rollup_test.go
+++ b/rules/rollup_test.go
@@ -154,17 +154,17 @@ func TestRollupTargetClone(t *testing.T) {
 }
 
 func TestRollupRuleSnapshotNilSchema(t *testing.T) {
-	_, err := newRollupRuleSnapshot(nil, nil)
+	_, err := newRollupRuleSnapshot(nil, testTagsFilterOptions())
 	require.Equal(t, errNilRollupRuleSnapshotSchema, err)
 }
 
 func TestRollupRuleNilSchema(t *testing.T) {
-	_, err := newRollupRule(nil, nil)
+	_, err := newRollupRule(nil, testTagsFilterOptions())
 	require.Equal(t, errNilRollupRuleSchema, err)
 }
 
 func TestRollupRuleValidSchema(t *testing.T) {
-	rr, err := newRollupRule(testRollupRuleSchema, nil)
+	rr, err := newRollupRule(testRollupRuleSchema, testTagsFilterOptions())
 	require.NoError(t, err)
 	require.Equal(t, "12669817-13ae-40e6-ba2f-33087b262c68", rr.uuid)
 
@@ -213,25 +213,25 @@ func TestRollupRuleValidSchema(t *testing.T) {
 }
 
 func TestRollupRuleActiveSnapshotNotFound(t *testing.T) {
-	rr, err := newRollupRule(testRollupRuleSchema, nil)
+	rr, err := newRollupRule(testRollupRuleSchema, testTagsFilterOptions())
 	require.NoError(t, err)
 	require.Nil(t, rr.ActiveSnapshot(0))
 }
 
 func TestRollupRuleActiveSnapshotFound(t *testing.T) {
-	rr, err := newRollupRule(testRollupRuleSchema, nil)
+	rr, err := newRollupRule(testRollupRuleSchema, testTagsFilterOptions())
 	require.NoError(t, err)
 	require.Equal(t, rr.snapshots[1], rr.ActiveSnapshot(100000))
 }
 
 func TestRollupRuleActiveRuleNotFound(t *testing.T) {
-	rr, err := newRollupRule(testRollupRuleSchema, nil)
+	rr, err := newRollupRule(testRollupRuleSchema, testTagsFilterOptions())
 	require.NoError(t, err)
 	require.Equal(t, rr, rr.ActiveRule(0))
 }
 
 func TestRollupRuleActiveRuleFound(t *testing.T) {
-	rr, err := newRollupRule(testRollupRuleSchema, nil)
+	rr, err := newRollupRule(testRollupRuleSchema, testTagsFilterOptions())
 	require.NoError(t, err)
 	expected := &rollupRule{
 		uuid:      rr.uuid,

--- a/rules/ruleset.go
+++ b/rules/ruleset.go
@@ -29,7 +29,7 @@ import (
 
 	"github.com/m3db/m3metrics/filters"
 	"github.com/m3db/m3metrics/generated/proto/schema"
-	mid "github.com/m3db/m3metrics/metric/id"
+	metricID "github.com/m3db/m3metrics/metric/id"
 	"github.com/m3db/m3metrics/policy"
 )
 
@@ -52,14 +52,14 @@ type activeRuleSet struct {
 	rollupRules     []*rollupRule
 	cutoverTimesAsc []int64
 	tagFilterOpts   filters.TagsFilterOptions
-	newRollupIDFn   mid.NewIDFn
+	newRollupIDFn   metricID.NewIDFn
 }
 
 func newActiveRuleSet(
 	mappingRules []*mappingRule,
 	rollupRules []*rollupRule,
 	tagFilterOpts filters.TagsFilterOptions,
-	newRollupIDFn mid.NewIDFn,
+	newRollupIDFn metricID.NewIDFn,
 ) *activeRuleSet {
 	uniqueCutoverTimes := make(map[int64]struct{})
 	for _, mappingRule := range mappingRules {
@@ -224,7 +224,7 @@ func (as *activeRuleSet) toRollupResults(id []byte, cutoverNanos int64, targets 
 		return nil
 	}
 
-	var tagPairs []mid.TagPair
+	var tagPairs []metricID.TagPair
 	rollups := make([]RollupResult, 0, len(targets))
 	for _, target := range targets {
 		tagPairs = tagPairs[:0]
@@ -240,7 +240,7 @@ func (as *activeRuleSet) toRollupResults(id []byte, cutoverNanos int64, targets 
 			tagName, tagVal := tagIter.Current()
 			res := bytes.Compare(tagName, target.Tags[targetTagIdx])
 			if res == 0 {
-				tagPairs = append(tagPairs, mid.TagPair{Name: tagName, Value: tagVal})
+				tagPairs = append(tagPairs, metricID.TagPair{Name: tagName, Value: tagVal})
 				targetTagIdx++
 				hasMoreTags = tagIter.Next()
 				continue
@@ -316,7 +316,7 @@ type ruleSet struct {
 	mappingRules       []*mappingRule
 	rollupRules        []*rollupRule
 	tagsFilterOpts     filters.TagsFilterOptions
-	newRollupIDFn      mid.NewIDFn
+	newRollupIDFn      metricID.NewIDFn
 }
 
 // NewRuleSet creates a new ruleset.

--- a/rules/ruleset.go
+++ b/rules/ruleset.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/m3db/m3metrics/filters"
 	"github.com/m3db/m3metrics/generated/proto/schema"
+	mid "github.com/m3db/m3metrics/metric/id"
 	"github.com/m3db/m3metrics/policy"
 )
 
@@ -40,12 +41,6 @@ var (
 	errNilRuleSetSchema = errors.New("nil rule set schema")
 )
 
-// TagPair contains a tag name and a tag value.
-type TagPair struct {
-	Name  []byte
-	Value []byte
-}
-
 // Matcher matches metrics against rules to determine applicable policies.
 type Matcher interface {
 	// MatchAll returns all applicable policies given a metric id between [from, to).
@@ -53,18 +48,18 @@ type Matcher interface {
 }
 
 type activeRuleSet struct {
-	iterFn          filters.NewSortedTagIteratorFn
-	newIDFn         NewIDFn
 	mappingRules    []*mappingRule
 	rollupRules     []*rollupRule
 	cutoverTimesAsc []int64
+	tagFilterOpts   filters.TagsFilterOptions
+	newRollupIDFn   mid.NewIDFn
 }
 
 func newActiveRuleSet(
-	iterFn filters.NewSortedTagIteratorFn,
-	newIDFn NewIDFn,
 	mappingRules []*mappingRule,
 	rollupRules []*rollupRule,
+	tagFilterOpts filters.TagsFilterOptions,
+	newRollupIDFn mid.NewIDFn,
 ) *activeRuleSet {
 	uniqueCutoverTimes := make(map[int64]struct{})
 	for _, mappingRule := range mappingRules {
@@ -85,11 +80,11 @@ func newActiveRuleSet(
 	sort.Sort(int64Asc(cutoverTimesAsc))
 
 	return &activeRuleSet{
-		iterFn:          iterFn,
-		newIDFn:         newIDFn,
 		mappingRules:    mappingRules,
 		rollupRules:     rollupRules,
 		cutoverTimesAsc: cutoverTimesAsc,
+		tagFilterOpts:   tagFilterOpts,
+		newRollupIDFn:   newRollupIDFn,
 	}
 }
 
@@ -221,23 +216,45 @@ func (as *activeRuleSet) toRollupResults(id []byte, cutoverNanos int64, targets 
 	if len(targets) == 0 {
 		return nil
 	}
-	var tagPairs []TagPair
+
+	// If we cannot extract tags from the id, this is likely an invalid
+	// metric and we bail early.
+	_, tags, err := as.tagFilterOpts.NameAndTagsFn(id)
+	if err != nil {
+		return nil
+	}
+
+	var tagPairs []mid.TagPair
 	rollups := make([]RollupResult, 0, len(targets))
 	for _, target := range targets {
 		tagPairs = tagPairs[:0]
-		for _, tag := range target.Tags {
-			iter := as.iterFn(id)
-			for iter.Next() {
-				name, value := iter.Current()
-				if bytes.Equal(name, tag) {
-					tagPairs = append(tagPairs, TagPair{Name: tag, Value: value})
-					break
-				}
+
+		// NB(xichen): this takes advantage of the fact that the tags in each rollup
+		// target is sorted in ascending order.
+		var (
+			tagIter      = as.tagFilterOpts.SortedTagIteratorFn(tags)
+			hasMoreTags  = tagIter.Next()
+			targetTagIdx = 0
+		)
+		for hasMoreTags && targetTagIdx < len(target.Tags) {
+			tagName, tagVal := tagIter.Current()
+			res := bytes.Compare(tagName, target.Tags[targetTagIdx])
+			if res == 0 {
+				tagPairs = append(tagPairs, mid.TagPair{Name: tagName, Value: tagVal})
+				targetTagIdx++
+				hasMoreTags = tagIter.Next()
+				continue
 			}
-			iter.Close()
+			if res > 0 {
+				targetTagIdx++
+				continue
+			}
+			hasMoreTags = tagIter.Next()
 		}
+		tagIter.Close()
+
 		result := RollupResult{
-			ID:           as.newIDFn(target.Name, tagPairs),
+			ID:           as.newRollupIDFn(target.Name, tagPairs),
 			PoliciesList: policy.PoliciesList{policy.NewStagedPolicies(cutoverNanos, false, target.Policies)},
 		}
 		rollups = append(rollups, result)
@@ -296,10 +313,10 @@ type ruleSet struct {
 	lastUpdatedAtNanos int64
 	tombstoned         bool
 	cutoverNanos       int64
-	iterFn             filters.NewSortedTagIteratorFn
-	newIDFn            NewIDFn
 	mappingRules       []*mappingRule
 	rollupRules        []*rollupRule
+	tagsFilterOpts     filters.TagsFilterOptions
+	newRollupIDFn      mid.NewIDFn
 }
 
 // NewRuleSet creates a new ruleset.
@@ -307,10 +324,10 @@ func NewRuleSet(version int, rs *schema.RuleSet, opts Options) (RuleSet, error) 
 	if rs == nil {
 		return nil, errNilRuleSetSchema
 	}
-	iterFn := opts.NewSortedTagIteratorFn()
+	tagsFilterOpts := opts.TagsFilterOptions()
 	mappingRules := make([]*mappingRule, 0, len(rs.MappingRules))
-	for _, rollupRule := range rs.MappingRules {
-		mc, err := newMappingRule(rollupRule, iterFn)
+	for _, mappingRule := range rs.MappingRules {
+		mc, err := newMappingRule(mappingRule, tagsFilterOpts)
 		if err != nil {
 			return nil, err
 		}
@@ -318,7 +335,7 @@ func NewRuleSet(version int, rs *schema.RuleSet, opts Options) (RuleSet, error) 
 	}
 	rollupRules := make([]*rollupRule, 0, len(rs.RollupRules))
 	for _, rollupRule := range rs.RollupRules {
-		rc, err := newRollupRule(rollupRule, iterFn)
+		rc, err := newRollupRule(rollupRule, tagsFilterOpts)
 		if err != nil {
 			return nil, err
 		}
@@ -332,10 +349,10 @@ func NewRuleSet(version int, rs *schema.RuleSet, opts Options) (RuleSet, error) 
 		lastUpdatedAtNanos: rs.LastUpdatedAt,
 		tombstoned:         rs.Tombstoned,
 		cutoverNanos:       rs.CutoverTime,
-		iterFn:             iterFn,
-		newIDFn:            opts.NewIDFn(),
 		mappingRules:       mappingRules,
 		rollupRules:        rollupRules,
+		tagsFilterOpts:     tagsFilterOpts,
+		newRollupIDFn:      opts.NewRollupIDFn(),
 	}, nil
 }
 
@@ -356,7 +373,12 @@ func (rs *ruleSet) ActiveSet(t time.Time) Matcher {
 		activeRule := rollupRule.ActiveRule(timeNanos)
 		rollupRules = append(rollupRules, activeRule)
 	}
-	return newActiveRuleSet(rs.iterFn, rs.newIDFn, mappingRules, rollupRules)
+	return newActiveRuleSet(
+		mappingRules,
+		rollupRules,
+		rs.tagsFilterOpts,
+		rs.newRollupIDFn,
+	)
 }
 
 // resolvePolicies resolves the conflicts among policies if any, following the rules below:

--- a/rules/ruleset_test.go
+++ b/rules/ruleset_test.go
@@ -1714,7 +1714,7 @@ func testRollupRulesConfig() []*schema.RollupRule {
 
 func testTagsFilterOptions() filters.TagsFilterOptions {
 	return filters.TagsFilterOptions{
-		NameTagName:         []byte("name"),
+		NameTagKey:          []byte("name"),
 		NameAndTagsFn:       func(b []byte) ([]byte, []byte, error) { return nil, b, nil },
 		SortedTagIteratorFn: filters.NewMockSortedTagIterator,
 	}

--- a/rules/ruleset_test.go
+++ b/rules/ruleset_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/m3db/m3metrics/filters"
 	"github.com/m3db/m3metrics/generated/proto/schema"
+	"github.com/m3db/m3metrics/metric/id"
 	"github.com/m3db/m3metrics/policy"
 	"github.com/m3db/m3x/time"
 
@@ -150,10 +151,10 @@ func TestActiveRuleSetMatchMappingRules(t *testing.T) {
 
 	mappingRules := testMappingRules(t)
 	as := newActiveRuleSet(
-		filters.NewMockSortedTagIterator,
-		mockNewID,
 		mappingRules,
 		nil,
+		testTagsFilterOptions(),
+		mockNewID,
 	)
 	expectedCutovers := []int64{10000, 15000, 20000, 22000, 24000, 30000, 34000, 35000, 100000}
 	require.Equal(t, expectedCutovers, as.cutoverTimesAsc)
@@ -310,10 +311,10 @@ func TestActiveRuleSetMatchRollupRules(t *testing.T) {
 
 	rollupRules := testRollupRules(t)
 	as := newActiveRuleSet(
-		filters.NewMockSortedTagIterator,
-		mockNewID,
 		nil,
 		rollupRules,
+		testTagsFilterOptions(),
+		mockNewID,
 	)
 	expectedCutovers := []int64{10000, 15000, 20000, 22000, 24000, 30000, 34000, 35000, 38000, 100000}
 	require.Equal(t, expectedCutovers, as.cutoverTimesAsc)
@@ -713,14 +714,14 @@ func TestRuleSetActiveSet(t *testing.T) {
 func testMappingRules(t *testing.T) []*mappingRule {
 	filter1, err := filters.NewTagsFilter(
 		map[string]string{"mtagName1": "mtagValue1"},
-		filters.NewMockSortedTagIterator,
 		filters.Conjunction,
+		testTagsFilterOptions(),
 	)
 	require.NoError(t, err)
 	filter2, err := filters.NewTagsFilter(
 		map[string]string{"mtagName1": "mtagValue2"},
-		filters.NewMockSortedTagIterator,
 		filters.Conjunction,
+		testTagsFilterOptions(),
 	)
 	require.NoError(t, err)
 
@@ -857,16 +858,16 @@ func testRollupRules(t *testing.T) []*rollupRule {
 			"rtagName1": "rtagValue1",
 			"rtagName2": "rtagValue2",
 		},
-		filters.NewMockSortedTagIterator,
 		filters.Conjunction,
+		testTagsFilterOptions(),
 	)
 	require.NoError(t, err)
 	filter2, err := filters.NewTagsFilter(
 		map[string]string{
 			"rtagName1": "rtagValue2",
 		},
-		filters.NewMockSortedTagIterator,
 		filters.Conjunction,
+		testTagsFilterOptions(),
 	)
 	require.NoError(t, err)
 
@@ -1075,11 +1076,11 @@ func testRollupRules(t *testing.T) []*rollupRule {
 
 func testRuleSetOptions() Options {
 	return NewOptions().
-		SetNewSortedTagIteratorFn(filters.NewMockSortedTagIterator).
-		SetNewIDFn(mockNewID)
+		SetTagsFilterOptions(testTagsFilterOptions()).
+		SetNewRollupIDFn(mockNewID)
 }
 
-func mockNewID(name []byte, tags []TagPair) []byte {
+func mockNewID(name []byte, tags []id.TagPair) []byte {
 	if len(tags) == 0 {
 		return name
 	}
@@ -1708,6 +1709,14 @@ func testRollupRulesConfig() []*schema.RollupRule {
 				},
 			},
 		},
+	}
+}
+
+func testTagsFilterOptions() filters.TagsFilterOptions {
+	return filters.TagsFilterOptions{
+		NameTagName:         []byte("name"),
+		NameAndTagsFn:       func(b []byte) ([]byte, []byte, error) { return nil, b, nil },
+		SortedTagIteratorFn: filters.NewMockSortedTagIterator,
 	}
 }
 


### PR DESCRIPTION
cc @robskillington @cw9 @jeromefroe @prateek @martin-mao 

This PR moves the `ID` interface from m3collector to m3metrics so it can be shared across repos. It also adds the implementation and utility functions for M3 metrics, which will be used from collectors.