### PR TITLE
Rule matcher API

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 07a1a24c24370b50b8cb4f21bdd6fd9b1b787f00c87b1f3f95715f93d84594f2
-updated: 2017-05-26T12:06:55.555982654-04:00
+hash: fe75ee1e2dd467685ad7c171a57b6ee56f8bddecde1a080746ed32768919a992
+updated: 2017-06-17T22:08:05.488840645-04:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
@@ -11,19 +11,34 @@ imports:
   version: de8695c8edbf8236f30d6e1376e20b198a028d42
   subpackages:
   - oleutil
+- name: github.com/golang/mock
+  version: bd3c8e81be01eef76d4b503f5e687d2d1354d2d9
+  subpackages:
+  - gomock
+  - mockgen
 - name: github.com/golang/protobuf
   version: 7390af9dcd3c33042ebaf2474a1724a83cf1a7e6
   subpackages:
   - proto
+- name: github.com/m3db/m3cluster
+  version: b596a86b06f37c9150ea352d6ec1549ed19f304b
+  subpackages:
+  - kv
+  - kv/mem
+  - kv/util/runtime
 - name: github.com/m3db/m3x
   version: bd6be18ffb184691512eb442561b16a59c15d797
   subpackages:
   - checked
+  - clock
+  - close
+  - id
   - instrument
   - log
   - pool
   - process
   - time
+  - watch
 - name: github.com/pmezard/go-difflib
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -5,6 +5,12 @@ import:
   subpackages:
   - pool
   - time
+- package: github.com/m3db/m3cluster
+  version: b596a86b06f37c9150ea352d6ec1549ed19f304b
+  subpackages:
+  - kv
+  - kv/mem
+  - kv/util/runtime
 - package: gopkg.in/vmihailenco/msgpack.v2
   version: a1382b1ce0c749733b814157c245e02cc1f41076
 - package: github.com/apache/thrift
@@ -60,3 +66,8 @@ testImport:
   version: d77da356e56a7428ad25149ca77381849a6a5232
   subpackages:
   - require
+- package: github.com/golang/mock
+  version: bd3c8e81be01eef76d4b503f5e687d2d1354d2d9
+  subpackages:
+  - gomock
+  - mockgen

--- a/matcher/cache.go
+++ b/matcher/cache.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package matcher
+
+import "github.com/m3db/m3metrics/rules"
+
+// Source is a datasource providing match results.
+type Source interface {
+	// Match returns the match result for an given id within time range
+	// [fromNanos, toNanos).
+	Match(id []byte, fromNanos, toNanos int64) rules.MatchResult
+}
+
+// Cache caches the rule matching result associated with metrics.
+type Cache interface {
+	// Match returns the rule matching result associated with a metric id
+	// between [fromNanos, toNanos).
+	Match(namespace, id []byte, fromNanos, toNanos int64) rules.MatchResult
+
+	// Register sets the result source for a given namespace.
+	Register(namespace []byte, source Source)
+
+	// Unregister deletes the cached results for a given namespace.
+	Unregister(namespace []byte)
+
+	// Close closes the cache.
+	Close() error
+}

--- a/matcher/cache.go
+++ b/matcher/cache.go
@@ -24,7 +24,7 @@ import "github.com/m3db/m3metrics/rules"
 
 // Source is a datasource providing match results.
 type Source interface {
-	// Match returns the match result for an given id within time range
+	// Match returns the match result for a given id within time range
 	// [fromNanos, toNanos).
 	Match(id []byte, fromNanos, toNanos int64) rules.MatchResult
 }

--- a/matcher/cache/cache.go
+++ b/matcher/cache/cache.go
@@ -1,0 +1,422 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package cache
+
+import (
+	"errors"
+	"math/rand"
+	"sync"
+	"time"
+
+	"github.com/m3db/m3metrics/matcher"
+	"github.com/m3db/m3metrics/rules"
+	"github.com/m3db/m3x/clock"
+	"github.com/m3db/m3x/id"
+
+	"github.com/uber-go/tally"
+)
+
+const (
+	numOngoingTasks          = 2
+	deletionThrottleInterval = 100 * time.Millisecond
+)
+
+var (
+	errCacheClosed = errors.New("cache is already closed")
+)
+
+type setType int
+
+const (
+	dontSetIfNotFound setType = iota
+	setIfNotFound
+)
+
+type sleepFn func(time.Duration)
+
+type elemMap map[xid.Hash]*element
+
+type results struct {
+	elems  elemMap
+	source matcher.Source
+}
+
+func newResults(source matcher.Source) results {
+	return results{elems: make(elemMap), source: source}
+}
+
+type cacheMetrics struct {
+	hits        tally.Counter
+	misses      tally.Counter
+	expires     tally.Counter
+	registers   tally.Counter
+	unregisters tally.Counter
+	promotions  tally.Counter
+	evictions   tally.Counter
+	deletions   tally.Counter
+}
+
+func newCacheMetrics(scope tally.Scope) cacheMetrics {
+	return cacheMetrics{
+		hits:        scope.Counter("hits"),
+		misses:      scope.Counter("misses"),
+		expires:     scope.Counter("expires"),
+		registers:   scope.Counter("registers"),
+		unregisters: scope.Counter("unregisters"),
+		promotions:  scope.Counter("promotions"),
+		evictions:   scope.Counter("evictions"),
+		deletions:   scope.Counter("deletions"),
+	}
+}
+
+// cache is an LRU-based read-through cache.
+type cache struct {
+	sync.RWMutex
+
+	capacity          int
+	nowFn             clock.NowFn
+	freshDuration     time.Duration
+	stutterDuration   time.Duration
+	evictionBatchSize int
+	deletionBatchSize int
+	invalidationMode  InvalidationMode
+	sleepFn           sleepFn
+
+	namespaces map[xid.Hash]results
+	list       lockedList
+	evictCh    chan struct{}
+	deleteCh   chan struct{}
+	toDelete   []elemMap
+	wgWorker   sync.WaitGroup
+	closed     bool
+	closedCh   chan struct{}
+	metrics    cacheMetrics
+}
+
+// NewCache creates a new cache.
+func NewCache(opts Options) matcher.Cache {
+	clockOpts := opts.ClockOptions()
+	instrumentOpts := opts.InstrumentOptions()
+	c := &cache{
+		capacity:          opts.Capacity(),
+		nowFn:             clockOpts.NowFn(),
+		freshDuration:     opts.FreshDuration(),
+		stutterDuration:   opts.StutterDuration(),
+		evictionBatchSize: opts.EvictionBatchSize(),
+		deletionBatchSize: opts.DeletionBatchSize(),
+		invalidationMode:  opts.InvalidationMode(),
+		sleepFn:           time.Sleep,
+		namespaces:        make(map[xid.Hash]results),
+		evictCh:           make(chan struct{}, 1),
+		deleteCh:          make(chan struct{}, 1),
+		closedCh:          make(chan struct{}),
+		metrics:           newCacheMetrics(instrumentOpts.MetricsScope()),
+	}
+
+	c.wgWorker.Add(numOngoingTasks)
+	go c.evict()
+	go c.delete()
+
+	return c
+}
+
+func (c *cache) Match(namespace, id []byte, fromNanos, toNanos int64) rules.MatchResult {
+	c.RLock()
+	res, found := c.tryGetWithLock(namespace, id, fromNanos, toNanos, dontSetIfNotFound)
+	c.RUnlock()
+	if found {
+		return res
+	}
+
+	c.Lock()
+	res, _ = c.tryGetWithLock(namespace, id, fromNanos, toNanos, setIfNotFound)
+	c.Unlock()
+
+	return res
+}
+
+func (c *cache) Register(namespace []byte, source matcher.Source) {
+	c.Lock()
+	nsHash := xid.HashFn(namespace)
+	results, exist := c.namespaces[nsHash]
+	if !exist {
+		results = newResults(source)
+	} else {
+		// Invalidate existing cached results.
+		c.toDelete = append(c.toDelete, results.elems)
+		c.notifyDeletion()
+		results.source = source
+		results.elems = make(elemMap)
+	}
+	c.namespaces[nsHash] = results
+	c.Unlock()
+	c.metrics.registers.Inc(1)
+}
+
+func (c *cache) Unregister(namespace []byte) {
+	c.Lock()
+	nsHash := xid.HashFn(namespace)
+	results, exists := c.namespaces[nsHash]
+	if !exists {
+		c.Unlock()
+		return
+	}
+	delete(c.namespaces, nsHash)
+	c.toDelete = append(c.toDelete, results.elems)
+	c.Unlock()
+
+	c.notifyDeletion()
+	c.metrics.unregisters.Inc(1)
+}
+
+func (c *cache) Close() error {
+	c.Lock()
+	if c.closed {
+		c.Unlock()
+		return errCacheClosed
+	}
+	c.closed = true
+	c.Unlock()
+
+	close(c.closedCh)
+	c.wgWorker.Wait()
+	return nil
+}
+
+// tryGetWithLock attempts to get the match result, returning true if a match
+// result is successfully determined and no further processing is required,
+// and false otherwise.
+func (c *cache) tryGetWithLock(
+	namespace, id []byte,
+	fromNanos, toNanos int64,
+	setType setType,
+) (rules.MatchResult, bool) {
+	res := rules.EmptyMatchResult
+	nsHash := xid.HashFn(namespace)
+	results, exists := c.namespaces[nsHash]
+	if !exists {
+		c.metrics.hits.Inc(1)
+		return res, true
+	}
+	idHash := xid.HashFn(id)
+	elem, exists := results.elems[idHash]
+	if exists {
+		res = elem.result
+		// NB(xichen): the cached match result expires when a new rule takes effect.
+		// Therefore we need to check if the cache result is valid up to the end
+		// of the match time range, a.k.a. toNanos.
+		if !res.HasExpired(toNanos) {
+			// NB(xichen): in order to avoid the overhead acquiring an exclusive
+			// lock to perform a promotion to move the element to the front of the
+			// list, we set an expiry time for each promotion and do not perform
+			// another promotion if the previous one is still fresh. This should be
+			// good enough because if the cache is sufficiently large, the frequently
+			// accessed items should be still near the front of the list. Additionally,
+			// we can still achieve the exact LRU semantics by setting fresh duration
+			// and stutter duration to 0.
+			now := c.nowFn()
+			if elem.ShouldPromote(now) {
+				c.promote(now, elem)
+			}
+			c.metrics.hits.Inc(1)
+			return res, true
+		}
+		c.metrics.expires.Inc(1)
+	}
+	if setType == dontSetIfNotFound {
+		return res, false
+	}
+	// NB(xichen): the result is either not cached, or cached but invalid, in both
+	// cases we should use the source to compute the result and set it in the cache.
+	return c.setWithLock(nsHash, idHash, id, fromNanos, toNanos, results, exists), true
+}
+
+func (c *cache) setWithLock(
+	nsHash, idHash xid.Hash,
+	id []byte,
+	fromNanos, toNanos int64,
+	results results,
+	invalidate bool,
+) rules.MatchResult {
+	// NB(xichen): if a cached result is invalid, it's very likely that we've reached
+	// a new cutover time and the old cached results are now invalid, therefore it's
+	// preferrable to invalidate everything to save the overhead of multiple invalidations.
+	if invalidate {
+		results = c.invalidateWithLock(nsHash, idHash, results)
+	}
+	res := results.source.Match(id, fromNanos, toNanos)
+	newElem := &element{nsHash: nsHash, idHash: idHash, result: res}
+	newElem.SetPromotionExpiry(c.newPromotionExpiry(c.nowFn()))
+	results.elems[idHash] = newElem
+	// NB(xichen): we don't evict until the number of cached items goes
+	// above the capacity by at least the eviction batch size to amortize
+	// the eviction overhead.
+	if newSize := c.add(newElem); newSize > c.capacity+c.evictionBatchSize {
+		c.notifyEviction()
+	}
+	c.metrics.misses.Inc(1)
+	return res
+}
+
+func (c *cache) add(elem *element) int {
+	c.list.Lock()
+	c.list.PushFront(elem)
+	size := c.list.Len()
+	c.list.Unlock()
+	return size
+}
+
+func (c *cache) promote(now time.Time, elem *element) {
+	c.list.Lock()
+	// Bail if someone else got ahead of us and promoted this element.
+	if !elem.ShouldPromote(now) {
+		c.list.Unlock()
+		return
+	}
+	// Otherwise proceed with promotion.
+	elem.SetPromotionExpiry(c.newPromotionExpiry(now))
+	c.list.MoveToFront(elem)
+	c.list.Unlock()
+	c.metrics.promotions.Inc(1)
+}
+
+func (c *cache) invalidateWithLock(nsHash xid.Hash, idHash xid.Hash, results results) results {
+	if c.invalidationMode == InvalidateAll {
+		c.toDelete = append(c.toDelete, results.elems)
+		c.notifyDeletion()
+		results.elems = make(elemMap)
+		c.namespaces[nsHash] = results
+	} else {
+		elem := results.elems[idHash]
+		delete(results.elems, idHash)
+		c.list.Lock()
+		c.list.Remove(elem)
+		c.list.Unlock()
+	}
+	return results
+}
+
+func (c *cache) evict() {
+	defer c.wgWorker.Done()
+
+	for {
+		select {
+		case <-c.evictCh:
+			c.doEvict()
+		case <-c.closedCh:
+			return
+		}
+	}
+}
+
+func (c *cache) doEvict() {
+	c.Lock()
+	c.list.Lock()
+	numEvicted := 0
+	for c.list.Len() > c.capacity {
+		elem := c.list.Back()
+		c.list.Remove(elem)
+		numEvicted++
+		// NB(xichen): the namespace owning this element may have been deleted,
+		// in which case we simply continue. This is okay because the deleted element
+		// will be marked as deleted so when the deletion goroutine sees and tries to
+		// delete it again, it will be a no op, at which point it will be removed from
+		// the owning map as well.
+		results, exists := c.namespaces[elem.nsHash]
+		if !exists {
+			continue
+		}
+		delete(results.elems, elem.idHash)
+	}
+	c.list.Unlock()
+	c.Unlock()
+	c.metrics.evictions.Inc(int64(numEvicted))
+}
+
+func (c *cache) delete() {
+	defer c.wgWorker.Done()
+
+	for {
+		select {
+		case <-c.deleteCh:
+			c.doDelete()
+		case <-c.closedCh:
+			return
+		}
+	}
+}
+
+func (c *cache) doDelete() {
+	c.Lock()
+	if len(c.toDelete) == 0 {
+		c.Unlock()
+		return
+	}
+
+	// NB(xichen): add pooling if deletion happens frequent enough.
+	toDelete := c.toDelete
+	c.toDelete = nil
+	c.Unlock()
+
+	allDeleted := 0
+	deleted := 0
+	c.list.Lock()
+	for _, elems := range toDelete {
+		for _, elem := range elems {
+			c.list.Remove(elem)
+			allDeleted++
+			deleted++
+			// If we have deleted enough elements, release the lock
+			// and give other goroutines a chance to acquire the lock
+			// since deletion does not need to be fast.
+			if deleted >= c.deletionBatchSize {
+				c.list.Unlock()
+				c.sleepFn(deletionThrottleInterval)
+				deleted = 0
+				c.list.Lock()
+			}
+		}
+	}
+	c.list.Unlock()
+	c.metrics.deletions.Inc(int64(allDeleted))
+}
+
+func (c *cache) notifyEviction() {
+	select {
+	case c.evictCh <- struct{}{}:
+	default:
+	}
+}
+
+func (c *cache) notifyDeletion() {
+	select {
+	case c.deleteCh <- struct{}{}:
+	default:
+	}
+}
+
+func (c *cache) newPromotionExpiry(now time.Time) time.Time {
+	expiry := now.Add(c.freshDuration)
+	if c.stutterDuration > 0 {
+		expiry = expiry.Add(time.Duration(rand.Int63n(int64(c.stutterDuration))))
+	}
+	return expiry
+}

