### PR TITLE
Add functions to find mapping policies for rollup metrics

### DIFF
--- a/metric/id/id.go
+++ b/metric/id/id.go
@@ -37,6 +37,9 @@ type NameAndTagsFn func(id []byte) (name []byte, tags []byte, err error)
 // NewIDFn creates a new metric ID based on the metric name and metric tag pairs.
 type NewIDFn func(name []byte, tags []TagPair) []byte
 
+// MatchIDFn determines whether an id is considered "matched" based on certain criteria.
+type MatchIDFn func(name []byte, tags []byte) bool
+
 // RawID is the raw metric id.
 type RawID []byte
 

--- a/metric/id/m3/id.go
+++ b/metric/id/m3/id.go
@@ -79,13 +79,19 @@ func NewRollupID(name []byte, tagPairs []id.TagPair) []byte {
 }
 
 // IsRollupID determines whether an id is a rollup id.
-func IsRollupID(id []byte) bool {
+// Caller may optionally pass in a pre-created sorted tag iterator for efficiency
+// reasons, in which case it is the caller's responsibility to close the iterator.
+func IsRollupID(id []byte, iter id.SortedTagIterator) bool {
 	_, tags, err := NameAndTags(id)
 	if err != nil {
 		return false
 	}
-	iter := NewSortedTagIterator(tags)
-	defer iter.Close()
+	if iter == nil {
+		iter = NewSortedTagIterator(tags)
+		defer iter.Close()
+	} else {
+		iter.Reset(tags)
+	}
 	for iter.Next() {
 		name, val := iter.Current()
 		if bytes.Equal(name, rollupTagPair.Name) && bytes.Equal(val, rollupTagPair.Value) {

--- a/metric/id/m3/id.go
+++ b/metric/id/m3/id.go
@@ -78,6 +78,23 @@ func NewRollupID(name []byte, tagPairs []id.TagPair) []byte {
 	return buf.Bytes()
 }
 
+// IsRollupID determines whether an id is a rollup id.
+func IsRollupID(id []byte) bool {
+	_, tags, err := NameAndTags(id)
+	if err != nil {
+		return false
+	}
+	iter := NewSortedTagIterator(tags)
+	defer iter.Close()
+	for iter.Next() {
+		name, val := iter.Current()
+		if bytes.Equal(name, rollupTagPair.Name) && bytes.Equal(val, rollupTagPair.Value) {
+			return true
+		}
+	}
+	return false
+}
+
 // TODO(xichen): pool the mids.
 type metricID struct {
 	id       []byte

--- a/metric/id/m3/id_test.go
+++ b/metric/id/m3/id_test.go
@@ -41,6 +41,20 @@ func TestNewRollupID(t *testing.T) {
 	require.Equal(t, expected, NewRollupID(name, tagPairs))
 }
 
+func TestIsRollupID(t *testing.T) {
+	inputs := []struct {
+		id       []byte
+		expected bool
+	}{
+		{id: []byte("m3+foo+a1=b1,m3_rollup=true,a2=b2"), expected: true},
+		{id: []byte("foo.bar.baz"), expected: false},
+		{id: []byte("m3+foo+a1=b1,a2=b2"), expected: false},
+	}
+	for _, input := range inputs {
+		require.Equal(t, input.expected, IsRollupID(input.id))
+	}
+}
+
 func TestMetricIDTagValue(t *testing.T) {
 	iterPool := id.NewSortedTagIteratorPool(nil)
 	iterPool.Init(func() id.SortedTagIterator {

--- a/metric/id/m3/id_test.go
+++ b/metric/id/m3/id_test.go
@@ -41,7 +41,7 @@ func TestNewRollupID(t *testing.T) {
 	require.Equal(t, expected, NewRollupID(name, tagPairs))
 }
 
-func TestIsRollupID(t *testing.T) {
+func TestIsRollupIDNilIterator(t *testing.T) {
 	inputs := []struct {
 		id       []byte
 		expected bool
@@ -51,7 +51,23 @@ func TestIsRollupID(t *testing.T) {
 		{id: []byte("m3+foo+a1=b1,a2=b2"), expected: false},
 	}
 	for _, input := range inputs {
-		require.Equal(t, input.expected, IsRollupID(input.id))
+		require.Equal(t, input.expected, IsRollupID(input.id, nil))
+	}
+}
+
+func TestIsRollupIDExternalIterator(t *testing.T) {
+	inputs := []struct {
+		id       []byte
+		expected bool
+	}{
+		{id: []byte("m3+foo+a1=b1,m3_rollup=true,a2=b2"), expected: true},
+		{id: []byte("foo.bar.baz"), expected: false},
+		{id: []byte("m3+foo+a1=b1,a2=b2"), expected: false},
+	}
+	it := NewSortedTagIterator(nil)
+	defer it.Close()
+	for _, input := range inputs {
+		require.Equal(t, input.expected, IsRollupID(input.id, it))
 	}
 }
 

--- a/rules/options.go
+++ b/rules/options.go
@@ -38,11 +38,18 @@ type Options interface {
 
 	// NewRollupIDFn returns the new rollup id function.
 	NewRollupIDFn() id.NewIDFn
+
+	// SetIsRollupIDFn sets the function that determines whether an id is a rollup id.
+	SetIsRollupIDFn(value id.MatchIDFn) Options
+
+	// IsRollupIDFn returns the function that determines whether an id is a rollup id.
+	IsRollupIDFn() id.MatchIDFn
 }
 
 type options struct {
 	tagsFilterOpts filters.TagsFilterOptions
 	newRollupIDFn  id.NewIDFn
+	isRollupIDFn   id.MatchIDFn
 }
 
 // NewOptions creates a new set of options.
@@ -68,4 +75,14 @@ func (o *options) SetNewRollupIDFn(value id.NewIDFn) Options {
 
 func (o *options) NewRollupIDFn() id.NewIDFn {
 	return o.newRollupIDFn
+}
+
+func (o *options) SetIsRollupIDFn(value id.MatchIDFn) Options {
+	opts := *o
+	opts.isRollupIDFn = value
+	return &opts
+}
+
+func (o *options) IsRollupIDFn() id.MatchIDFn {
+	return o.isRollupIDFn
 }

--- a/rules/ruleset_test.go
+++ b/rules/ruleset_test.go
@@ -48,10 +48,9 @@ func TestActiveRuleSetMappingPoliciesForNonRollupID(t *testing.T) {
 	inputs := []testMappingsData{
 		{
 			id:            "mtagName1=mtagValue1",
-			isRollupID:    false,
-			matchFrom:     time.Unix(0, 25000),
-			matchTo:       time.Unix(0, 25001),
-			opts:          MatchOptions{Mode: Full, UseDefaultIfNoMatch: true},
+			matchFrom:     25000,
+			matchTo:       25001,
+			matchMode:     Forward,
 			expireAtNanos: 30000,
 			result: policy.PoliciesList{
 				policy.NewStagedPolicies(
@@ -68,10 +67,9 @@ func TestActiveRuleSetMappingPoliciesForNonRollupID(t *testing.T) {
 		},
 		{
 			id:            "mtagName1=mtagValue1",
-			isRollupID:    false,
-			matchFrom:     time.Unix(0, 35000),
-			matchTo:       time.Unix(0, 35001),
-			opts:          MatchOptions{Mode: Full, UseDefaultIfNoMatch: true},
+			matchFrom:     35000,
+			matchTo:       35001,
+			matchMode:     Forward,
 			expireAtNanos: 100000,
 			result: policy.PoliciesList{
 				policy.NewStagedPolicies(
@@ -87,10 +85,9 @@ func TestActiveRuleSetMappingPoliciesForNonRollupID(t *testing.T) {
 		},
 		{
 			id:            "mtagName1=mtagValue2",
-			isRollupID:    false,
-			matchFrom:     time.Unix(0, 25000),
-			matchTo:       time.Unix(0, 25001),
-			opts:          MatchOptions{Mode: Full, UseDefaultIfNoMatch: true},
+			matchFrom:     25000,
+			matchTo:       25001,
+			matchMode:     Forward,
 			expireAtNanos: 30000,
 			result: policy.PoliciesList{
 				policy.NewStagedPolicies(
@@ -104,19 +101,17 @@ func TestActiveRuleSetMappingPoliciesForNonRollupID(t *testing.T) {
 		},
 		{
 			id:            "mtagName1=mtagValue3",
-			isRollupID:    false,
-			matchFrom:     time.Unix(0, 25000),
-			matchTo:       time.Unix(0, 25001),
-			opts:          MatchOptions{Mode: Full, UseDefaultIfNoMatch: true},
+			matchFrom:     25000,
+			matchTo:       25001,
+			matchMode:     Forward,
 			expireAtNanos: 30000,
 			result:        policy.DefaultPoliciesList,
 		},
 		{
 			id:            "mtagName1=mtagValue1",
-			isRollupID:    false,
-			matchFrom:     time.Unix(0, 10000),
-			matchTo:       time.Unix(0, 40000),
-			opts:          MatchOptions{Mode: Full, UseDefaultIfNoMatch: true},
+			matchFrom:     10000,
+			matchTo:       40000,
+			matchMode:     Forward,
 			expireAtNanos: 100000,
 			result: policy.PoliciesList{
 				policy.NewStagedPolicies(
@@ -176,10 +171,9 @@ func TestActiveRuleSetMappingPoliciesForNonRollupID(t *testing.T) {
 		},
 		{
 			id:            "mtagName1=mtagValue2",
-			isRollupID:    false,
-			matchFrom:     time.Unix(0, 10000),
-			matchTo:       time.Unix(0, 40000),
-			opts:          MatchOptions{Mode: Full, UseDefaultIfNoMatch: true},
+			matchFrom:     10000,
+			matchTo:       40000,
+			matchMode:     Forward,
 			expireAtNanos: 100000,
 			result: policy.PoliciesList{
 				policy.DefaultStagedPolicies,
@@ -200,11 +194,12 @@ func TestActiveRuleSetMappingPoliciesForNonRollupID(t *testing.T) {
 		nil,
 		testTagsFilterOptions(),
 		mockNewID,
+		nil,
 	)
 	expectedCutovers := []int64{10000, 15000, 20000, 22000, 24000, 30000, 34000, 35000, 100000}
 	require.Equal(t, expectedCutovers, as.cutoverTimesAsc)
 	for _, input := range inputs {
-		res := as.MatchAll(b(input.id), input.isRollupID, input.matchFrom, input.matchTo, input.opts)
+		res := as.MatchAll(b(input.id), input.matchFrom, input.matchTo, input.matchMode)
 		require.Equal(t, input.expireAtNanos, res.expireAtNanos)
 		require.Equal(t, input.result, res.MappingsAt(0))
 	}
@@ -214,10 +209,9 @@ func TestActiveRuleSetMappingPoliciesForRollupID(t *testing.T) {
 	inputs := []testMappingsData{
 		{
 			id:            "rName4|rtagName1=rtagValue2",
-			isRollupID:    true,
-			matchFrom:     time.Unix(0, 25000),
-			matchTo:       time.Unix(0, 25001),
-			opts:          MatchOptions{Mode: MappingPoliciesOnly, UseDefaultIfNoMatch: false},
+			matchFrom:     25000,
+			matchTo:       25001,
+			matchMode:     Reverse,
 			expireAtNanos: 30000,
 			result: policy.PoliciesList{
 				policy.NewStagedPolicies(
@@ -231,28 +225,25 @@ func TestActiveRuleSetMappingPoliciesForRollupID(t *testing.T) {
 		},
 		{
 			id:            "rName4|rtagName2=rtagValue2",
-			isRollupID:    true,
-			matchFrom:     time.Unix(0, 25000),
-			matchTo:       time.Unix(0, 25001),
-			opts:          MatchOptions{Mode: MappingPoliciesOnly, UseDefaultIfNoMatch: false},
+			matchFrom:     25000,
+			matchTo:       25001,
+			matchMode:     Reverse,
 			expireAtNanos: 30000,
 			result:        nil,
 		},
 		{
 			id:            "rName4|rtagName1=rtagValue2",
-			isRollupID:    true,
-			matchFrom:     time.Unix(0, 10000),
-			matchTo:       time.Unix(0, 10001),
-			opts:          MatchOptions{Mode: MappingPoliciesOnly, UseDefaultIfNoMatch: false},
+			matchFrom:     10000,
+			matchTo:       10001,
+			matchMode:     Reverse,
 			expireAtNanos: 15000,
 			result:        nil,
 		},
 		{
 			id:            "rName3|rtagName1=rtagValue2",
-			isRollupID:    true,
-			matchFrom:     time.Unix(0, 25000),
-			matchTo:       time.Unix(0, 25001),
-			opts:          MatchOptions{Mode: MappingPoliciesOnly, UseDefaultIfNoMatch: false},
+			matchFrom:     25000,
+			matchTo:       25001,
+			matchMode:     Reverse,
 			expireAtNanos: 30000,
 			result:        nil,
 		},
@@ -264,11 +255,12 @@ func TestActiveRuleSetMappingPoliciesForRollupID(t *testing.T) {
 		rollupRules,
 		testTagsFilterOptions(),
 		mockNewID,
+		func([]byte, []byte) bool { return true },
 	)
 	expectedCutovers := []int64{10000, 15000, 20000, 22000, 24000, 30000, 34000, 35000, 38000, 100000}
 	require.Equal(t, expectedCutovers, as.cutoverTimesAsc)
 	for _, input := range inputs {
-		res := as.MatchAll(b(input.id), input.isRollupID, input.matchFrom, input.matchTo, input.opts)
+		res := as.MatchAll(b(input.id), input.matchFrom, input.matchTo, input.matchMode)
 		require.Equal(t, input.expireAtNanos, res.expireAtNanos)
 		require.Equal(t, input.result, res.MappingsAt(0))
 		require.Nil(t, res.rollups)
@@ -279,10 +271,9 @@ func TestActiveRuleSetRollupResults(t *testing.T) {
 	inputs := []testRollupResultsData{
 		{
 			id:            "rtagName1=rtagValue1,rtagName2=rtagValue2,rtagName3=rtagValue3",
-			isRollupID:    false,
-			matchFrom:     time.Unix(0, 25000),
-			matchTo:       time.Unix(0, 25001),
-			opts:          MatchOptions{Mode: Full, UseDefaultIfNoMatch: true},
+			matchFrom:     25000,
+			matchTo:       25001,
+			matchMode:     Forward,
 			expireAtNanos: 30000,
 			result: []RollupResult{
 				{
@@ -316,10 +307,9 @@ func TestActiveRuleSetRollupResults(t *testing.T) {
 		},
 		{
 			id:            "rtagName1=rtagValue2",
-			isRollupID:    false,
-			matchFrom:     time.Unix(0, 25000),
-			matchTo:       time.Unix(0, 25001),
-			opts:          MatchOptions{Mode: Full, UseDefaultIfNoMatch: true},
+			matchFrom:     25000,
+			matchTo:       25001,
+			matchMode:     Forward,
 			expireAtNanos: 30000,
 			result: []RollupResult{
 				{
@@ -338,19 +328,17 @@ func TestActiveRuleSetRollupResults(t *testing.T) {
 		},
 		{
 			id:            "rtagName5=rtagValue5",
-			isRollupID:    false,
-			matchFrom:     time.Unix(0, 25000),
-			matchTo:       time.Unix(0, 25001),
-			opts:          MatchOptions{Mode: Full, UseDefaultIfNoMatch: true},
+			matchFrom:     25000,
+			matchTo:       25001,
+			matchMode:     Forward,
 			expireAtNanos: 30000,
 			result:        []RollupResult{},
 		},
 		{
 			id:            "rtagName1=rtagValue1,rtagName2=rtagValue2,rtagName3=rtagValue3",
-			isRollupID:    false,
-			matchFrom:     time.Unix(0, 10000),
-			matchTo:       time.Unix(0, 40000),
-			opts:          MatchOptions{Mode: Full, UseDefaultIfNoMatch: true},
+			matchFrom:     10000,
+			matchTo:       40000,
+			matchMode:     Forward,
 			expireAtNanos: 100000,
 			result: []RollupResult{
 				{
@@ -448,11 +436,12 @@ func TestActiveRuleSetRollupResults(t *testing.T) {
 		rollupRules,
 		testTagsFilterOptions(),
 		mockNewID,
+		nil,
 	)
 	expectedCutovers := []int64{10000, 15000, 20000, 22000, 24000, 30000, 34000, 35000, 38000, 100000}
 	require.Equal(t, expectedCutovers, as.cutoverTimesAsc)
 	for _, input := range inputs {
-		res := as.MatchAll(b(input.id), input.isRollupID, input.matchFrom, input.matchTo, input.opts)
+		res := as.MatchAll(b(input.id), input.matchFrom, input.matchTo, input.matchMode)
 		require.Equal(t, input.expireAtNanos, res.expireAtNanos)
 		require.Equal(t, len(input.result), res.NumRollups())
 		for i := 0; i < len(input.result); i++ {
@@ -507,10 +496,9 @@ func TestRuleSetActiveSet(t *testing.T) {
 			mappingInputs: []testMappingsData{
 				{
 					id:            "mtagName1=mtagValue1",
-					isRollupID:    false,
-					matchFrom:     time.Unix(0, 25000),
-					matchTo:       time.Unix(0, 25001),
-					opts:          MatchOptions{Mode: Full, UseDefaultIfNoMatch: true},
+					matchFrom:     25000,
+					matchTo:       25001,
+					matchMode:     Forward,
 					expireAtNanos: 30000,
 					result: policy.PoliciesList{
 						policy.NewStagedPolicies(
@@ -528,10 +516,9 @@ func TestRuleSetActiveSet(t *testing.T) {
 				},
 				{
 					id:            "mtagName1=mtagValue1",
-					isRollupID:    false,
-					matchFrom:     time.Unix(0, 35000),
-					matchTo:       time.Unix(0, 35001),
-					opts:          MatchOptions{Mode: Full, UseDefaultIfNoMatch: true},
+					matchFrom:     35000,
+					matchTo:       35001,
+					matchMode:     Forward,
 					expireAtNanos: 100000,
 					result: policy.PoliciesList{
 						policy.NewStagedPolicies(
@@ -547,10 +534,9 @@ func TestRuleSetActiveSet(t *testing.T) {
 				},
 				{
 					id:            "mtagName1=mtagValue2",
-					isRollupID:    false,
-					matchFrom:     time.Unix(0, 25000),
-					matchTo:       time.Unix(0, 25001),
-					opts:          MatchOptions{Mode: Full, UseDefaultIfNoMatch: true},
+					matchFrom:     25000,
+					matchTo:       25001,
+					matchMode:     Forward,
 					expireAtNanos: 30000,
 					result: policy.PoliciesList{
 						policy.NewStagedPolicies(
@@ -564,10 +550,9 @@ func TestRuleSetActiveSet(t *testing.T) {
 				},
 				{
 					id:            "mtagName1=mtagValue3",
-					isRollupID:    false,
-					matchFrom:     time.Unix(0, 25000),
-					matchTo:       time.Unix(0, 25001),
-					opts:          MatchOptions{Mode: Full, UseDefaultIfNoMatch: true},
+					matchFrom:     25000,
+					matchTo:       25001,
+					matchMode:     Forward,
 					expireAtNanos: 30000,
 					result:        policy.DefaultPoliciesList,
 				},
@@ -575,10 +560,9 @@ func TestRuleSetActiveSet(t *testing.T) {
 			rollupInputs: []testRollupResultsData{
 				{
 					id:            "rtagName1=rtagValue1,rtagName2=rtagValue2,rtagName3=rtagValue3",
-					isRollupID:    false,
-					matchFrom:     time.Unix(0, 25000),
-					matchTo:       time.Unix(0, 25001),
-					opts:          MatchOptions{Mode: Full, UseDefaultIfNoMatch: true},
+					matchFrom:     25000,
+					matchTo:       25001,
+					matchMode:     Forward,
 					expireAtNanos: 30000,
 					result: []RollupResult{
 						{
@@ -612,10 +596,9 @@ func TestRuleSetActiveSet(t *testing.T) {
 				},
 				{
 					id:            "rtagName1=rtagValue2",
-					isRollupID:    false,
-					matchFrom:     time.Unix(0, 25000),
-					matchTo:       time.Unix(0, 25001),
-					opts:          MatchOptions{Mode: Full, UseDefaultIfNoMatch: true},
+					matchFrom:     25000,
+					matchTo:       25001,
+					matchMode:     Forward,
 					expireAtNanos: 30000,
 					result: []RollupResult{
 						{
@@ -634,10 +617,9 @@ func TestRuleSetActiveSet(t *testing.T) {
 				},
 				{
 					id:            "rtagName5=rtagValue5",
-					isRollupID:    false,
-					matchFrom:     time.Unix(0, 25000),
-					matchTo:       time.Unix(0, 25001),
-					opts:          MatchOptions{Mode: Full, UseDefaultIfNoMatch: true},
+					matchFrom:     25000,
+					matchTo:       25001,
+					matchMode:     Forward,
 					expireAtNanos: 30000,
 					result:        []RollupResult{},
 				},
@@ -648,10 +630,9 @@ func TestRuleSetActiveSet(t *testing.T) {
 			mappingInputs: []testMappingsData{
 				{
 					id:            "mtagName1=mtagValue1",
-					isRollupID:    false,
-					matchFrom:     time.Unix(0, 35000),
-					matchTo:       time.Unix(0, 35001),
-					opts:          MatchOptions{Mode: Full, UseDefaultIfNoMatch: true},
+					matchFrom:     35000,
+					matchTo:       35001,
+					matchMode:     Forward,
 					expireAtNanos: 100000,
 					result: policy.PoliciesList{
 						policy.NewStagedPolicies(
@@ -667,10 +648,9 @@ func TestRuleSetActiveSet(t *testing.T) {
 				},
 				{
 					id:            "mtagName1=mtagValue2",
-					isRollupID:    false,
-					matchFrom:     time.Unix(0, 35000),
-					matchTo:       time.Unix(0, 35001),
-					opts:          MatchOptions{Mode: Full, UseDefaultIfNoMatch: true},
+					matchFrom:     35000,
+					matchTo:       35001,
+					matchMode:     Forward,
 					expireAtNanos: 100000,
 					result: policy.PoliciesList{
 						policy.NewStagedPolicies(
@@ -684,10 +664,9 @@ func TestRuleSetActiveSet(t *testing.T) {
 				},
 				{
 					id:            "mtagName1=mtagValue3",
-					isRollupID:    false,
-					matchFrom:     time.Unix(0, 35000),
-					matchTo:       time.Unix(0, 35001),
-					opts:          MatchOptions{Mode: Full, UseDefaultIfNoMatch: true},
+					matchFrom:     35000,
+					matchTo:       35001,
+					matchMode:     Forward,
 					expireAtNanos: 100000,
 					result:        policy.DefaultPoliciesList,
 				},
@@ -695,10 +674,9 @@ func TestRuleSetActiveSet(t *testing.T) {
 			rollupInputs: []testRollupResultsData{
 				{
 					id:            "rtagName1=rtagValue1,rtagName2=rtagValue2,rtagName3=rtagValue3",
-					isRollupID:    false,
-					matchFrom:     time.Unix(0, 35000),
-					matchTo:       time.Unix(0, 35001),
-					opts:          MatchOptions{Mode: Full, UseDefaultIfNoMatch: true},
+					matchFrom:     35000,
+					matchTo:       35001,
+					matchMode:     Forward,
 					expireAtNanos: 100000,
 					result: []RollupResult{
 						{
@@ -719,10 +697,9 @@ func TestRuleSetActiveSet(t *testing.T) {
 				},
 				{
 					id:            "rtagName1=rtagValue2",
-					isRollupID:    false,
-					matchFrom:     time.Unix(0, 35000),
-					matchTo:       time.Unix(0, 35001),
-					opts:          MatchOptions{Mode: Full, UseDefaultIfNoMatch: true},
+					matchFrom:     35000,
+					matchTo:       35001,
+					matchMode:     Forward,
 					expireAtNanos: 100000,
 					result: []RollupResult{
 						{
@@ -741,10 +718,9 @@ func TestRuleSetActiveSet(t *testing.T) {
 				},
 				{
 					id:            "rtagName5=rtagValue5",
-					isRollupID:    false,
-					matchFrom:     time.Unix(0, 35000),
-					matchTo:       time.Unix(0, 35001),
-					opts:          MatchOptions{Mode: Full, UseDefaultIfNoMatch: true},
+					matchFrom:     35000,
+					matchTo:       35001,
+					matchMode:     Forward,
 					expireAtNanos: 100000,
 					result:        []RollupResult{},
 				},
@@ -755,10 +731,9 @@ func TestRuleSetActiveSet(t *testing.T) {
 			mappingInputs: []testMappingsData{
 				{
 					id:            "mtagName1=mtagValue1",
-					isRollupID:    false,
-					matchFrom:     time.Unix(0, 250000),
-					matchTo:       time.Unix(0, 250001),
-					opts:          MatchOptions{Mode: Full, UseDefaultIfNoMatch: true},
+					matchFrom:     250000,
+					matchTo:       250001,
+					matchMode:     Forward,
 					expireAtNanos: timeNanosMax,
 					result: policy.PoliciesList{
 						policy.NewStagedPolicies(
@@ -774,10 +749,9 @@ func TestRuleSetActiveSet(t *testing.T) {
 				},
 				{
 					id:            "mtagName1=mtagValue2",
-					isRollupID:    false,
-					matchFrom:     time.Unix(0, 250000),
-					matchTo:       time.Unix(0, 250001),
-					opts:          MatchOptions{Mode: Full, UseDefaultIfNoMatch: true},
+					matchFrom:     250000,
+					matchTo:       250001,
+					matchMode:     Forward,
 					expireAtNanos: timeNanosMax,
 					result: policy.PoliciesList{
 						policy.NewStagedPolicies(
@@ -791,10 +765,9 @@ func TestRuleSetActiveSet(t *testing.T) {
 				},
 				{
 					id:            "mtagName1=mtagValue3",
-					isRollupID:    false,
-					matchFrom:     time.Unix(0, 250000),
-					matchTo:       time.Unix(0, 250001),
-					opts:          MatchOptions{Mode: Full, UseDefaultIfNoMatch: true},
+					matchFrom:     250000,
+					matchTo:       250001,
+					matchMode:     Forward,
 					expireAtNanos: timeNanosMax,
 					result:        policy.DefaultPoliciesList,
 				},
@@ -802,10 +775,9 @@ func TestRuleSetActiveSet(t *testing.T) {
 			rollupInputs: []testRollupResultsData{
 				{
 					id:            "rtagName1=rtagValue1,rtagName2=rtagValue2,rtagName3=rtagValue3",
-					isRollupID:    false,
-					matchFrom:     time.Unix(0, 250000),
-					matchTo:       time.Unix(0, 250001),
-					opts:          MatchOptions{Mode: Full, UseDefaultIfNoMatch: true},
+					matchFrom:     250000,
+					matchTo:       250001,
+					matchMode:     Forward,
 					expireAtNanos: timeNanosMax,
 					result: []RollupResult{
 						{
@@ -838,10 +810,9 @@ func TestRuleSetActiveSet(t *testing.T) {
 				},
 				{
 					id:            "rtagName1=rtagValue2",
-					isRollupID:    false,
-					matchFrom:     time.Unix(0, 250000),
-					matchTo:       time.Unix(0, 250001),
-					opts:          MatchOptions{Mode: Full, UseDefaultIfNoMatch: true},
+					matchFrom:     250000,
+					matchTo:       250001,
+					matchMode:     Forward,
 					expireAtNanos: timeNanosMax,
 					result: []RollupResult{
 						{
@@ -860,10 +831,9 @@ func TestRuleSetActiveSet(t *testing.T) {
 				},
 				{
 					id:            "rtagName5=rtagValue5",
-					isRollupID:    false,
-					matchFrom:     time.Unix(0, 250000),
-					matchTo:       time.Unix(0, 250001),
-					opts:          MatchOptions{Mode: Full, UseDefaultIfNoMatch: true},
+					matchFrom:     250000,
+					matchTo:       250001,
+					matchMode:     Forward,
 					expireAtNanos: timeNanosMax,
 					result:        []RollupResult{},
 				},
@@ -874,12 +844,12 @@ func TestRuleSetActiveSet(t *testing.T) {
 	for _, inputs := range allInputs {
 		as := newRuleSet.ActiveSet(inputs.activeSetTime)
 		for _, input := range inputs.mappingInputs {
-			res := as.MatchAll(b(input.id), input.isRollupID, input.matchFrom, input.matchTo, input.opts)
+			res := as.MatchAll(b(input.id), input.matchFrom, input.matchTo, input.matchMode)
 			require.Equal(t, input.expireAtNanos, res.expireAtNanos)
 			require.Equal(t, input.result, res.MappingsAt(0))
 		}
 		for _, input := range inputs.rollupInputs {
-			res := as.MatchAll(b(input.id), input.isRollupID, input.matchFrom, input.matchTo, input.opts)
+			res := as.MatchAll(b(input.id), input.matchFrom, input.matchTo, input.matchMode)
 			require.Equal(t, input.expireAtNanos, res.expireAtNanos)
 			require.Equal(t, len(input.result), res.NumRollups())
 			for i := 0; i < len(input.result); i++ {
@@ -2008,20 +1978,18 @@ func testTagsFilterOptions() filters.TagsFilterOptions {
 
 type testMappingsData struct {
 	id            string
-	isRollupID    bool
-	matchFrom     time.Time
-	matchTo       time.Time
-	opts          MatchOptions
+	matchFrom     int64
+	matchTo       int64
+	matchMode     MatchMode
 	expireAtNanos int64
 	result        policy.PoliciesList
 }
 
 type testRollupResultsData struct {
 	id            string
-	isRollupID    bool
-	matchFrom     time.Time
-	matchTo       time.Time
-	opts          MatchOptions
+	matchFrom     int64
+	matchTo       int64
+	matchMode     MatchMode
 	expireAtNanos int64
 	result        []RollupResult
 }

--- a/rules/ruleset_test.go
+++ b/rules/ruleset_test.go
@@ -44,12 +44,14 @@ var (
 	compressedCountAndMean, _ = compressor.Compress(policy.AggregationTypes{policy.Count, policy.Mean})
 )
 
-func TestActiveRuleSetMatchMappingRules(t *testing.T) {
+func TestActiveRuleSetMappingPoliciesForNonRollupID(t *testing.T) {
 	inputs := []testMappingsData{
 		{
 			id:            "mtagName1=mtagValue1",
+			isRollupID:    false,
 			matchFrom:     time.Unix(0, 25000),
 			matchTo:       time.Unix(0, 25001),
+			opts:          MatchOptions{Mode: Full, UseDefaultIfNoMatch: true},
 			expireAtNanos: 30000,
 			result: policy.PoliciesList{
 				policy.NewStagedPolicies(
@@ -66,8 +68,10 @@ func TestActiveRuleSetMatchMappingRules(t *testing.T) {
 		},
 		{
 			id:            "mtagName1=mtagValue1",
+			isRollupID:    false,
 			matchFrom:     time.Unix(0, 35000),
 			matchTo:       time.Unix(0, 35001),
+			opts:          MatchOptions{Mode: Full, UseDefaultIfNoMatch: true},
 			expireAtNanos: 100000,
 			result: policy.PoliciesList{
 				policy.NewStagedPolicies(
@@ -83,8 +87,10 @@ func TestActiveRuleSetMatchMappingRules(t *testing.T) {
 		},
 		{
 			id:            "mtagName1=mtagValue2",
+			isRollupID:    false,
 			matchFrom:     time.Unix(0, 25000),
 			matchTo:       time.Unix(0, 25001),
+			opts:          MatchOptions{Mode: Full, UseDefaultIfNoMatch: true},
 			expireAtNanos: 30000,
 			result: policy.PoliciesList{
 				policy.NewStagedPolicies(
@@ -98,15 +104,19 @@ func TestActiveRuleSetMatchMappingRules(t *testing.T) {
 		},
 		{
 			id:            "mtagName1=mtagValue3",
+			isRollupID:    false,
 			matchFrom:     time.Unix(0, 25000),
 			matchTo:       time.Unix(0, 25001),
+			opts:          MatchOptions{Mode: Full, UseDefaultIfNoMatch: true},
 			expireAtNanos: 30000,
 			result:        policy.DefaultPoliciesList,
 		},
 		{
 			id:            "mtagName1=mtagValue1",
+			isRollupID:    false,
 			matchFrom:     time.Unix(0, 10000),
 			matchTo:       time.Unix(0, 40000),
+			opts:          MatchOptions{Mode: Full, UseDefaultIfNoMatch: true},
 			expireAtNanos: 100000,
 			result: policy.PoliciesList{
 				policy.NewStagedPolicies(
@@ -166,8 +176,10 @@ func TestActiveRuleSetMatchMappingRules(t *testing.T) {
 		},
 		{
 			id:            "mtagName1=mtagValue2",
+			isRollupID:    false,
 			matchFrom:     time.Unix(0, 10000),
 			matchTo:       time.Unix(0, 40000),
+			opts:          MatchOptions{Mode: Full, UseDefaultIfNoMatch: true},
 			expireAtNanos: 100000,
 			result: policy.PoliciesList{
 				policy.DefaultStagedPolicies,
@@ -192,18 +204,85 @@ func TestActiveRuleSetMatchMappingRules(t *testing.T) {
 	expectedCutovers := []int64{10000, 15000, 20000, 22000, 24000, 30000, 34000, 35000, 100000}
 	require.Equal(t, expectedCutovers, as.cutoverTimesAsc)
 	for _, input := range inputs {
-		res := as.MatchAll(b(input.id), input.matchFrom, input.matchTo)
+		res := as.MatchAll(b(input.id), input.isRollupID, input.matchFrom, input.matchTo, input.opts)
 		require.Equal(t, input.expireAtNanos, res.expireAtNanos)
 		require.Equal(t, input.result, res.MappingsAt(0))
 	}
 }
 
-func TestActiveRuleSetMatchRollupRules(t *testing.T) {
+func TestActiveRuleSetMappingPoliciesForRollupID(t *testing.T) {
+	inputs := []testMappingsData{
+		{
+			id:            "rName4|rtagName1=rtagValue2",
+			isRollupID:    true,
+			matchFrom:     time.Unix(0, 25000),
+			matchTo:       time.Unix(0, 25001),
+			opts:          MatchOptions{Mode: MappingPoliciesOnly, UseDefaultIfNoMatch: false},
+			expireAtNanos: 30000,
+			result: policy.PoliciesList{
+				policy.NewStagedPolicies(
+					24000,
+					false,
+					[]policy.Policy{
+						policy.NewPolicy(policy.NewStoragePolicy(time.Second, xtime.Second, time.Minute), policy.DefaultAggregationID),
+					},
+				),
+			},
+		},
+		{
+			id:            "rName4|rtagName2=rtagValue2",
+			isRollupID:    true,
+			matchFrom:     time.Unix(0, 25000),
+			matchTo:       time.Unix(0, 25001),
+			opts:          MatchOptions{Mode: MappingPoliciesOnly, UseDefaultIfNoMatch: false},
+			expireAtNanos: 30000,
+			result:        nil,
+		},
+		{
+			id:            "rName4|rtagName1=rtagValue2",
+			isRollupID:    true,
+			matchFrom:     time.Unix(0, 10000),
+			matchTo:       time.Unix(0, 10001),
+			opts:          MatchOptions{Mode: MappingPoliciesOnly, UseDefaultIfNoMatch: false},
+			expireAtNanos: 15000,
+			result:        nil,
+		},
+		{
+			id:            "rName3|rtagName1=rtagValue2",
+			isRollupID:    true,
+			matchFrom:     time.Unix(0, 25000),
+			matchTo:       time.Unix(0, 25001),
+			opts:          MatchOptions{Mode: MappingPoliciesOnly, UseDefaultIfNoMatch: false},
+			expireAtNanos: 30000,
+			result:        nil,
+		},
+	}
+
+	rollupRules := testRollupRules(t)
+	as := newActiveRuleSet(
+		nil,
+		rollupRules,
+		testTagsFilterOptions(),
+		mockNewID,
+	)
+	expectedCutovers := []int64{10000, 15000, 20000, 22000, 24000, 30000, 34000, 35000, 38000, 100000}
+	require.Equal(t, expectedCutovers, as.cutoverTimesAsc)
+	for _, input := range inputs {
+		res := as.MatchAll(b(input.id), input.isRollupID, input.matchFrom, input.matchTo, input.opts)
+		require.Equal(t, input.expireAtNanos, res.expireAtNanos)
+		require.Equal(t, input.result, res.MappingsAt(0))
+		require.Nil(t, res.rollups)
+	}
+}
+
+func TestActiveRuleSetRollupResults(t *testing.T) {
 	inputs := []testRollupResultsData{
 		{
 			id:            "rtagName1=rtagValue1,rtagName2=rtagValue2,rtagName3=rtagValue3",
+			isRollupID:    false,
 			matchFrom:     time.Unix(0, 25000),
 			matchTo:       time.Unix(0, 25001),
+			opts:          MatchOptions{Mode: Full, UseDefaultIfNoMatch: true},
 			expireAtNanos: 30000,
 			result: []RollupResult{
 				{
@@ -237,18 +316,20 @@ func TestActiveRuleSetMatchRollupRules(t *testing.T) {
 		},
 		{
 			id:            "rtagName1=rtagValue2",
+			isRollupID:    false,
 			matchFrom:     time.Unix(0, 25000),
 			matchTo:       time.Unix(0, 25001),
+			opts:          MatchOptions{Mode: Full, UseDefaultIfNoMatch: true},
 			expireAtNanos: 30000,
 			result: []RollupResult{
 				{
-					ID: b("rName3|rtagName1=rtagValue2"),
+					ID: b("rName4|rtagName1=rtagValue2"),
 					PoliciesList: policy.PoliciesList{
 						policy.NewStagedPolicies(
 							24000,
 							false,
 							[]policy.Policy{
-								policy.NewPolicy(policy.NewStoragePolicy(time.Minute, xtime.Minute, time.Hour), policy.DefaultAggregationID),
+								policy.NewPolicy(policy.NewStoragePolicy(time.Second, xtime.Second, time.Minute), policy.DefaultAggregationID),
 							},
 						),
 					},
@@ -257,15 +338,19 @@ func TestActiveRuleSetMatchRollupRules(t *testing.T) {
 		},
 		{
 			id:            "rtagName5=rtagValue5",
+			isRollupID:    false,
 			matchFrom:     time.Unix(0, 25000),
 			matchTo:       time.Unix(0, 25001),
+			opts:          MatchOptions{Mode: Full, UseDefaultIfNoMatch: true},
 			expireAtNanos: 30000,
 			result:        []RollupResult{},
 		},
 		{
 			id:            "rtagName1=rtagValue1,rtagName2=rtagValue2,rtagName3=rtagValue3",
+			isRollupID:    false,
 			matchFrom:     time.Unix(0, 10000),
 			matchTo:       time.Unix(0, 40000),
+			opts:          MatchOptions{Mode: Full, UseDefaultIfNoMatch: true},
 			expireAtNanos: 100000,
 			result: []RollupResult{
 				{
@@ -367,7 +452,7 @@ func TestActiveRuleSetMatchRollupRules(t *testing.T) {
 	expectedCutovers := []int64{10000, 15000, 20000, 22000, 24000, 30000, 34000, 35000, 38000, 100000}
 	require.Equal(t, expectedCutovers, as.cutoverTimesAsc)
 	for _, input := range inputs {
-		res := as.MatchAll(b(input.id), input.matchFrom, input.matchTo)
+		res := as.MatchAll(b(input.id), input.isRollupID, input.matchFrom, input.matchTo, input.opts)
 		require.Equal(t, input.expireAtNanos, res.expireAtNanos)
 		require.Equal(t, len(input.result), res.NumRollups())
 		for i := 0; i < len(input.result); i++ {
@@ -422,8 +507,10 @@ func TestRuleSetActiveSet(t *testing.T) {
 			mappingInputs: []testMappingsData{
 				{
 					id:            "mtagName1=mtagValue1",
+					isRollupID:    false,
 					matchFrom:     time.Unix(0, 25000),
 					matchTo:       time.Unix(0, 25001),
+					opts:          MatchOptions{Mode: Full, UseDefaultIfNoMatch: true},
 					expireAtNanos: 30000,
 					result: policy.PoliciesList{
 						policy.NewStagedPolicies(
@@ -441,8 +528,10 @@ func TestRuleSetActiveSet(t *testing.T) {
 				},
 				{
 					id:            "mtagName1=mtagValue1",
+					isRollupID:    false,
 					matchFrom:     time.Unix(0, 35000),
 					matchTo:       time.Unix(0, 35001),
+					opts:          MatchOptions{Mode: Full, UseDefaultIfNoMatch: true},
 					expireAtNanos: 100000,
 					result: policy.PoliciesList{
 						policy.NewStagedPolicies(
@@ -458,8 +547,10 @@ func TestRuleSetActiveSet(t *testing.T) {
 				},
 				{
 					id:            "mtagName1=mtagValue2",
+					isRollupID:    false,
 					matchFrom:     time.Unix(0, 25000),
 					matchTo:       time.Unix(0, 25001),
+					opts:          MatchOptions{Mode: Full, UseDefaultIfNoMatch: true},
 					expireAtNanos: 30000,
 					result: policy.PoliciesList{
 						policy.NewStagedPolicies(
@@ -473,8 +564,10 @@ func TestRuleSetActiveSet(t *testing.T) {
 				},
 				{
 					id:            "mtagName1=mtagValue3",
+					isRollupID:    false,
 					matchFrom:     time.Unix(0, 25000),
 					matchTo:       time.Unix(0, 25001),
+					opts:          MatchOptions{Mode: Full, UseDefaultIfNoMatch: true},
 					expireAtNanos: 30000,
 					result:        policy.DefaultPoliciesList,
 				},
@@ -482,8 +575,10 @@ func TestRuleSetActiveSet(t *testing.T) {
 			rollupInputs: []testRollupResultsData{
 				{
 					id:            "rtagName1=rtagValue1,rtagName2=rtagValue2,rtagName3=rtagValue3",
+					isRollupID:    false,
 					matchFrom:     time.Unix(0, 25000),
 					matchTo:       time.Unix(0, 25001),
+					opts:          MatchOptions{Mode: Full, UseDefaultIfNoMatch: true},
 					expireAtNanos: 30000,
 					result: []RollupResult{
 						{
@@ -517,18 +612,20 @@ func TestRuleSetActiveSet(t *testing.T) {
 				},
 				{
 					id:            "rtagName1=rtagValue2",
+					isRollupID:    false,
 					matchFrom:     time.Unix(0, 25000),
 					matchTo:       time.Unix(0, 25001),
+					opts:          MatchOptions{Mode: Full, UseDefaultIfNoMatch: true},
 					expireAtNanos: 30000,
 					result: []RollupResult{
 						{
-							ID: b("rName3|rtagName1=rtagValue2"),
+							ID: b("rName4|rtagName1=rtagValue2"),
 							PoliciesList: policy.PoliciesList{
 								policy.NewStagedPolicies(
 									24000,
 									false,
 									[]policy.Policy{
-										policy.NewPolicy(policy.NewStoragePolicy(time.Minute, xtime.Minute, time.Hour), policy.DefaultAggregationID),
+										policy.NewPolicy(policy.NewStoragePolicy(time.Second, xtime.Second, time.Minute), policy.DefaultAggregationID),
 									},
 								),
 							},
@@ -537,8 +634,10 @@ func TestRuleSetActiveSet(t *testing.T) {
 				},
 				{
 					id:            "rtagName5=rtagValue5",
+					isRollupID:    false,
 					matchFrom:     time.Unix(0, 25000),
 					matchTo:       time.Unix(0, 25001),
+					opts:          MatchOptions{Mode: Full, UseDefaultIfNoMatch: true},
 					expireAtNanos: 30000,
 					result:        []RollupResult{},
 				},
@@ -549,8 +648,10 @@ func TestRuleSetActiveSet(t *testing.T) {
 			mappingInputs: []testMappingsData{
 				{
 					id:            "mtagName1=mtagValue1",
+					isRollupID:    false,
 					matchFrom:     time.Unix(0, 35000),
 					matchTo:       time.Unix(0, 35001),
+					opts:          MatchOptions{Mode: Full, UseDefaultIfNoMatch: true},
 					expireAtNanos: 100000,
 					result: policy.PoliciesList{
 						policy.NewStagedPolicies(
@@ -566,8 +667,10 @@ func TestRuleSetActiveSet(t *testing.T) {
 				},
 				{
 					id:            "mtagName1=mtagValue2",
+					isRollupID:    false,
 					matchFrom:     time.Unix(0, 35000),
 					matchTo:       time.Unix(0, 35001),
+					opts:          MatchOptions{Mode: Full, UseDefaultIfNoMatch: true},
 					expireAtNanos: 100000,
 					result: policy.PoliciesList{
 						policy.NewStagedPolicies(
@@ -581,8 +684,10 @@ func TestRuleSetActiveSet(t *testing.T) {
 				},
 				{
 					id:            "mtagName1=mtagValue3",
+					isRollupID:    false,
 					matchFrom:     time.Unix(0, 35000),
 					matchTo:       time.Unix(0, 35001),
+					opts:          MatchOptions{Mode: Full, UseDefaultIfNoMatch: true},
 					expireAtNanos: 100000,
 					result:        policy.DefaultPoliciesList,
 				},
@@ -590,8 +695,10 @@ func TestRuleSetActiveSet(t *testing.T) {
 			rollupInputs: []testRollupResultsData{
 				{
 					id:            "rtagName1=rtagValue1,rtagName2=rtagValue2,rtagName3=rtagValue3",
+					isRollupID:    false,
 					matchFrom:     time.Unix(0, 35000),
 					matchTo:       time.Unix(0, 35001),
+					opts:          MatchOptions{Mode: Full, UseDefaultIfNoMatch: true},
 					expireAtNanos: 100000,
 					result: []RollupResult{
 						{
@@ -612,18 +719,20 @@ func TestRuleSetActiveSet(t *testing.T) {
 				},
 				{
 					id:            "rtagName1=rtagValue2",
+					isRollupID:    false,
 					matchFrom:     time.Unix(0, 35000),
 					matchTo:       time.Unix(0, 35001),
+					opts:          MatchOptions{Mode: Full, UseDefaultIfNoMatch: true},
 					expireAtNanos: 100000,
 					result: []RollupResult{
 						{
-							ID: b("rName3|rtagName1=rtagValue2"),
+							ID: b("rName4|rtagName1=rtagValue2"),
 							PoliciesList: policy.PoliciesList{
 								policy.NewStagedPolicies(
 									24000,
 									false,
 									[]policy.Policy{
-										policy.NewPolicy(policy.NewStoragePolicy(time.Minute, xtime.Minute, time.Hour), policy.DefaultAggregationID),
+										policy.NewPolicy(policy.NewStoragePolicy(time.Second, xtime.Second, time.Minute), policy.DefaultAggregationID),
 									},
 								),
 							},
@@ -632,8 +741,10 @@ func TestRuleSetActiveSet(t *testing.T) {
 				},
 				{
 					id:            "rtagName5=rtagValue5",
+					isRollupID:    false,
 					matchFrom:     time.Unix(0, 35000),
 					matchTo:       time.Unix(0, 35001),
+					opts:          MatchOptions{Mode: Full, UseDefaultIfNoMatch: true},
 					expireAtNanos: 100000,
 					result:        []RollupResult{},
 				},
@@ -644,8 +755,10 @@ func TestRuleSetActiveSet(t *testing.T) {
 			mappingInputs: []testMappingsData{
 				{
 					id:            "mtagName1=mtagValue1",
+					isRollupID:    false,
 					matchFrom:     time.Unix(0, 250000),
 					matchTo:       time.Unix(0, 250001),
+					opts:          MatchOptions{Mode: Full, UseDefaultIfNoMatch: true},
 					expireAtNanos: timeNanosMax,
 					result: policy.PoliciesList{
 						policy.NewStagedPolicies(
@@ -661,8 +774,10 @@ func TestRuleSetActiveSet(t *testing.T) {
 				},
 				{
 					id:            "mtagName1=mtagValue2",
+					isRollupID:    false,
 					matchFrom:     time.Unix(0, 250000),
 					matchTo:       time.Unix(0, 250001),
+					opts:          MatchOptions{Mode: Full, UseDefaultIfNoMatch: true},
 					expireAtNanos: timeNanosMax,
 					result: policy.PoliciesList{
 						policy.NewStagedPolicies(
@@ -676,8 +791,10 @@ func TestRuleSetActiveSet(t *testing.T) {
 				},
 				{
 					id:            "mtagName1=mtagValue3",
+					isRollupID:    false,
 					matchFrom:     time.Unix(0, 250000),
 					matchTo:       time.Unix(0, 250001),
+					opts:          MatchOptions{Mode: Full, UseDefaultIfNoMatch: true},
 					expireAtNanos: timeNanosMax,
 					result:        policy.DefaultPoliciesList,
 				},
@@ -685,8 +802,10 @@ func TestRuleSetActiveSet(t *testing.T) {
 			rollupInputs: []testRollupResultsData{
 				{
 					id:            "rtagName1=rtagValue1,rtagName2=rtagValue2,rtagName3=rtagValue3",
+					isRollupID:    false,
 					matchFrom:     time.Unix(0, 250000),
 					matchTo:       time.Unix(0, 250001),
+					opts:          MatchOptions{Mode: Full, UseDefaultIfNoMatch: true},
 					expireAtNanos: timeNanosMax,
 					result: []RollupResult{
 						{
@@ -719,18 +838,20 @@ func TestRuleSetActiveSet(t *testing.T) {
 				},
 				{
 					id:            "rtagName1=rtagValue2",
+					isRollupID:    false,
 					matchFrom:     time.Unix(0, 250000),
 					matchTo:       time.Unix(0, 250001),
+					opts:          MatchOptions{Mode: Full, UseDefaultIfNoMatch: true},
 					expireAtNanos: timeNanosMax,
 					result: []RollupResult{
 						{
-							ID: b("rName3|rtagName1=rtagValue2"),
+							ID: b("rName4|rtagName1=rtagValue2"),
 							PoliciesList: policy.PoliciesList{
 								policy.NewStagedPolicies(
 									24000,
 									false,
 									[]policy.Policy{
-										policy.NewPolicy(policy.NewStoragePolicy(time.Minute, xtime.Minute, time.Hour), policy.DefaultAggregationID),
+										policy.NewPolicy(policy.NewStoragePolicy(time.Second, xtime.Second, time.Minute), policy.DefaultAggregationID),
 									},
 								),
 							},
@@ -739,8 +860,10 @@ func TestRuleSetActiveSet(t *testing.T) {
 				},
 				{
 					id:            "rtagName5=rtagValue5",
+					isRollupID:    false,
 					matchFrom:     time.Unix(0, 250000),
 					matchTo:       time.Unix(0, 250001),
+					opts:          MatchOptions{Mode: Full, UseDefaultIfNoMatch: true},
 					expireAtNanos: timeNanosMax,
 					result:        []RollupResult{},
 				},
@@ -751,12 +874,12 @@ func TestRuleSetActiveSet(t *testing.T) {
 	for _, inputs := range allInputs {
 		as := newRuleSet.ActiveSet(inputs.activeSetTime)
 		for _, input := range inputs.mappingInputs {
-			res := as.MatchAll(b(input.id), input.matchFrom, input.matchTo)
+			res := as.MatchAll(b(input.id), input.isRollupID, input.matchFrom, input.matchTo, input.opts)
 			require.Equal(t, input.expireAtNanos, res.expireAtNanos)
 			require.Equal(t, input.result, res.MappingsAt(0))
 		}
 		for _, input := range inputs.rollupInputs {
-			res := as.MatchAll(b(input.id), input.matchFrom, input.matchTo)
+			res := as.MatchAll(b(input.id), input.isRollupID, input.matchFrom, input.matchTo, input.opts)
 			require.Equal(t, input.expireAtNanos, res.expireAtNanos)
 			require.Equal(t, len(input.result), res.NumRollups())
 			for i := 0; i < len(input.result); i++ {
@@ -1115,6 +1238,27 @@ func testRollupRules(t *testing.T) []*rollupRule {
 			&rollupRuleSnapshot{
 				name:         "rollupRule5.snapshot1",
 				tombstoned:   false,
+				cutoverNanos: 24000,
+				filter:       filter2,
+				targets: []rollupTarget{
+					{
+						Name: b("rName4"),
+						Tags: [][]byte{b("rtagName1")},
+						Policies: []policy.Policy{
+							policy.NewPolicy(policy.NewStoragePolicy(time.Second, xtime.Second, time.Minute), policy.DefaultAggregationID),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	rollupRule6 := &rollupRule{
+		uuid: "rollupRule6",
+		snapshots: []*rollupRuleSnapshot{
+			&rollupRuleSnapshot{
+				name:         "rollupRule6.snapshot1",
+				tombstoned:   false,
 				cutoverNanos: 100000,
 				filter:       filter1,
 				targets: []rollupTarget{
@@ -1130,33 +1274,7 @@ func testRollupRules(t *testing.T) []*rollupRule {
 		},
 	}
 
-	return []*rollupRule{rollupRule1, rollupRule2, rollupRule3, rollupRule4, rollupRule5}
-}
-
-func testRuleSetOptions() Options {
-	return NewOptions().
-		SetTagsFilterOptions(testTagsFilterOptions()).
-		SetNewRollupIDFn(mockNewID)
-}
-
-func mockNewID(name []byte, tags []id.TagPair) []byte {
-	if len(tags) == 0 {
-		return name
-	}
-	var buf bytes.Buffer
-	buf.Write(name)
-	if len(tags) > 0 {
-		buf.WriteString("|")
-		for idx, p := range tags {
-			buf.Write(p.Name)
-			buf.WriteString("=")
-			buf.Write(p.Value)
-			if idx < len(tags)-1 {
-				buf.WriteString(",")
-			}
-		}
-	}
-	return buf.Bytes()
+	return []*rollupRule{rollupRule1, rollupRule2, rollupRule3, rollupRule4, rollupRule5, rollupRule6}
 }
 
 func testMappingRulesConfig() []*schema.MappingRule {
@@ -1786,6 +1904,38 @@ func testRollupRulesConfig() []*schema.RollupRule {
 				&schema.RollupRuleSnapshot{
 					Name:        "rollupRule5.snapshot1",
 					Tombstoned:  false,
+					CutoverTime: 24000,
+					TagFilters: map[string]string{
+						"rtagName1": "rtagValue2",
+					},
+					Targets: []*schema.RollupTarget{
+						&schema.RollupTarget{
+							Name: "rName4",
+							Tags: []string{"rtagName1"},
+							Policies: []*schema.Policy{
+								&schema.Policy{
+									StoragePolicy: &schema.StoragePolicy{
+										Resolution: &schema.Resolution{
+											WindowSize: int64(time.Second),
+											Precision:  int64(time.Second),
+										},
+										Retention: &schema.Retention{
+											Period: int64(time.Minute),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		&schema.RollupRule{
+			Uuid: "rollupRule6",
+			Snapshots: []*schema.RollupRuleSnapshot{
+				&schema.RollupRuleSnapshot{
+					Name:        "rollupRule6.snapshot1",
+					Tombstoned:  false,
 					CutoverTime: 100000,
 					TagFilters: map[string]string{
 						"rtagName1": "rtagValue1",
@@ -1816,26 +1966,62 @@ func testRollupRulesConfig() []*schema.RollupRule {
 	}
 }
 
+func testRuleSetOptions() Options {
+	return NewOptions().
+		SetTagsFilterOptions(testTagsFilterOptions()).
+		SetNewRollupIDFn(mockNewID)
+}
+
+func mockNewID(name []byte, tags []id.TagPair) []byte {
+	if len(tags) == 0 {
+		return name
+	}
+	var buf bytes.Buffer
+	buf.Write(name)
+	if len(tags) > 0 {
+		buf.WriteString("|")
+		for idx, p := range tags {
+			buf.Write(p.Name)
+			buf.WriteString("=")
+			buf.Write(p.Value)
+			if idx < len(tags)-1 {
+				buf.WriteString(",")
+			}
+		}
+	}
+	return buf.Bytes()
+}
+
 func testTagsFilterOptions() filters.TagsFilterOptions {
 	return filters.TagsFilterOptions{
-		NameTagKey:          []byte("name"),
-		NameAndTagsFn:       func(b []byte) ([]byte, []byte, error) { return nil, b, nil },
+		NameTagKey: []byte("name"),
+		NameAndTagsFn: func(b []byte) ([]byte, []byte, error) {
+			idx := bytes.Index(b, []byte("|"))
+			if idx == -1 {
+				return nil, b, nil
+			}
+			return b[:idx], b[idx+1:], nil
+		},
 		SortedTagIteratorFn: filters.NewMockSortedTagIterator,
 	}
 }
 
 type testMappingsData struct {
 	id            string
+	isRollupID    bool
 	matchFrom     time.Time
 	matchTo       time.Time
+	opts          MatchOptions
 	expireAtNanos int64
 	result        policy.PoliciesList
 }
 
 type testRollupResultsData struct {
 	id            string
+	isRollupID    bool
 	matchFrom     time.Time
 	matchTo       time.Time
+	opts          MatchOptions
 	expireAtNanos int64
 	result        []RollupResult
 }


### PR DESCRIPTION
cc @cw9 @prateek @jeromefroe 

This PR adapts the `MatchAll` interface to find policies for rollup metrics (i.e., those generated from a rollup rule).