--- a/matcher/cache/cache_test.go
+++ b/matcher/cache/cache_test.go
@@ -1,0 +1,686 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package cache
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/m3db/m3metrics/matcher"
+	"github.com/m3db/m3metrics/rules"
+	"github.com/m3db/m3x/clock"
+	"github.com/m3db/m3x/id"
+
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	errTestWaitUntilTimeout = errors.New("test timed out waiting for condition")
+	testEmptyMatchResult    = rules.EmptyMatchResult
+	testWaitTimeout         = 200 * time.Millisecond
+	testValues              = []testValue{
+		{namespace: []byte("nsfoo"), id: []byte("foo"), result: testValidResults[0]},
+		{namespace: []byte("nsbar"), id: []byte("bar"), result: testValidResults[1]},
+	}
+)
+
+func TestCacheMatchNamespaceDoesNotExist(t *testing.T) {
+	opts := testCacheOptions()
+	c := NewCache(opts)
+
+	res := c.Match([]byte("nonexistentNs"), []byte("foo"), 0, 0)
+	require.Equal(t, testEmptyMatchResult, res)
+}
+
+func TestCacheMatchIDCachedValidNoPromotion(t *testing.T) {
+	opts := testCacheOptions()
+	c := NewCache(opts).(*cache)
+	now := time.Now()
+	c.nowFn = func() time.Time { return now }
+	source := newMockSource()
+	populateCache(c, testValues, now.Add(time.Minute), source, populateBoth)
+
+	// Get the second id and assert we didn't perform a promotion.
+	res := c.Match(testValues[1].namespace, testValues[1].id, now.UnixNano(), now.UnixNano())
+	require.Equal(t, testValues[1].result, res)
+	validateCache(t, c, testValues)
+}
+
+func TestCacheMatchIDCachedValidWithPromotion(t *testing.T) {
+	opts := testCacheOptions()
+	c := NewCache(opts).(*cache)
+	now := time.Now()
+	c.nowFn = func() time.Time { return now }
+	source := newMockSource()
+	populateCache(c, testValues, now, source, populateBoth)
+
+	// Move the time and assert we performed a promotion.
+	now = now.Add(time.Minute)
+	res := c.Match(testValues[1].namespace, testValues[1].id, now.UnixNano(), now.UnixNano())
+	require.Equal(t, testValues[1].result, res)
+	expected := []testValue{testValues[1], testValues[0]}
+	validateCache(t, c, expected)
+}
+
+func TestCacheMatchIDCachedInvalidSourceValidInvalidateAll(t *testing.T) {
+	opts := testCacheOptions()
+	c := NewCache(opts).(*cache)
+	now := time.Now()
+	c.nowFn = func() time.Time { return now }
+	source := newMockSource()
+	input := []testValue{
+		{namespace: testValues[1].namespace, id: testValues[0].id, result: testValues[0].result},
+		{namespace: testValues[1].namespace, id: testValues[1].id, result: rules.NewMatchResult(now.Add(time.Second).UnixNano(), nil, nil)},
+	}
+	populateCache(c, input, now, source, populateBoth)
+	require.Equal(t, 2, len(c.namespaces[testValues[1].nsHash()].elems))
+
+	var (
+		ns         = testValues[1].namespace
+		nsHash     = xid.HashFn(ns)
+		id         = testValues[1].id
+		idHash     = testValues[1].idHash()
+		newVersion = 3
+	)
+	result := rules.NewMatchResult(math.MaxInt64, testMappingPoliciesList, testRollupResults)
+	source.setVersion(newVersion)
+	source.setResult(id, result)
+
+	require.Equal(t, 2, len(c.namespaces[nsHash].elems))
+	res := c.Match(ns, id, now.UnixNano(), now.Add(time.Minute).UnixNano())
+	require.Equal(t, result, res)
+
+	// Wait for deletion to happen
+	conditionFn := func() bool {
+		c.list.Lock()
+		len := c.list.Len()
+		c.list.Unlock()
+		return len == 1
+	}
+	require.NoError(t, testWaitUntilWithTimeout(conditionFn, testWaitTimeout))
+
+	expected := []testValue{{namespace: ns, id: id, result: result}}
+	require.Equal(t, 1, len(c.namespaces))
+	require.Equal(t, 1, len(c.namespaces[nsHash].elems))
+	elem, exists := c.namespaces[nsHash].elems[idHash]
+	require.True(t, exists)
+	require.Equal(t, elem, c.list.Front())
+	validateCache(t, c, expected)
+}
+
+func TestCacheMatchIDCachedInvalidSourceValidInvalidateAllNoEviction(t *testing.T) {
+	opts := testCacheOptions()
+	c := NewCache(opts).(*cache)
+	now := time.Now()
+	c.nowFn = func() time.Time { return now }
+	source := newMockSource()
+	input := []testValue{
+		{namespace: testValues[1].namespace, id: testValues[0].id, result: testValues[0].result},
+		{namespace: testValues[1].namespace, id: testValues[1].id, result: testExpiredResults[1]},
+	}
+	populateCache(c, input, now, source, populateBoth)
+	require.Equal(t, 2, len(c.namespaces[testValues[1].nsHash()].elems))
+
+	var (
+		ns         = testValues[1].namespace
+		nsHash     = xid.HashFn(ns)
+		id         = testValues[1].id
+		idHash     = testValues[1].idHash()
+		newVersion = 3
+	)
+	result := rules.NewMatchResult(math.MaxInt64, testMappingPoliciesList, testRollupResults)
+	source.setVersion(newVersion)
+	source.setResult(id, result)
+
+	require.Equal(t, 2, len(c.namespaces[nsHash].elems))
+	res := c.Match(ns, id, now.UnixNano(), now.UnixNano())
+	require.Equal(t, result, res)
+
+	// Wait for deletion to happen
+	conditionFn := func() bool {
+		c.list.Lock()
+		len := c.list.Len()
+		c.list.Unlock()
+		return len == 1
+	}
+	require.NoError(t, testWaitUntilWithTimeout(conditionFn, testWaitTimeout))
+
+	expected := []testValue{{namespace: ns, id: id, result: result}}
+	require.Equal(t, 1, len(c.namespaces))
+	require.Equal(t, 1, len(c.namespaces[nsHash].elems))
+	elem, exists := c.namespaces[nsHash].elems[idHash]
+	require.True(t, exists)
+	require.Equal(t, elem, c.list.Front())
+	validateCache(t, c, expected)
+}
+
+func TestCacheMatchIDCachedInvalidSourceValidInvalidateOneNoEviction(t *testing.T) {
+	opts := testCacheOptions().SetInvalidationMode(InvalidateOne)
+	c := NewCache(opts).(*cache)
+	now := time.Now()
+	c.nowFn = func() time.Time { return now }
+	source := newMockSource()
+	input := []testValue{
+		{namespace: testValues[1].namespace, id: testValues[0].id, result: testValues[0].result},
+		{namespace: testValues[1].namespace, id: testValues[1].id, result: testExpiredResults[1]},
+	}
+	populateCache(c, input, now, source, populateBoth)
+
+	var (
+		ns         = testValues[1].namespace
+		nsHash     = testValues[1].nsHash()
+		id         = testValues[1].id
+		idHash     = testValues[1].idHash()
+		newVersion = 3
+	)
+	result := rules.NewMatchResult(math.MaxInt64, testMappingPoliciesList, testRollupResults)
+	source.setVersion(newVersion)
+	source.setResult(id, result)
+
+	require.Equal(t, 2, len(c.namespaces[nsHash].elems))
+	res := c.Match(ns, id, now.UnixNano(), now.UnixNano())
+	require.Equal(t, result, res)
+
+	// Wait for deletion to happen.
+	conditionFn := func() bool {
+		c.list.Lock()
+		len := c.list.Len()
+		c.list.Unlock()
+		return len == 2
+	}
+	require.NoError(t, testWaitUntilWithTimeout(conditionFn, testWaitTimeout))
+
+	expected := []testValue{
+		{namespace: ns, id: id, result: result},
+		{namespace: ns, id: testValues[0].id, result: testValues[0].result},
+	}
+	require.Equal(t, 1, len(c.namespaces))
+	require.Equal(t, 2, len(c.namespaces[nsHash].elems))
+	elem, exists := c.namespaces[nsHash].elems[idHash]
+	require.True(t, exists)
+	require.Equal(t, elem, c.list.Front())
+	validateCache(t, c, expected)
+}
+
+func TestCacheMatchIDCachedInvalidSourceValidWithEviction(t *testing.T) {
+	opts := testCacheOptions().SetInvalidationMode(InvalidateOne)
+	c := NewCache(opts).(*cache)
+	now := time.Now()
+	c.nowFn = func() time.Time { return now }
+	source := newMockSource()
+	input := []testValue{
+		{namespace: []byte("ns1"), id: []byte("foo"), result: testExpiredResults[0]},
+		{namespace: []byte("ns1"), id: []byte("bar"), result: testExpiredResults[0]},
+		{namespace: []byte("ns2"), id: []byte("baz"), result: testExpiredResults[1]},
+		{namespace: []byte("ns2"), id: []byte("cat"), result: testExpiredResults[1]},
+	}
+	populateCache(c, input, now, source, populateBoth)
+
+	newVersion := 3
+	newResult := rules.NewMatchResult(math.MaxInt64, testMappingPoliciesList, testRollupResults)
+	source.setVersion(newVersion)
+	for _, id := range []string{"foo", "bar", "baz", "cat", "lol"} {
+		source.setResult([]byte(id), newResult)
+	}
+
+	// Retrieve a few ids and assert we don't evict due to eviction batching.
+	for _, value := range []struct {
+		namespace []byte
+		id        []byte
+	}{
+		{namespace: []byte("ns1"), id: []byte("foo")},
+		{namespace: []byte("ns1"), id: []byte("bar")},
+		{namespace: []byte("ns2"), id: []byte("baz")},
+		{namespace: []byte("ns2"), id: []byte("cat")},
+	} {
+		res := c.Match(value.namespace, value.id, now.UnixNano(), now.UnixNano())
+		require.Equal(t, newResult, res)
+	}
+	conditionFn := func() bool {
+		c.list.Lock()
+		len := c.list.Len()
+		c.list.Unlock()
+		return len == c.capacity
+	}
+	require.Equal(t, errTestWaitUntilTimeout, testWaitUntilWithTimeout(conditionFn, testWaitTimeout))
+	expected := []testValue{
+		{namespace: []byte("ns2"), id: []byte("cat"), result: newResult},
+		{namespace: []byte("ns2"), id: []byte("baz"), result: newResult},
+		{namespace: []byte("ns1"), id: []byte("bar"), result: newResult},
+		{namespace: []byte("ns1"), id: []byte("foo"), result: newResult},
+	}
+	validateCache(t, c, expected)
+
+	// Retrieve one more id and assert we perform async eviction.
+	c.invalidationMode = InvalidateAll
+	res := c.Match([]byte("ns1"), []byte("lol"), now.UnixNano(), now.UnixNano())
+	require.Equal(t, newResult, res)
+	require.NoError(t, testWaitUntilWithTimeout(conditionFn, testWaitTimeout))
+	expected = []testValue{
+		{namespace: []byte("ns1"), id: []byte("lol"), result: newResult},
+		{namespace: []byte("ns2"), id: []byte("cat"), result: newResult},
+	}
+	validateCache(t, c, expected)
+}
+
+func TestCacheMatchIDNotCachedAndDoesNotExistInSource(t *testing.T) {
+	opts := testCacheOptions()
+	c := NewCache(opts).(*cache)
+	now := time.Now()
+	c.nowFn = func() time.Time { return now }
+	source := newMockSource()
+	populateCache(c, testValues, now.Add(time.Minute), source, populateBoth)
+
+	res := c.Match([]byte("nsfoo"), []byte("nonExistent"), now.UnixNano(), now.UnixNano())
+	require.Equal(t, testEmptyMatchResult, res)
+}
+
+func TestCacheMatchIDNotCachedSourceValidNoEviction(t *testing.T) {
+	opts := testCacheOptions()
+	c := NewCache(opts).(*cache)
+	now := time.Now()
+	c.nowFn = func() time.Time { return now }
+	source := newMockSource()
+	populateCache(c, []testValue{testValues[1]}, now, source, populateSource)
+
+	var (
+		ns     = testValues[1].namespace
+		nsHash = xid.HashFn(ns)
+		id     = testValues[1].id
+		idHash = testValues[1].idHash()
+		result = testValues[1].result
+	)
+	require.Equal(t, 0, len(c.namespaces[nsHash].elems))
+	res := c.Match(ns, id, now.UnixNano(), now.UnixNano())
+	require.Equal(t, result, res)
+
+	expected := []testValue{testValues[1]}
+	elem, exists := c.namespaces[nsHash].elems[idHash]
+	require.True(t, exists)
+	require.Equal(t, elem, c.list.Front())
+	validateCache(t, c, expected)
+}
+
+func TestCacheMatchParallel(t *testing.T) {
+	opts := testCacheOptions()
+	c := NewCache(opts).(*cache)
+	now := time.Now()
+	c.nowFn = func() time.Time { return now }
+	source := newMockSource()
+	input := []testValue{
+		{namespace: []byte("ns1"), id: []byte("foo"), result: testExpiredResults[0]},
+		{namespace: []byte("ns2"), id: []byte("baz"), result: testExpiredResults[1]},
+	}
+	populateCache(c, input, now, source, populateBoth)
+
+	newVersion := 3
+	nowNanos := time.Now().UnixNano()
+	newResult := rules.NewMatchResult(nowNanos, testMappingPoliciesList, testRollupResults)
+	source.setVersion(newVersion)
+	for _, id := range []string{"foo", "baz"} {
+		source.setResult([]byte(id), newResult)
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 1000; i++ {
+		v := input[i%2]
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			res := c.Match(v.namespace, v.id, now.UnixNano(), now.UnixNano())
+			require.Equal(t, newResult, res)
+		}()
+	}
+	wg.Wait()
+
+	if c.list.Front().idHash == input[0].idHash() {
+		validateCache(t, c, []testValue{
+			{namespace: []byte("ns1"), id: []byte("foo"), result: newResult},
+			{namespace: []byte("ns2"), id: []byte("baz"), result: newResult},
+		})
+	} else {
+		validateCache(t, c, []testValue{
+			{namespace: []byte("ns2"), id: []byte("baz"), result: newResult},
+			{namespace: []byte("ns1"), id: []byte("foo"), result: newResult},
+		})
+	}
+}
+
+func TestCacheRegisterNamespaceDoesNotExist(t *testing.T) {
+	opts := testCacheOptions()
+	c := NewCache(opts).(*cache)
+	now := time.Now()
+	c.nowFn = func() time.Time { return now }
+	require.Equal(t, 0, len(c.namespaces))
+
+	var (
+		ns     = []byte("ns")
+		nsHash = xid.HashFn(ns)
+		source = newMockSource()
+	)
+	c.Register(ns, source)
+	require.Equal(t, 1, len(c.namespaces))
+	require.Equal(t, 0, len(c.namespaces[nsHash].elems))
+	require.Equal(t, source, c.namespaces[nsHash].source)
+}
+
+func TestCacheRegisterNamespaceExists(t *testing.T) {
+	opts := testCacheOptions()
+	c := NewCache(opts).(*cache)
+	now := time.Now()
+	c.nowFn = func() time.Time { return now }
+	populateCache(c, []testValue{testValues[0]}, now, nil, populateBoth)
+
+	ns := testValues[0].namespace
+	nsHash := xid.HashFn(ns)
+	require.Equal(t, 1, len(c.namespaces))
+	require.Equal(t, 1, len(c.namespaces[nsHash].elems))
+	require.Nil(t, c.namespaces[nsHash].source)
+
+	source := newMockSource()
+	c.Register(ns, source)
+
+	// Wait till the outdated cached data are deleted.
+	conditionFn := func() bool {
+		c.list.Lock()
+		len := c.list.Len()
+		c.list.Unlock()
+		return len == 0
+	}
+	require.NoError(t, testWaitUntilWithTimeout(conditionFn, testWaitTimeout))
+
+	require.Equal(t, 1, len(c.namespaces))
+	require.Equal(t, 0, len(c.namespaces[nsHash].elems))
+	require.Equal(t, source, c.namespaces[nsHash].source)
+}
+
+func TestCacheUnregisterNamespaceDoesNotExist(t *testing.T) {
+	opts := testCacheOptions()
+	c := NewCache(opts).(*cache)
+	now := time.Now()
+	c.nowFn = func() time.Time { return now }
+	populateCache(c, testValues, now, nil, populateBoth)
+
+	// Delete a namespace that doesn't exist.
+	c.Unregister([]byte("nonexistent"))
+
+	// Wait a little in case anything unexpected would happen.
+	time.Sleep(100 * time.Millisecond)
+
+	validateCache(t, c, testValues)
+}
+
+func TestCacheUnregisterNamespaceExists(t *testing.T) {
+	opts := testCacheOptions()
+	c := NewCache(opts).(*cache)
+	now := time.Now()
+	c.nowFn = func() time.Time { return now }
+	populateCache(c, testValues, now, nil, populateBoth)
+
+	// Delete a namespace.
+	for _, value := range testValues {
+		c.Unregister(value.namespace)
+	}
+
+	// Wait till the namespace is deleted.
+	conditionFn := func() bool {
+		c.list.Lock()
+		len := c.list.Len()
+		c.list.Unlock()
+		return len == 0
+	}
+	require.NoError(t, testWaitUntilWithTimeout(conditionFn, testWaitTimeout))
+
+	// Assert the value has been deleted.
+	validateCache(t, c, nil)
+}
+
+func TestCacheDeleteBatching(t *testing.T) {
+	opts := testCacheOptions().SetDeletionBatchSize(10)
+	c := NewCache(opts).(*cache)
+	now := time.Now()
+	c.nowFn = func() time.Time { return now }
+	var intervals []time.Duration
+	c.sleepFn = func(d time.Duration) {
+		intervals = append(intervals, d)
+	}
+
+	var elemMaps []elemMap
+	for _, value := range testValues {
+		m := make(elemMap)
+		for i := 0; i < 37; i++ {
+			elem := &element{
+				nsHash:      value.nsHash(),
+				idHash:      xid.HashFn([]byte(fmt.Sprintf("%s%d", value.id, i))),
+				result:      value.result,
+				expiryNanos: now.UnixNano(),
+			}
+			m[elem.idHash] = elem
+			c.list.PushBack(elem)
+		}
+		elemMaps = append(elemMaps, m)
+	}
+
+	c.Lock()
+	c.toDelete = elemMaps
+	c.Unlock()
+
+	// Send the deletion signal.
+	c.deleteCh <- struct{}{}
+
+	// Wait till the namespace is deleted.
+	conditionFn := func() bool {
+		c.list.Lock()
+		len := c.list.Len()
+		c.list.Unlock()
+		return len == 0
+	}
+	require.NoError(t, testWaitUntilWithTimeout(conditionFn, testWaitTimeout))
+
+	// Assert the value has been deleted.
+	validateCache(t, c, nil)
+
+	// Assert we have slept 7 times.
+	require.Equal(t, 7, len(intervals))
+	for i := 0; i < 7; i++ {
+		require.Equal(t, deletionThrottleInterval, intervals[i])
+	}
+}
+
+func TestCacheClose(t *testing.T) {
+	opts := testCacheOptions()
+	c := NewCache(opts).(*cache)
+
+	// Make sure we can close multiple times.
+	require.NoError(t, c.Close())
+
+	// Make sure the workers have exited.
+	c.evictCh <- struct{}{}
+	c.deleteCh <- struct{}{}
+
+	// Sleep a little in case those signals can be consumed.
+	time.Sleep(100 * time.Millisecond)
+
+	// Assert no goroutines are consuming the signals.
+	require.Equal(t, 1, len(c.evictCh))
+	require.Equal(t, 1, len(c.deleteCh))
+
+	// Assert closing the cache again will return an error.
+	require.Equal(t, errCacheClosed, c.Close())
+}
+
+type populationMode int
+
+const (
+	populateMap    populationMode = 1 << 0
+	populateSource populationMode = 1 << 1
+	populateBoth   populationMode = populateMap | populateSource
+)
+
+type mockSource struct {
+	sync.Mutex
+
+	idMap       map[string]rules.MatchResult
+	currVersion int
+}
+
+func newMockSource() *mockSource {
+	return &mockSource{idMap: make(map[string]rules.MatchResult)}
+}
+
+func (s *mockSource) IsValid(version int) bool {
+	s.Lock()
+	currVersion := s.currVersion
+	s.Unlock()
+	return version >= currVersion
+}
+
+func (s *mockSource) Match(id []byte, fromNanos, toNanos int64) rules.MatchResult {
+	s.Lock()
+	defer s.Unlock()
+	if res, exists := s.idMap[string(id)]; exists {
+		return res
+	}
+	return rules.EmptyMatchResult
+}
+
+func (s *mockSource) setVersion(version int) {
+	s.Lock()
+	s.currVersion = version
+	s.Unlock()
+}
+
+func (s *mockSource) setResult(id []byte, res rules.MatchResult) {
+	s.Lock()
+	s.idMap[string(id)] = res
+	s.Unlock()
+}
+
+type conditionFn func() bool
+
+func testWaitUntilWithTimeout(fn conditionFn, dur time.Duration) error {
+	start := time.Now()
+	for !fn() {
+		time.Sleep(100 * time.Millisecond)
+		end := time.Now()
+		if end.Sub(start) >= dur {
+			return errTestWaitUntilTimeout
+		}
+	}
+	return nil
+}
+
+func testCacheOptions() Options {
+	return NewOptions().
+		SetClockOptions(clock.NewOptions()).
+		SetCapacity(2).
+		SetFreshDuration(5 * time.Second).
+		SetStutterDuration(1 * time.Second).
+		SetEvictionBatchSize(2).
+		SetDeletionBatchSize(2).
+		SetInvalidationMode(InvalidateAll)
+}
+
+func populateCache(
+	c *cache,
+	values []testValue,
+	expiry time.Time,
+	source *mockSource,
+	mode populationMode,
+) {
+	var resultSource matcher.Source
+	if source != nil {
+		resultSource = source
+	}
+	for _, value := range values {
+		results, exists := c.namespaces[value.nsHash()]
+		if !exists {
+			results = newResults(resultSource)
+			c.namespaces[value.nsHash()] = results
+		}
+		if (mode & populateMap) > 0 {
+			elem := &element{
+				nsHash:      value.nsHash(),
+				idHash:      value.idHash(),
+				result:      value.result,
+				expiryNanos: expiry.UnixNano(),
+			}
+			results.elems[elem.idHash] = elem
+			c.list.PushBack(elem)
+		}
+		if (mode&populateSource) > 0 && source != nil {
+			source.idMap[string(value.id)] = value.result
+		}
+	}
+}
+
+func validateCache(t *testing.T, c *cache, expected []testValue) {
+	c.list.Lock()
+	defer c.list.Unlock()
+
+	validateList(t, &c.list.list, expected)
+	validateNamespaces(t, c.namespaces, &c.list.list, expected)
+}
+
+func validateNamespaces(
+	t *testing.T,
+	namespaces map[xid.Hash]results,
+	l *list,
+	expected []testValue,
+) {
+	expectedNamespaces := make(map[xid.Hash][]testValue)
+	for _, v := range expected {
+		expectedNamespaces[v.nsHash()] = append(expectedNamespaces[v.nsHash()], v)
+	}
+	require.Equal(t, len(expectedNamespaces), len(namespaces))
+	for namespace, results := range namespaces {
+		expectedResults, exists := expectedNamespaces[namespace]
+		require.True(t, exists)
+		validateResults(t, results.elems, l, expectedResults)
+	}
+}
+
+func validateResults(t *testing.T, elems elemMap, l *list, expected []testValue) {
+	require.Equal(t, len(expected), len(elems))
+	elemMap := make(map[*element]struct{})
+	for _, v := range expected {
+		e, exists := elems[v.idHash()]
+		require.True(t, exists)
+		elemMap[e] = struct{}{}
+
+		// Assert the element is in the list.
+		found := false
+		for le := l.Front(); le != nil; le = le.next {
+			if le == e {
+				found = true
+				break
+			}
+		}
+		require.True(t, found)
+	}
+
+	// Assert all the elements are unique.
+	require.Equal(t, len(expected), len(elemMap))
+}

--- a/matcher/cache/list.go
+++ b/matcher/cache/list.go
@@ -1,0 +1,155 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package cache
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/m3db/m3metrics/rules"
+	"github.com/m3db/m3x/id"
+)
+
+// element is a list element
+type element struct {
+	nsHash      xid.Hash
+	idHash      xid.Hash
+	result      rules.MatchResult
+	deleted     bool
+	expiryNanos int64
+	prev        *element
+	next        *element
+}
+
+// ShouldPromote determines whether the previous promotion has expired
+// and we should perform a new promotion.
+func (e *element) ShouldPromote(now time.Time) bool {
+	return atomic.LoadInt64(&e.expiryNanos) <= now.UnixNano()
+}
+
+// SetPromotionExpiry sets the expiry time of the current promotion.
+func (e *element) SetPromotionExpiry(t time.Time) {
+	atomic.StoreInt64(&e.expiryNanos, t.UnixNano())
+}
+
+// list is a type-specific implementation of doubly linked lists consisting
+// of elements so when we retrieve match results, there is no conversion
+// between interface{} and the concrete result type.
+type list struct {
+	head   *element
+	tail   *element
+	length int
+}
+
+// Len returns the number of elements in the list.
+func (l *list) Len() int { return l.length }
+
+// Front returns the first element in the list.
+func (l *list) Front() *element { return l.head }
+
+// Back returns the last element in the list.
+func (l *list) Back() *element { return l.tail }
+
+// PushFront pushes an element to the front of the list.
+func (l *list) PushFront(elem *element) {
+	if elem == nil || elem.deleted {
+		return
+	}
+	if l.head == nil {
+		l.head = elem
+		l.tail = elem
+		elem.prev = nil
+		elem.next = nil
+	} else {
+		elem.next = l.head
+		elem.prev = nil
+		l.head.prev = elem
+		l.head = elem
+	}
+	l.length++
+}
+
+// PushBack pushes an element to the back of the list.
+func (l *list) PushBack(elem *element) {
+	if elem == nil || elem.deleted {
+		return
+	}
+	if l.tail == nil {
+		l.head = elem
+		l.tail = elem
+		elem.prev = nil
+		elem.next = nil
+	} else {
+		elem.prev = l.tail
+		elem.next = nil
+		l.tail.next = elem
+		l.tail = elem
+	}
+	l.length++
+}
+
+// Remove removes an element from the list.
+func (l *list) Remove(elem *element) {
+	if elem == nil || elem.deleted {
+		return
+	}
+
+	// Remove the element from the list.
+	l.remove(elem, true)
+}
+
+// MoveToFront moves an element to the beginning of the list.
+func (l *list) MoveToFront(elem *element) {
+	if elem == nil || elem.deleted {
+		return
+	}
+
+	// Removing the element from the list.
+	l.remove(elem, false)
+
+	// Pushing the element to the front of the list.
+	l.PushFront(elem)
+}
+
+func (l *list) remove(elem *element, markDeleted bool) {
+	prev := elem.prev
+	next := elem.next
+	if prev == nil {
+		l.head = next
+	} else {
+		prev.next = next
+	}
+	if next == nil {
+		l.tail = prev
+	} else {
+		next.prev = prev
+	}
+	l.length--
+	elem.prev = nil // avoid memory leak.
+	elem.next = nil // avoid memory leak.
+	elem.deleted = markDeleted
+}
+
+type lockedList struct {
+	sync.Mutex
+	list
+}

--- a/matcher/cache/list_test.go
+++ b/matcher/cache/list_test.go
@@ -1,0 +1,250 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package cache
+
+import (
+	"fmt"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/m3db/m3metrics/policy"
+	"github.com/m3db/m3metrics/rules"
+	xid "github.com/m3db/m3x/id"
+	"github.com/m3db/m3x/time"
+
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	testMappingPoliciesList = policy.PoliciesList{
+		policy.NewStagedPolicies(
+			0,
+			false,
+			[]policy.Policy{
+				policy.NewPolicy(policy.NewStoragePolicy(20*time.Second, xtime.Second, 6*time.Hour), policy.DefaultAggregationID),
+				policy.NewPolicy(policy.NewStoragePolicy(time.Minute, xtime.Minute, 2*24*time.Hour), policy.DefaultAggregationID),
+				policy.NewPolicy(policy.NewStoragePolicy(10*time.Minute, xtime.Minute, 25*24*time.Hour), policy.DefaultAggregationID),
+			},
+		),
+		policy.NewStagedPolicies(
+			0,
+			true,
+			[]policy.Policy{
+				policy.NewPolicy(policy.NewStoragePolicy(time.Second, xtime.Second, time.Hour), policy.DefaultAggregationID),
+			},
+		),
+	}
+	testRollupResults = []rules.RollupResult{
+		{
+			ID:           []byte("rID1"),
+			PoliciesList: policy.DefaultPoliciesList,
+		},
+		{
+			ID: []byte("rID2"),
+			PoliciesList: policy.PoliciesList{
+				policy.NewStagedPolicies(
+					0,
+					false,
+					[]policy.Policy{
+						policy.NewPolicy(policy.NewStoragePolicy(20*time.Second, xtime.Second, 6*time.Hour), policy.DefaultAggregationID),
+						policy.NewPolicy(policy.NewStoragePolicy(time.Minute, xtime.Minute, 2*24*time.Hour), policy.DefaultAggregationID),
+						policy.NewPolicy(policy.NewStoragePolicy(10*time.Minute, xtime.Minute, 25*24*time.Hour), policy.DefaultAggregationID),
+					},
+				),
+				policy.NewStagedPolicies(
+					0,
+					true,
+					[]policy.Policy{
+						policy.NewPolicy(policy.NewStoragePolicy(time.Second, xtime.Second, time.Hour), policy.DefaultAggregationID),
+					},
+				),
+			},
+		},
+	}
+	testValidResults = []rules.MatchResult{
+		rules.NewMatchResult(math.MaxInt64, nil, nil),
+		rules.NewMatchResult(math.MaxInt64, testMappingPoliciesList, testRollupResults),
+	}
+	testExpiredResults = []rules.MatchResult{
+		rules.NewMatchResult(0, nil, nil),
+		rules.NewMatchResult(0, testMappingPoliciesList, testRollupResults),
+	}
+)
+
+func TestElementShouldExpire(t *testing.T) {
+	now := time.Unix(0, 1234)
+	e := &element{}
+	for _, input := range []struct {
+		expiryNanos int64
+		expected    bool
+	}{
+		{expiryNanos: 1233, expected: true},
+		{expiryNanos: 1234, expected: true},
+		{expiryNanos: 1235, expected: false},
+	} {
+		e.expiryNanos = input.expiryNanos
+		require.Equal(t, input.expected, e.ShouldPromote(now))
+	}
+}
+
+func TestListPushFront(t *testing.T) {
+	var (
+		l      list
+		iter   = 10
+		inputs = make([]testValue, iter)
+	)
+	for i := 0; i < iter; i++ {
+		namespace := []byte(fmt.Sprintf("namespace%d", i))
+		id := []byte(fmt.Sprintf("foo%d", i))
+		result := testValidResults[i%2]
+		inputs[iter-i-1] = testValue{namespace: namespace, id: id, result: result}
+		l.PushFront(&element{nsHash: xid.HashFn(namespace), idHash: xid.HashFn(id), result: result})
+	}
+
+	// Pushing front a nil pointer is a no-op.
+	l.PushFront(nil)
+
+	// Pushing front a deleted element is a no-op.
+	l.PushFront(&element{nsHash: xid.HashFn([]byte("deletedNs")), result: testValidResults[0], deleted: true})
+
+	validateList(t, &l, inputs)
+}
+
+func TestListPushBack(t *testing.T) {
+	var (
+		l      list
+		iter   = 10
+		inputs = make([]testValue, iter)
+	)
+	for i := 0; i < iter; i++ {
+		namespace := []byte(fmt.Sprintf("namespace%d", i))
+		id := []byte(fmt.Sprintf("foo%d", i))
+		result := testValidResults[i%2]
+		inputs[i] = testValue{namespace: namespace, id: id, result: result}
+		l.PushBack(&element{nsHash: xid.HashFn(namespace), idHash: xid.HashFn(id), result: result})
+	}
+
+	// Pushing back a nil pointer is a no-op.
+	l.PushBack(nil)
+
+	// Pushing back a deleted element is a no-op.
+	l.PushBack(&element{nsHash: xid.HashFn([]byte("deletedNs")), result: testValidResults[0], deleted: true})
+
+	validateList(t, &l, inputs)
+}
+
+func TestListRemove(t *testing.T) {
+	var (
+		l      list
+		iter   = 10
+		inputs = make([]testValue, iter)
+	)
+	for i := 0; i < iter; i++ {
+		namespace := []byte(fmt.Sprintf("namespace%d", i))
+		id := []byte(fmt.Sprintf("foo%d", i))
+		result := testValidResults[i%2]
+		inputs[i] = testValue{namespace: namespace, id: id, result: result}
+		l.PushBack(&element{nsHash: xid.HashFn(namespace), idHash: xid.HashFn(id), result: result})
+	}
+
+	// Removing a nil pointer is no-op.
+	l.Remove(nil)
+
+	// Removing a deleted element is a no-op.
+	l.Remove(&element{nsHash: xid.HashFn([]byte("deletedNs")), result: testValidResults[0], deleted: true})
+
+	for i := 0; i < iter; i++ {
+		elem := l.Front()
+		l.Remove(elem)
+		require.Nil(t, elem.prev)
+		require.Nil(t, elem.next)
+		validateList(t, &l, inputs[i+1:])
+	}
+}
+
+func TestListMoveToFront(t *testing.T) {
+	var (
+		l      list
+		iter   = 10
+		inputs = make([]testValue, iter)
+	)
+	for i := 0; i < iter; i++ {
+		namespace := []byte(fmt.Sprintf("namespace%d", i))
+		id := []byte(fmt.Sprintf("foo%d", i))
+		result := testValidResults[i%2]
+		inputs[i] = testValue{namespace: namespace, id: id, result: result}
+		l.PushBack(&element{nsHash: xid.HashFn(namespace), idHash: xid.HashFn(id), result: result})
+	}
+
+	// Moving a nil pointer to front is a no-op.
+	l.MoveToFront(nil)
+
+	// Moving a deleted element to front is a no-op.
+	l.MoveToFront(&element{nsHash: xid.HashFn([]byte("deletedNs")), result: testValidResults[0], deleted: true})
+
+	// Starting from the back, moving elements to front one at a time.
+	var prev, curr, last *element
+	for {
+		if curr == last && curr != nil {
+			break
+		}
+		if last == nil {
+			last = l.Back()
+			curr = last
+		}
+		prev = curr.prev
+		l.MoveToFront(curr)
+		require.Equal(t, l.head, curr)
+		require.Nil(t, curr.prev)
+		curr = prev
+	}
+	validateList(t, &l, inputs)
+}
+
+type testValue struct {
+	namespace []byte
+	id        []byte
+	result    rules.MatchResult
+}
+
+func (v testValue) nsHash() xid.Hash { return xid.HashFn(v.namespace) }
+func (v testValue) idHash() xid.Hash { return xid.HashFn(v.id) }
+
+func validateList(t *testing.T, l *list, expected []testValue) {
+	require.Equal(t, len(expected), l.Len())
+	i := 0
+	for elem := l.Front(); elem != nil; elem = elem.next {
+		require.Equal(t, expected[i].nsHash(), elem.nsHash)
+		require.Equal(t, expected[i].idHash(), elem.idHash)
+		require.Equal(t, expected[i].result, elem.result)
+		i++
+	}
+	if len(expected) == 0 {
+		require.Nil(t, l.head)
+		require.Nil(t, l.tail)
+	} else {
+		require.Equal(t, l.Front(), l.head)
+		require.Nil(t, l.head.prev)
+		require.Equal(t, l.Back(), l.tail)
+		require.Nil(t, l.tail.next)
+	}
+}

--- a/matcher/cache/options.go
+++ b/matcher/cache/options.go
@@ -1,0 +1,204 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package cache
+
+import (
+	"time"
+
+	"github.com/m3db/m3x/clock"
+	"github.com/m3db/m3x/instrument"
+)
+
+// InvalidationMode is the invalidation mode.
+type InvalidationMode int
+
+const (
+	// InvalidateOne only invalidates a single invalid entry as needed.
+	InvalidateOne InvalidationMode = iota
+
+	// InvalidateAll invalidates all entries as long as one entry is invalid.
+	InvalidateAll
+)
+
+const (
+	defaultCapacity          = 200000
+	defaultFreshDuration     = 5 * time.Minute
+	defaultStutterDuration   = time.Minute
+	defaultEvictionBatchSize = 1024
+	defaultDeletionBatchSize = 1024
+	defaultInvalidationMode  = InvalidateAll
+)
+
+// Options provide a set of cache options.
+type Options interface {
+	// SetClockOptions sets the clock options.
+	SetClockOptions(value clock.Options) Options
+
+	// ClockOptions returns the clock options.
+	ClockOptions() clock.Options
+
+	// SetInstrumentOptions sets the instrument options.
+	SetInstrumentOptions(value instrument.Options) Options
+
+	// InstrumentOptions returns the instrument options.
+	InstrumentOptions() instrument.Options
+
+	// SetCapacity sets the cache capacity.
+	SetCapacity(value int) Options
+
+	// Capacity returns the cache capacity.
+	Capacity() int
+
+	// SetFreshDuration sets the entry fresh duration.
+	SetFreshDuration(value time.Duration) Options
+
+	// FreshDuration returns the fresh duration.
+	FreshDuration() time.Duration
+
+	// SetStutterDuration sets the entry stutter duration.
+	SetStutterDuration(value time.Duration) Options
+
+	// StutterDuration returns the entry stutter duration.
+	StutterDuration() time.Duration
+
+	// SetEvictionBatchSize sets the eviction batch size.
+	SetEvictionBatchSize(value int) Options
+
+	// EvictionBatchSize returns the eviction batch size.
+	EvictionBatchSize() int
+
+	// SetDeletionBatchSize sets the deletion batch size.
+	SetDeletionBatchSize(value int) Options
+
+	// DeletionBatchSize returns the deletion batch size.
+	DeletionBatchSize() int
+
+	// SetInvalidationMode sets the invalidation mode.
+	SetInvalidationMode(value InvalidationMode) Options
+
+	// InvalidationMode returns the invalidation mode.
+	InvalidationMode() InvalidationMode
+}
+
+type options struct {
+	clockOpts         clock.Options
+	instrumentOpts    instrument.Options
+	capacity          int
+	freshDuration     time.Duration
+	stutterDuration   time.Duration
+	evictionBatchSize int
+	deletionBatchSize int
+	invalidationMode  InvalidationMode
+}
+
+// NewOptions creates a new set of options.
+func NewOptions() Options {
+	return &options{
+		clockOpts:         clock.NewOptions(),
+		instrumentOpts:    instrument.NewOptions(),
+		capacity:          defaultCapacity,
+		freshDuration:     defaultFreshDuration,
+		stutterDuration:   defaultStutterDuration,
+		evictionBatchSize: defaultEvictionBatchSize,
+		deletionBatchSize: defaultDeletionBatchSize,
+		invalidationMode:  defaultInvalidationMode,
+	}
+}
+
+func (o *options) SetClockOptions(value clock.Options) Options {
+	opts := *o
+	opts.clockOpts = value
+	return &opts
+}
+
+func (o *options) ClockOptions() clock.Options {
+	return o.clockOpts
+}
+
+func (o *options) SetInstrumentOptions(value instrument.Options) Options {
+	opts := *o
+	opts.instrumentOpts = value
+	return &opts
+}
+
+func (o *options) InstrumentOptions() instrument.Options {
+	return o.instrumentOpts
+}
+
+func (o *options) SetCapacity(value int) Options {
+	opts := *o
+	opts.capacity = value
+	return &opts
+}
+
+func (o *options) Capacity() int {
+	return o.capacity
+}
+
+func (o *options) SetFreshDuration(value time.Duration) Options {
+	opts := *o
+	opts.freshDuration = value
+	return &opts
+}
+
+func (o *options) FreshDuration() time.Duration {
+	return o.freshDuration
+}
+
+func (o *options) SetStutterDuration(value time.Duration) Options {
+	opts := *o
+	opts.stutterDuration = value
+	return &opts
+}
+
+func (o *options) StutterDuration() time.Duration {
+	return o.stutterDuration
+}
+
+func (o *options) SetEvictionBatchSize(value int) Options {
+	opts := *o
+	opts.evictionBatchSize = value
+	return &opts
+}
+
+func (o *options) EvictionBatchSize() int {
+	return o.evictionBatchSize
+}
+
+func (o *options) SetDeletionBatchSize(value int) Options {
+	opts := *o
+	opts.evictionBatchSize = value
+	return &opts
+}
+
+func (o *options) DeletionBatchSize() int {
+	return o.evictionBatchSize
+}
+
+func (o *options) SetInvalidationMode(value InvalidationMode) Options {
+	opts := *o
+	opts.invalidationMode = value
+	return &opts
+}
+
+func (o *options) InvalidationMode() InvalidationMode {
+	return o.invalidationMode
+}

--- a/matcher/match.go
+++ b/matcher/match.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package matcher
+
+import (
+	"github.com/m3db/m3cluster/kv/util/runtime"
+	"github.com/m3db/m3metrics/metric/id"
+	"github.com/m3db/m3metrics/rules"
+	"github.com/m3db/m3x/log"
+)
+
+// Matcher matches rules against metric IDs.
+type Matcher interface {
+	// Match matches rules against metric ID for time range [fromNanos, toNanos)
+	// and returns the match result.
+	Match(id id.ID, fromNanos, toNanos int64) rules.MatchResult
+
+	// Close closes the matcher.
+	Close() error
+}
+
+type matcher struct {
+	opts             Options
+	namespaceTag     []byte
+	defaultNamespace []byte
+
+	namespaces *namespaces
+	cache      Cache
+}
+
+// NewMatcher creates a new rule matcher.
+func NewMatcher(cache Cache, opts Options) (Matcher, error) {
+	key := opts.NamespacesKey()
+	namespaces := newNamespaces(key, cache, opts)
+	// NB(xichen): if there is no cache provided, the newly created
+	// namespaces object is used as a zero-size forwarding cache that
+	// forwards all match requests to the backing rulesets.
+	if cache == nil {
+		cache = namespaces
+		namespaces.setCache(namespaces)
+	}
+	if err := namespaces.Watch(); err != nil {
+		scope := opts.InstrumentOptions().MetricsScope()
+		errCreateWatch, ok := err.(runtime.CreateWatchError)
+		if ok {
+			scope.Counter("create-watch-errors").Inc(1)
+			return nil, errCreateWatch
+		}
+		// NB(xichen): we managed to watch the key but weren't able
+		// to initialize the value. In this case, log the error instead
+		// to be more resilient to error conditions preventing process
+		// from starting up.
+		scope.Counter("init-watch-errors").Inc(1)
+		log := opts.InstrumentOptions().Logger()
+		log.WithFields(
+			xlog.NewLogField("key", key),
+			xlog.NewLogErrField(err),
+		).Error("error initializing namespaces values")
+	}
+	return &matcher{
+		opts:             opts,
+		namespaceTag:     opts.NamespaceTag(),
+		defaultNamespace: opts.DefaultNamespace(),
+		namespaces:       namespaces,
+		cache:            cache,
+	}, nil
+}
+
+func (m *matcher) Match(id id.ID, fromNanos, toNanos int64) rules.MatchResult {
+	ns, found := id.TagValue(m.namespaceTag)
+	if !found {
+		ns = m.defaultNamespace
+	}
+	return m.cache.Match(ns, id.Bytes(), fromNanos, toNanos)
+}
+
+func (m *matcher) Close() error {
+	m.namespaces.Close()
+	return m.cache.Close()
+}

--- a/matcher/match_test.go
+++ b/matcher/match_test.go
@@ -1,0 +1,145 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package matcher
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/m3db/m3cluster/kv"
+	"github.com/m3db/m3cluster/kv/mem"
+	"github.com/m3db/m3cluster/kv/util/runtime"
+	"github.com/m3db/m3metrics/generated/proto/schema"
+	"github.com/m3db/m3metrics/rules"
+	"github.com/m3db/m3x/clock"
+	"github.com/m3db/m3x/instrument"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMatcherCreateWatchError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	kvStore := kv.NewMockStore(ctrl)
+	kvStore.EXPECT().Watch(testNamespacesKey).Return(nil, runtime.CreateWatchError{})
+	opts := NewOptions().
+		SetInitWatchTimeout(10 * time.Millisecond).
+		SetNamespacesKey(testNamespacesKey).
+		SetKVStore(kvStore)
+
+	_, err := NewMatcher(newMemCache(), opts)
+	require.Error(t, err)
+	_, ok := err.(runtime.CreateWatchError)
+	require.True(t, ok)
+}
+
+func TestMatcherInitializeValueError(t *testing.T) {
+	memStore := mem.NewStore()
+	opts := NewOptions().
+		SetInitWatchTimeout(10 * time.Millisecond).
+		SetNamespacesKey(testNamespacesKey).
+		SetKVStore(memStore)
+
+	matcher, err := NewMatcher(newMemCache(), opts)
+	require.NoError(t, err)
+	require.NotNil(t, matcher)
+}
+
+func TestMatcherMatchDoesNotExist(t *testing.T) {
+	id := &testMetricID{
+		id:         []byte("foo"),
+		tagValueFn: func(tagName []byte) ([]byte, bool) { return nil, false },
+	}
+	now := time.Now()
+	matcher := testMatcher(t, nil)
+	require.Equal(t, rules.EmptyMatchResult, matcher.Match(id, now.UnixNano(), now.UnixNano()))
+}
+
+func TestMatcherMatchExists(t *testing.T) {
+	var (
+		ns = "ns/foo"
+		id = &testMetricID{
+			id:         []byte("foo"),
+			tagValueFn: func(tagName []byte) ([]byte, bool) { return []byte(ns), true },
+		}
+		now    = time.Now()
+		res    = rules.NewMatchResult(math.MaxInt64, nil, nil)
+		memRes = memResults{results: map[string]rules.MatchResult{"foo": res}}
+	)
+	cache := newMemCache()
+	matcher := testMatcher(t, cache)
+	c := cache.(*memCache)
+	c.namespaces[ns] = memRes
+	require.Equal(t, res, matcher.Match(id, now.UnixNano(), now.UnixNano()))
+}
+
+func TestMatcherClose(t *testing.T) {
+	matcher := testMatcher(t, newMemCache())
+	require.NoError(t, matcher.Close())
+}
+
+func testMatcher(t *testing.T, cache Cache) Matcher {
+	var (
+		store = mem.NewStore()
+		opts  = NewOptions().
+			SetClockOptions(clock.NewOptions()).
+			SetInstrumentOptions(instrument.NewOptions()).
+			SetInitWatchTimeout(100 * time.Millisecond).
+			SetKVStore(store).
+			SetNamespacesKey(testNamespacesKey).
+			SetNamespaceTag([]byte("namespace")).
+			SetDefaultNamespace([]byte("default")).
+			SetRuleSetKeyFn(defaultRuleSetKeyFn).
+			SetRuleSetOptions(rules.NewOptions())
+		proto = &schema.Namespaces{
+			Namespaces: []*schema.Namespace{
+				&schema.Namespace{
+					Name: "fooNs",
+					Snapshots: []*schema.NamespaceSnapshot{
+						&schema.NamespaceSnapshot{
+							ForRulesetVersion: 1,
+							Tombstoned:        true,
+						},
+					},
+				},
+			},
+		}
+	)
+	_, err := store.SetIfNotExists(testNamespacesKey, proto)
+	require.NoError(t, err)
+
+	m, err := NewMatcher(cache, opts)
+	require.NoError(t, err)
+	return m
+}
+
+type tagValueFn func(tagName []byte) ([]byte, bool)
+
+type testMetricID struct {
+	id         []byte
+	tagValueFn tagValueFn
+}
+
+func (id *testMetricID) Bytes() []byte                          { return id.id }
+func (id *testMetricID) TagValue(tagName []byte) ([]byte, bool) { return id.tagValueFn(tagName) }

--- a/matcher/match_test.go
+++ b/matcher/match_test.go
@@ -72,7 +72,7 @@ func TestMatcherMatchDoesNotExist(t *testing.T) {
 		tagValueFn: func(tagName []byte) ([]byte, bool) { return nil, false },
 	}
 	now := time.Now()
-	matcher := testMatcher(t, nil)
+	matcher := testMatcher(t, newMemCache())
 	require.Equal(t, rules.EmptyMatchResult, matcher.Match(id, now.UnixNano(), now.UnixNano()))
 }
 

--- a/matcher/namespaces.go
+++ b/matcher/namespaces.go
@@ -1,0 +1,207 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package matcher
+
+import (
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/m3db/m3cluster/kv"
+	"github.com/m3db/m3cluster/kv/util/runtime"
+	"github.com/m3db/m3metrics/generated/proto/schema"
+	"github.com/m3db/m3metrics/rules"
+	"github.com/m3db/m3x/clock"
+	"github.com/m3db/m3x/id"
+	"github.com/m3db/m3x/log"
+)
+
+var (
+	emptyNamespaces rules.Namespaces
+	errNilValue     = errors.New("nil value received")
+)
+
+// namespaces contains the list of namespace users have defined rules for.
+// NB(xichen): namespaces implements the Cache interface and can be used as
+// a zero-size forwarding cache that forwards all match requests to the backing
+// rulesets without caching any match results.
+type namespaces struct {
+	sync.RWMutex
+	runtime.Value
+
+	key            string
+	store          kv.Store
+	cache          Cache
+	opts           Options
+	log            xlog.Logger
+	ruleSetKeyFn   RuleSetKeyFn
+	nowFn          clock.NowFn
+	matchRangePast time.Duration
+
+	proto *schema.Namespaces
+	rules map[xid.Hash]*ruleSet
+}
+
+func newNamespaces(key string, cache Cache, opts Options) *namespaces {
+	n := &namespaces{
+		key:            key,
+		store:          opts.KVStore(),
+		cache:          cache,
+		opts:           opts,
+		log:            opts.InstrumentOptions().Logger(),
+		ruleSetKeyFn:   opts.RuleSetKeyFn(),
+		proto:          &schema.Namespaces{},
+		rules:          make(map[xid.Hash]*ruleSet),
+		nowFn:          opts.ClockOptions().NowFn(),
+		matchRangePast: opts.MatchRangePast(),
+	}
+	valueOpts := runtime.NewOptions().
+		SetInstrumentOptions(opts.InstrumentOptions()).
+		SetInitWatchTimeout(opts.InitWatchTimeout()).
+		SetKVStore(n.store).
+		SetUnmarshalFn(n.toNamespaces).
+		SetProcessFn(n.process)
+	n.Value = runtime.NewValue(key, valueOpts)
+	return n
+}
+
+func (n *namespaces) Match(namespace, id []byte, fromNanos, toNanos int64) rules.MatchResult {
+	var (
+		res    = rules.EmptyMatchResult
+		nsHash = xid.HashFn(namespace)
+	)
+	n.RLock()
+	ruleSet, exists := n.rules[nsHash]
+	if !exists {
+		// TODO: add metrics.
+		n.RUnlock()
+		return res
+	}
+	n.RUnlock()
+	return ruleSet.Match(id, fromNanos, toNanos)
+}
+
+func (n *namespaces) Register([]byte, Source) {}
+func (n *namespaces) Unregister([]byte)       {}
+
+func (n *namespaces) Close() error {
+	// NB(xichen): we stop watching the value outside lock because otherwise we might
+	// be holding the namespace lock while attempting to acquire the value lock, and
+	// the updating goroutine might be holding the value lock and attempting to
+	// acquire the namespace lock, causing a deadlock.
+	n.Value.Unwatch()
+
+	n.RLock()
+	for _, rs := range n.rules {
+		rs.Unwatch()
+	}
+	n.RUnlock()
+	return nil
+}
+
+func (n *namespaces) setCache(cache Cache) {
+	n.Lock()
+	n.cache = cache
+	n.Unlock()
+}
+
+func (n *namespaces) toNamespaces(value kv.Value) (interface{}, error) {
+	n.Lock()
+	defer n.Unlock()
+
+	if value == nil {
+		return emptyNamespaces, errNilValue
+	}
+	n.proto.Reset()
+	if err := value.Unmarshal(n.proto); err != nil {
+		return emptyNamespaces, err
+	}
+	return rules.NewNamespaces(value.Version(), n.proto)
+}
+
+func (n *namespaces) process(value interface{}) error {
+	var (
+		nss        = value.(rules.Namespaces)
+		version    = nss.Version()
+		namespaces = nss.Namespaces()
+		incoming   = make(map[xid.Hash]rules.Namespace, len(namespaces))
+	)
+	for _, ns := range namespaces {
+		incoming[xid.HashFn(ns.Name())] = ns
+	}
+
+	n.Lock()
+	defer n.Unlock()
+
+	for nsHash, ns := range incoming {
+		nsName, snapshots := ns.Name(), ns.Snapshots()
+		ruleSet, exists := n.rules[nsHash]
+		if !exists {
+			ruleSetKey := n.ruleSetKeyFn(ns.Name())
+			ruleSet = newRuleSet(nsName, ruleSetKey, n.cache, n.opts)
+			n.rules[nsHash] = ruleSet
+		}
+
+		shouldWatch := true
+		// This should never happen but just to be on the defensive side.
+		if len(snapshots) == 0 {
+			n.log.WithFields(
+				xlog.NewLogField("version", version),
+			).Warn("namespace updates have no snapshots")
+		} else {
+			latestSnapshot := snapshots[len(snapshots)-1]
+			// If the latest update shows the namespace is tombstoned, and we
+			// have received the corresponding ruleset update, we can stop watching
+			// the ruleset updates.
+			if latestSnapshot.Tombstoned() && latestSnapshot.ForRuleSetVersion() == ruleSet.Version() {
+				shouldWatch = false
+			}
+		}
+		if !shouldWatch {
+			ruleSet.Unwatch()
+		} else if err := ruleSet.Watch(); err != nil {
+			n.log.WithFields(
+				xlog.NewLogField("ruleSetKey", ruleSet.Key()),
+				xlog.NewLogErrField(err),
+			).Error("failed to watch ruleset updates")
+		}
+
+		if !exists {
+			n.cache.Register(nsName, ruleSet)
+		}
+	}
+
+	for nsHash, ruleSet := range n.rules {
+		_, exists := incoming[nsHash]
+		if exists {
+			continue
+		}
+		// Process the namespaces not in the incoming update.
+		earliest := n.nowFn().Add(-n.matchRangePast)
+		if ruleSet.Tombstoned() && ruleSet.CutoverNanos() <= earliest.UnixNano() {
+			n.cache.Unregister(ruleSet.Namespace())
+			delete(n.rules, nsHash)
+			ruleSet.Unwatch()
+		}
+	}
+
+	return nil
+}

--- a/matcher/namespaces.go
+++ b/matcher/namespaces.go
@@ -128,11 +128,10 @@ func (n *namespaces) Version(namespace []byte) int {
 	nsHash := xid.HashFn(namespace)
 	n.RLock()
 	ruleSet, exists := n.rules[nsHash]
+	n.RUnlock()
 	if !exists {
-		n.RUnlock()
 		return kv.UninitializedVersion
 	}
-	n.RUnlock()
 	return ruleSet.Version()
 }
 
@@ -143,12 +142,11 @@ func (n *namespaces) Match(namespace, id []byte, fromNanos, toNanos int64) rules
 	)
 	n.RLock()
 	ruleSet, exists := n.rules[nsHash]
+	n.RUnlock()
 	if !exists {
-		n.RUnlock()
 		n.metrics.notExists.Inc(1)
 		return res
 	}
-	n.RUnlock()
 	return ruleSet.Match(id, fromNanos, toNanos)
 }
 

--- a/matcher/namespaces_test.go
+++ b/matcher/namespaces_test.go
@@ -1,0 +1,292 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package matcher
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/m3db/m3cluster/kv"
+	"github.com/m3db/m3cluster/kv/mem"
+	"github.com/m3db/m3metrics/generated/proto/schema"
+	"github.com/m3db/m3metrics/rules"
+	"github.com/m3db/m3x/id"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testNamespacesKey = "testNamespaces"
+)
+
+func TestNamespacesWatchAndClose(t *testing.T) {
+	store, _, nss, _ := testNamespaces()
+	proto := &schema.Namespaces{
+		Namespaces: []*schema.Namespace{
+			&schema.Namespace{
+				Name: "fooNs",
+				Snapshots: []*schema.NamespaceSnapshot{
+					&schema.NamespaceSnapshot{
+						ForRulesetVersion: 1,
+						Tombstoned:        true,
+					},
+				},
+			},
+		},
+	}
+	_, err := store.SetIfNotExists(testNamespacesKey, proto)
+	require.NoError(t, err)
+	require.NoError(t, nss.Watch())
+	require.Equal(t, 1, len(nss.rules))
+	nss.Close()
+}
+
+func TestToNamespacesNilValue(t *testing.T) {
+	_, _, nss, _ := testNamespaces()
+	_, err := nss.toNamespaces(nil)
+	require.Equal(t, errNilValue, err)
+}
+
+func TestToNamespacesUnmarshalError(t *testing.T) {
+	_, _, nss, _ := testNamespaces()
+	_, err := nss.toNamespaces(&mockValue{})
+	require.Error(t, err)
+}
+
+func TestToNamespacesSuccess(t *testing.T) {
+	store, _, nss, _ := testNamespaces()
+	proto := &schema.Namespaces{
+		Namespaces: []*schema.Namespace{
+			&schema.Namespace{
+				Name: "fooNs",
+				Snapshots: []*schema.NamespaceSnapshot{
+					&schema.NamespaceSnapshot{
+						ForRulesetVersion: 1,
+						Tombstoned:        true,
+					},
+				},
+			},
+		},
+	}
+	_, err := store.SetIfNotExists(testNamespacesKey, proto)
+	require.NoError(t, err)
+	v, err := store.Get(testNamespacesKey)
+	require.NoError(t, err)
+	res, err := nss.toNamespaces(v)
+	require.NoError(t, err)
+	actual := res.(rules.Namespaces)
+	require.Equal(t, 1, actual.Version())
+	require.Equal(t, 1, len(actual.Namespaces()))
+	require.Equal(t, []byte("fooNs"), actual.Namespaces()[0].Name())
+}
+
+func TestNamespacesProcess(t *testing.T) {
+	_, cache, nss, opts := testNamespaces()
+	c := cache.(*memCache)
+
+	for _, input := range []struct {
+		namespace  []byte
+		id         string
+		version    int
+		tombstoned bool
+	}{
+		{namespace: []byte("fooNs"), id: "foo", version: 1, tombstoned: false},
+		{namespace: []byte("barNs"), id: "bar", version: 1, tombstoned: true},
+		{namespace: []byte("catNs"), id: "cat", version: 3, tombstoned: true},
+		{namespace: []byte("lolNs"), id: "lol", version: 3, tombstoned: true},
+	} {
+		rs := newRuleSet(input.namespace, input.id, cache, opts)
+		rs.Value = &mockRuntimeValue{key: input.id}
+		rs.version = input.version
+		rs.tombstoned = input.tombstoned
+		nss.rules[xid.HashFn(input.namespace)] = rs
+		c.namespaces[string(input.namespace)] = memResults{source: rs}
+	}
+
+	update := &schema.Namespaces{
+		Namespaces: []*schema.Namespace{
+			&schema.Namespace{
+				Name: "fooNs",
+				Snapshots: []*schema.NamespaceSnapshot{
+					&schema.NamespaceSnapshot{
+						ForRulesetVersion: 1,
+						Tombstoned:        false,
+					},
+					&schema.NamespaceSnapshot{
+						ForRulesetVersion: 2,
+						Tombstoned:        false,
+					},
+				},
+			},
+			&schema.Namespace{
+				Name: "barNs",
+				Snapshots: []*schema.NamespaceSnapshot{
+					&schema.NamespaceSnapshot{
+						ForRulesetVersion: 1,
+						Tombstoned:        false,
+					},
+					&schema.NamespaceSnapshot{
+						ForRulesetVersion: 2,
+						Tombstoned:        true,
+					},
+				},
+			},
+			&schema.Namespace{
+				Name: "bazNs",
+				Snapshots: []*schema.NamespaceSnapshot{
+					&schema.NamespaceSnapshot{
+						ForRulesetVersion: 1,
+						Tombstoned:        false,
+					},
+					&schema.NamespaceSnapshot{
+						ForRulesetVersion: 2,
+						Tombstoned:        false,
+					},
+				},
+			},
+			&schema.Namespace{
+				Name: "catNs",
+				Snapshots: []*schema.NamespaceSnapshot{
+					&schema.NamespaceSnapshot{
+						ForRulesetVersion: 3,
+						Tombstoned:        true,
+					},
+				},
+			},
+			&schema.Namespace{
+				Name:      "mehNs",
+				Snapshots: nil,
+			},
+		},
+	}
+
+	nssValue, err := rules.NewNamespaces(5, update)
+	require.NoError(t, err)
+	require.NoError(t, nss.process(nssValue))
+	require.Equal(t, 5, len(nss.rules))
+	require.Equal(t, 5, len(c.namespaces))
+
+	expected := []struct {
+		key       string
+		watched   int32
+		unwatched int32
+	}{
+		{key: "foo", watched: 1, unwatched: 0},
+		{key: "bar", watched: 1, unwatched: 0},
+		{key: "/ruleset/bazNs", watched: 1, unwatched: 0},
+		{key: "cat", watched: 0, unwatched: 1},
+		{key: "/ruleset/mehNs", watched: 1, unwatched: 0},
+	}
+	for i, ns := range update.Namespaces {
+		rs, exists := nss.rules[xid.HashFn([]byte(ns.Name))]
+		require.True(t, exists)
+		require.Equal(t, expected[i].key, rs.Key())
+		require.Equal(t, rs, c.namespaces[string(ns.Name)].source.(*ruleSet))
+		mv, ok := rs.Value.(*mockRuntimeValue)
+		if !ok {
+			continue
+		}
+		require.Equal(t, expected[i].watched, mv.numWatched)
+		require.Equal(t, expected[i].unwatched, mv.numUnwatched)
+	}
+}
+
+func testNamespaces() (kv.Store, Cache, *namespaces, Options) {
+	store := mem.NewStore()
+	cache := newMemCache()
+	opts := NewOptions().
+		SetInitWatchTimeout(100 * time.Millisecond).
+		SetKVStore(store).
+		SetNamespacesKey(testNamespacesKey)
+	return store, cache, newNamespaces(testNamespacesKey, cache, opts), opts
+}
+
+type memResults struct {
+	results map[string]rules.MatchResult
+	source  Source
+}
+
+type memCache struct {
+	sync.RWMutex
+
+	namespaces map[string]memResults
+}
+
+func newMemCache() Cache {
+	return &memCache{namespaces: make(map[string]memResults)}
+}
+
+func (c *memCache) Match(namespace, id []byte, fromNanos, toNanos int64) rules.MatchResult {
+	c.RLock()
+	defer c.RUnlock()
+	if results, exists := c.namespaces[string(namespace)]; exists {
+		return results.results[string(id)]
+	}
+	return rules.EmptyMatchResult
+}
+
+func (c *memCache) Register(namespace []byte, source Source) {
+	c.Lock()
+	defer c.Unlock()
+
+	results, exists := c.namespaces[string(namespace)]
+	if !exists {
+		results = memResults{
+			results: make(map[string]rules.MatchResult),
+			source:  source,
+		}
+	} else {
+		results.source = source
+	}
+	c.namespaces[string(namespace)] = results
+}
+
+func (c *memCache) Unregister(namespace []byte) {
+	c.Lock()
+	defer c.Unlock()
+	delete(c.namespaces, string(namespace))
+}
+
+func (c *memCache) Close() error { return nil }
+
+type mockRuntimeValue struct {
+	key          string
+	numWatched   int32
+	watchErr     error
+	numUnwatched int32
+}
+
+func (mv *mockRuntimeValue) Key() string  { return mv.key }
+func (mv *mockRuntimeValue) Watch() error { atomic.AddInt32(&mv.numWatched, 1); return nil }
+func (mv *mockRuntimeValue) Unwatch()     { atomic.AddInt32(&mv.numUnwatched, 1) }
+
+type mockValue struct {
+	version int
+	cutover time.Time
+}
+
+func (v mockValue) Unmarshal(proto.Message) error { return errors.New("unimplemented") }
+func (v mockValue) Version() int                  { return v.version }
+func (v mockValue) IsNewer(other kv.Value) bool   { return v.version > other.Version() }

--- a/matcher/options.go
+++ b/matcher/options.go
@@ -1,0 +1,245 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package matcher
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/m3db/m3cluster/kv"
+	"github.com/m3db/m3cluster/kv/mem"
+	"github.com/m3db/m3metrics/rules"
+	"github.com/m3db/m3x/clock"
+	"github.com/m3db/m3x/instrument"
+)
+
+const (
+	defaultInitWatchTimeout = 10 * time.Second
+	defaultValueRetryPeriod = 10 * time.Second
+	defaultValueRetryExpiry = 3 * time.Hour
+	defaultNamespacesKey    = "/namespaces"
+	defaultRuleSetKeyFormat = "/ruleset/%s"
+	defaultMatchRangePast   = 0
+)
+
+var (
+	defaultNamespaceTag     = []byte("namespace")
+	defaultDefaultNamespace = []byte("defaultNamespace")
+)
+
+func defaultRuleSetKeyFn(namespace []byte) string {
+	return fmt.Sprintf(defaultRuleSetKeyFormat, namespace)
+}
+
+// RuleSetKeyFn generates the ruleset key for a given namespace.
+type RuleSetKeyFn func(namespace []byte) string
+
+// Options provide a set of options for the msgpack-based reporter.
+type Options interface {
+	// SetClockOptions sets the clock options.
+	SetClockOptions(value clock.Options) Options
+
+	// ClockOptions returns the clock options.
+	ClockOptions() clock.Options
+
+	// SetInstrumentOptions sets the instrument options.
+	SetInstrumentOptions(value instrument.Options) Options
+
+	// InstrumentOptions returns the instrument options.
+	InstrumentOptions() instrument.Options
+
+	// SetRuleSetOptions sets the ruleset options.
+	SetRuleSetOptions(value rules.Options) Options
+
+	// RuleSetOptions returns the ruleset options.
+	RuleSetOptions() rules.Options
+
+	// SetInitWatchTimeout sets the initial watch timeout.
+	SetInitWatchTimeout(value time.Duration) Options
+
+	// InitWatchTimeout returns the initial watch timeout.
+	InitWatchTimeout() time.Duration
+
+	// SetKVStore sets the kv store.
+	SetKVStore(value kv.Store) Options
+
+	// KVStore returns the kv store.
+	KVStore() kv.Store
+
+	// SetNamespacesKey sets the key for the full list of namespaces.
+	SetNamespacesKey(value string) Options
+
+	// NamespacesKey returns the key for the full list of namespaces.
+	NamespacesKey() string
+
+	// SetRuleSetKeyFn sets the function to generate ruleset keys.
+	SetRuleSetKeyFn(value RuleSetKeyFn) Options
+
+	// RuleSetKeyFn returns the function to generate ruleset keys.
+	RuleSetKeyFn() RuleSetKeyFn
+
+	// SetNamespaceTag sets the namespace tag.
+	SetNamespaceTag(value []byte) Options
+
+	// NamespaceTag returns the namespace tag.
+	NamespaceTag() []byte
+
+	// SetDefaultNamespace sets the default namespace for ids without a namespace.
+	SetDefaultNamespace(value []byte) Options
+
+	// DefaultNamespace returns the default namespace for ids without a namespace.
+	DefaultNamespace() []byte
+
+	// SetMatchRangePast sets the limit on the earliest time eligible for rule matching.
+	SetMatchRangePast(value time.Duration) Options
+
+	// MatchRangePast returns the limit on the earliest time eligible for rule matching.
+	MatchRangePast() time.Duration
+}
+
+type options struct {
+	clockOpts        clock.Options
+	instrumentOpts   instrument.Options
+	ruleSetOpts      rules.Options
+	initWatchTimeout time.Duration
+	kvStore          kv.Store
+	namespacesKey    string
+	ruleSetKeyFn     RuleSetKeyFn
+	namespaceTag     []byte
+	defaultNamespace []byte
+	matchRangePast   time.Duration
+}
+
+// NewOptions creates a new set of options.
+func NewOptions() Options {
+	return &options{
+		clockOpts:        clock.NewOptions(),
+		instrumentOpts:   instrument.NewOptions(),
+		ruleSetOpts:      rules.NewOptions(),
+		initWatchTimeout: defaultInitWatchTimeout,
+		kvStore:          mem.NewStore(),
+		namespacesKey:    defaultNamespacesKey,
+		ruleSetKeyFn:     defaultRuleSetKeyFn,
+		namespaceTag:     defaultNamespaceTag,
+		defaultNamespace: defaultDefaultNamespace,
+		matchRangePast:   defaultMatchRangePast,
+	}
+}
+
+func (o *options) SetClockOptions(value clock.Options) Options {
+	opts := *o
+	opts.clockOpts = value
+	return &opts
+}
+
+func (o *options) ClockOptions() clock.Options {
+	return o.clockOpts
+}
+
+func (o *options) SetInstrumentOptions(value instrument.Options) Options {
+	opts := *o
+	opts.instrumentOpts = value
+	return &opts
+}
+
+func (o *options) InstrumentOptions() instrument.Options {
+	return o.instrumentOpts
+}
+
+func (o *options) SetRuleSetOptions(value rules.Options) Options {
+	opts := *o
+	opts.ruleSetOpts = value
+	return &opts
+}
+
+func (o *options) RuleSetOptions() rules.Options {
+	return o.ruleSetOpts
+}
+
+func (o *options) SetInitWatchTimeout(value time.Duration) Options {
+	opts := *o
+	opts.initWatchTimeout = value
+	return &opts
+}
+
+func (o *options) InitWatchTimeout() time.Duration {
+	return o.initWatchTimeout
+}
+
+func (o *options) SetKVStore(value kv.Store) Options {
+	opts := *o
+	opts.kvStore = value
+	return &opts
+}
+
+func (o *options) KVStore() kv.Store {
+	return o.kvStore
+}
+
+func (o *options) SetNamespacesKey(value string) Options {
+	opts := *o
+	opts.namespacesKey = value
+	return &opts
+}
+
+func (o *options) NamespacesKey() string {
+	return o.namespacesKey
+}
+
+func (o *options) SetRuleSetKeyFn(value RuleSetKeyFn) Options {
+	opts := *o
+	opts.ruleSetKeyFn = value
+	return &opts
+}
+
+func (o *options) RuleSetKeyFn() RuleSetKeyFn {
+	return o.ruleSetKeyFn
+}
+
+func (o *options) SetNamespaceTag(value []byte) Options {
+	opts := *o
+	opts.namespaceTag = value
+	return &opts
+}
+
+func (o *options) NamespaceTag() []byte {
+	return o.namespaceTag
+}
+
+func (o *options) SetDefaultNamespace(value []byte) Options {
+	opts := *o
+	opts.defaultNamespace = value
+	return &opts
+}
+
+func (o *options) DefaultNamespace() []byte {
+	return o.defaultNamespace
+}
+
+func (o *options) SetMatchRangePast(value time.Duration) Options {
+	opts := *o
+	opts.matchRangePast = value
+	return &opts
+}
+
+func (o *options) MatchRangePast() time.Duration {
+	return o.matchRangePast
+}

--- a/matcher/ruleset.go
+++ b/matcher/ruleset.go
@@ -1,0 +1,147 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package matcher
+
+import (
+	"sync"
+	"time"
+
+	"github.com/m3db/m3cluster/kv"
+	"github.com/m3db/m3cluster/kv/util/runtime"
+	"github.com/m3db/m3metrics/generated/proto/schema"
+	"github.com/m3db/m3metrics/rules"
+	"github.com/m3db/m3x/clock"
+)
+
+// ruleSet contains the list of rules for a namespace.
+type ruleSet struct {
+	sync.RWMutex
+	runtime.Value
+
+	namespace      []byte
+	key            string
+	cache          Cache
+	store          kv.Store
+	opts           Options
+	nowFn          clock.NowFn
+	matchRangePast time.Duration
+	ruleSetOpts    rules.Options
+
+	proto        *schema.RuleSet
+	version      int
+	cutoverNanos int64
+	tombstoned   bool
+	matcher      rules.Matcher
+}
+
+func newRuleSet(
+	namespace []byte,
+	key string,
+	cache Cache,
+	opts Options,
+) *ruleSet {
+	r := &ruleSet{
+		namespace:      namespace,
+		key:            key,
+		cache:          cache,
+		store:          opts.KVStore(),
+		opts:           opts,
+		nowFn:          opts.ClockOptions().NowFn(),
+		matchRangePast: opts.MatchRangePast(),
+		ruleSetOpts:    opts.RuleSetOptions(),
+		proto:          &schema.RuleSet{},
+		version:        kv.UninitializedVersion,
+	}
+	valueOpts := runtime.NewOptions().
+		SetInstrumentOptions(opts.InstrumentOptions()).
+		SetInitWatchTimeout(opts.InitWatchTimeout()).
+		SetKVStore(r.store).
+		SetUnmarshalFn(r.toRuleSet).
+		SetProcessFn(r.process)
+	r.Value = runtime.NewValue(key, valueOpts)
+	return r
+}
+
+func (r *ruleSet) Namespace() []byte {
+	r.RLock()
+	namespace := r.namespace
+	r.RUnlock()
+	return namespace
+}
+
+func (r *ruleSet) Version() int {
+	r.RLock()
+	version := r.version
+	r.RUnlock()
+	return version
+}
+
+func (r *ruleSet) CutoverNanos() int64 {
+	r.RLock()
+	cutoverNanos := r.cutoverNanos
+	r.RUnlock()
+	return cutoverNanos
+}
+
+func (r *ruleSet) Tombstoned() bool {
+	r.RLock()
+	tombstoned := r.tombstoned
+	r.RUnlock()
+	return tombstoned
+}
+
+func (r *ruleSet) Match(id []byte, fromNanos, toNanos int64) rules.MatchResult {
+	r.RLock()
+	defer r.RUnlock()
+
+	if r.matcher == nil {
+		return rules.EmptyMatchResult
+	}
+	return r.matcher.MatchAll(id, fromNanos, toNanos, rules.ForwardMatch)
+}
+
+func (r *ruleSet) toRuleSet(value kv.Value) (interface{}, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	if value == nil {
+		return nil, errNilValue
+	}
+	r.proto.Reset()
+	if err := value.Unmarshal(r.proto); err != nil {
+		return nil, err
+	}
+	return rules.NewRuleSet(value.Version(), r.proto, r.ruleSetOpts)
+}
+
+// process processes an ruleset update.
+func (r *ruleSet) process(value interface{}) error {
+	r.Lock()
+	defer r.Unlock()
+
+	ruleSet := value.(rules.RuleSet)
+	r.version = ruleSet.Version()
+	r.cutoverNanos = ruleSet.CutoverNanos()
+	r.tombstoned = ruleSet.TombStoned()
+	r.matcher = ruleSet.ActiveSet(r.nowFn().Add(-r.matchRangePast))
+	r.cache.Register(r.namespace, r)
+	return nil
+}

--- a/matcher/ruleset_test.go
+++ b/matcher/ruleset_test.go
@@ -1,0 +1,178 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package matcher
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/m3db/m3cluster/kv"
+	"github.com/m3db/m3cluster/kv/mem"
+	"github.com/m3db/m3metrics/generated/proto/schema"
+	"github.com/m3db/m3metrics/rules"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testRuleSetKey = "testRuleSet"
+)
+
+var (
+	testNamespace = []byte("testNamespace")
+)
+
+func TestRuleSetProperties(t *testing.T) {
+	_, _, rs, _ := testRuleSet()
+	rs.namespace = testNamespace
+	rs.version = 2
+	rs.cutoverNanos = 12345
+	rs.tombstoned = true
+
+	require.Equal(t, testNamespace, rs.Namespace())
+	require.Equal(t, 2, rs.Version())
+	require.Equal(t, int64(12345), rs.CutoverNanos())
+	require.Equal(t, true, rs.Tombstoned())
+}
+
+func TestRuleSetMatchNoMatcher(t *testing.T) {
+	_, _, rs, _ := testRuleSet()
+	nowNanos := rs.nowFn().UnixNano()
+	require.Equal(t, rules.EmptyMatchResult, rs.Match([]byte("foo"), nowNanos, nowNanos))
+}
+
+func TestRuleSetMatchWithMatcher(t *testing.T) {
+	_, _, rs, _ := testRuleSet()
+	mockMatcher := &mockMatcher{res: rules.EmptyMatchResult}
+	rs.matcher = mockMatcher
+
+	var (
+		now       = rs.nowFn()
+		fromNanos = now.Add(-time.Second).UnixNano()
+		toNanos   = now.Add(time.Second).UnixNano()
+	)
+
+	require.Equal(t, mockMatcher.res, rs.Match([]byte("foo"), fromNanos, toNanos))
+	require.Equal(t, []byte("foo"), mockMatcher.id)
+	require.Equal(t, fromNanos, mockMatcher.fromNanos)
+	require.Equal(t, toNanos, mockMatcher.toNanos)
+}
+
+func TestToRuleSetNilValue(t *testing.T) {
+	_, _, rs, _ := testRuleSet()
+	_, err := rs.toRuleSet(nil)
+	require.Equal(t, errNilValue, err)
+}
+
+func TestToRuleSetUnmarshalError(t *testing.T) {
+	_, _, rs, _ := testRuleSet()
+	_, err := rs.toRuleSet(&mockValue{})
+	require.Error(t, err)
+}
+
+func TestToRuleSetSuccess(t *testing.T) {
+	store, _, rs, _ := testRuleSet()
+	proto := &schema.RuleSet{
+		Namespace:   string(testNamespace),
+		Tombstoned:  false,
+		CutoverTime: 123456,
+	}
+	_, err := store.SetIfNotExists(testRuleSetKey, proto)
+	require.NoError(t, err)
+	v, err := store.Get(testRuleSetKey)
+	require.NoError(t, err)
+	res, err := rs.toRuleSet(v)
+	require.NoError(t, err)
+	actual := res.(rules.RuleSet)
+	require.Equal(t, testNamespace, actual.Namespace())
+	require.Equal(t, 1, actual.Version())
+	require.Equal(t, int64(123456), actual.CutoverNanos())
+	require.Equal(t, false, actual.TombStoned())
+}
+
+func TestRuleSetProcess(t *testing.T) {
+	var (
+		inputs = []rules.RuleSet{
+			mockRuleSet{namespace: "ns1", version: 1, cutoverNanos: 1234, tombstoned: false, matcher: &mockMatcher{}},
+			mockRuleSet{namespace: "ns2", version: 2, cutoverNanos: 1235, tombstoned: true, matcher: &mockMatcher{}},
+			mockRuleSet{namespace: "ns3", version: 3, cutoverNanos: 1236, tombstoned: false, matcher: &mockMatcher{}},
+			mockRuleSet{namespace: "ns4", version: 4, cutoverNanos: 1237, tombstoned: true, matcher: &mockMatcher{}},
+			mockRuleSet{namespace: "ns5", version: 5, cutoverNanos: 1238, tombstoned: false, matcher: &mockMatcher{}},
+		}
+	)
+
+	_, cache, rs, _ := testRuleSet()
+	memCache := cache.(*memCache)
+	for _, input := range inputs {
+		rs.process(input)
+	}
+
+	require.Equal(t, 5, rs.Version())
+	require.Equal(t, int64(1238), rs.CutoverNanos())
+	require.Equal(t, false, rs.Tombstoned())
+	require.NotNil(t, 5, rs.matcher)
+	require.Equal(t, 1, len(memCache.namespaces))
+	_, exists := memCache.namespaces[string(testNamespace)]
+	require.True(t, exists)
+}
+
+type mockMatcher struct {
+	id        []byte
+	fromNanos int64
+	toNanos   int64
+	res       rules.MatchResult
+}
+
+func (mm *mockMatcher) MatchAll(
+	id []byte,
+	fromNanos, toNanos int64,
+	matchMode rules.MatchMode,
+) rules.MatchResult {
+	mm.id = id
+	mm.fromNanos = fromNanos
+	mm.toNanos = toNanos
+	return mm.res
+}
+
+type mockRuleSet struct {
+	namespace    string
+	version      int
+	cutoverNanos int64
+	tombstoned   bool
+	matcher      *mockMatcher
+}
+
+func (r mockRuleSet) Namespace() []byte                   { return []byte(r.namespace) }
+func (r mockRuleSet) Version() int                        { return r.version }
+func (r mockRuleSet) CutoverNanos() int64                 { return r.cutoverNanos }
+func (r mockRuleSet) TombStoned() bool                    { return r.tombstoned }
+func (r mockRuleSet) ActiveSet(t time.Time) rules.Matcher { return r.matcher }
+
+func testRuleSet() (kv.Store, Cache, *ruleSet, Options) {
+	store := mem.NewStore()
+	cache := newMemCache()
+	opts := NewOptions().
+		SetInitWatchTimeout(100 * time.Millisecond).
+		SetKVStore(store).
+		SetRuleSetKeyFn(func(ns []byte) string { return fmt.Sprintf("/rules/%s", ns) })
+	return store, cache, newRuleSet(testNamespace, testNamespacesKey, cache, opts), opts
+}

--- a/matcher/ruleset_test.go
+++ b/matcher/ruleset_test.go
@@ -173,6 +173,7 @@ func testRuleSet() (kv.Store, Cache, *ruleSet, Options) {
 	opts := NewOptions().
 		SetInitWatchTimeout(100 * time.Millisecond).
 		SetKVStore(store).
-		SetRuleSetKeyFn(func(ns []byte) string { return fmt.Sprintf("/rules/%s", ns) })
-	return store, cache, newRuleSet(testNamespace, testNamespacesKey, cache, opts), opts
+		SetRuleSetKeyFn(func(ns []byte) string { return fmt.Sprintf("/rules/%s", ns) }).
+		SetOnRuleSetUpdatedFn(func(namespace []byte, ruleSet RuleSet) { cache.Register(namespace, ruleSet) })
+	return store, cache, newRuleSet(testNamespace, testNamespacesKey, opts).(*ruleSet), opts
 }


### PR DESCRIPTION
cc @cw9 @prateek @jeromefroe 

This PR moves the rule matcher API from `m3collector` to `m3metrics` so the underlying implementation can be reused across the collector, the indexer, and the query service, with some modifications to the existing implementation.

* Define `Namespaces` interface and `RuleSet` interface. They are useful for indexer/query where in-memory caching is ineffective and we'd like to bypass the readthrough cache and directly perform rule matching using the underlying namespaces and rulesets.

* I also adapted the `Matcher` interface to take a `fromNanos` and a `toNanos` as the match time range. This used to be determined internally inside the `cache` implementation and various other places based on the clock skew offsets. By explicitly passing in the time range, it can be used in different contexts (e.g., collector can determine the match time range based on the clock skew, whereas the indexer can determine the match time range based on when the policy may expire and when the future policy may take effect). As part of the changes, I also renamed `maxNegativeSkew` to `matchRangePast` to make it more generic.

*  I also added metrics to various components to get better visibility.

I'll put up a separate PR that pulls this into m3collector and makes necessary changes to use the new matcher API.