### PR TITLE
Add configurations

### DIFF
--- a/matcher/cache/config.go
+++ b/matcher/cache/config.go
@@ -1,0 +1,45 @@
+package cache
+
+import (
+	"time"
+
+	"github.com/m3db/m3metrics/matcher"
+	"github.com/m3db/m3x/clock"
+	"github.com/m3db/m3x/instrument"
+)
+
+// Configuration is config used to create a matcher.Cache.
+type Configuration struct {
+	Capacity          int           `yaml:"capacity"`
+	FreshDuration     time.Duration `yaml:"freshDuration"`
+	StutterDuration   time.Duration `yaml:"stutterDuration"`
+	EvictionBatchSize int           `yaml:"evictionBatchSize"`
+	DeletionBatchSize int           `yaml:"deletionBatchSize"`
+}
+
+// NewCache creates a matcher.Cache.
+func (cfg *Configuration) NewCache(
+	clockOpts clock.Options,
+	instrumentOpts instrument.Options,
+) matcher.Cache {
+	opts := NewOptions().
+		SetClockOptions(clockOpts).
+		SetInstrumentOptions(instrumentOpts)
+	if cfg.Capacity != 0 {
+		opts = opts.SetCapacity(cfg.Capacity)
+	}
+	if cfg.FreshDuration != 0 {
+		opts = opts.SetFreshDuration(cfg.FreshDuration)
+	}
+	if cfg.StutterDuration != 0 {
+		opts = opts.SetStutterDuration(cfg.StutterDuration)
+	}
+	if cfg.EvictionBatchSize != 0 {
+		opts = opts.SetEvictionBatchSize(cfg.EvictionBatchSize)
+	}
+	if cfg.DeletionBatchSize != 0 {
+		opts = opts.SetDeletionBatchSize(cfg.DeletionBatchSize)
+	}
+
+	return NewCache(opts)
+}

--- a/matcher/cache/config_test.go
+++ b/matcher/cache/config_test.go
@@ -21,45 +21,28 @@
 package cache
 
 import (
+	"testing"
 	"time"
 
-	"github.com/m3db/m3metrics/matcher"
 	"github.com/m3db/m3x/clock"
 	"github.com/m3db/m3x/instrument"
+	"github.com/stretchr/testify/require"
 )
 
-// Configuration is config used to create a matcher.Cache.
-type Configuration struct {
-	Capacity          int           `yaml:"capacity"`
-	FreshDuration     time.Duration `yaml:"freshDuration"`
-	StutterDuration   time.Duration `yaml:"stutterDuration"`
-	EvictionBatchSize int           `yaml:"evictionBatchSize"`
-	DeletionBatchSize int           `yaml:"deletionBatchSize"`
-}
-
-// NewCache creates a matcher.Cache.
-func (cfg *Configuration) NewCache(
-	clockOpts clock.Options,
-	instrumentOpts instrument.Options,
-) matcher.Cache {
-	opts := NewOptions().
-		SetClockOptions(clockOpts).
-		SetInstrumentOptions(instrumentOpts)
-	if cfg.Capacity != 0 {
-		opts = opts.SetCapacity(cfg.Capacity)
-	}
-	if cfg.FreshDuration != 0 {
-		opts = opts.SetFreshDuration(cfg.FreshDuration)
-	}
-	if cfg.StutterDuration != 0 {
-		opts = opts.SetStutterDuration(cfg.StutterDuration)
-	}
-	if cfg.EvictionBatchSize != 0 {
-		opts = opts.SetEvictionBatchSize(cfg.EvictionBatchSize)
-	}
-	if cfg.DeletionBatchSize != 0 {
-		opts = opts.SetDeletionBatchSize(cfg.DeletionBatchSize)
+func TestConfig(t *testing.T) {
+	cfg := Configuration{
+		Capacity:          10,
+		FreshDuration:     time.Second,
+		StutterDuration:   time.Minute,
+		EvictionBatchSize: 20,
+		DeletionBatchSize: 30,
 	}
 
-	return NewCache(opts)
+	c := cfg.NewCache(clock.NewOptions(), instrument.NewOptions())
+	cache := c.(*cache)
+	require.Equal(t, 10, cache.capacity)
+	require.Equal(t, time.Second, cache.freshDuration)
+	require.Equal(t, time.Minute, cache.stutterDuration)
+	require.Equal(t, 20, cache.evictionBatchSize)
+	require.Equal(t, 30, cache.deletionBatchSize)
 }

--- a/matcher/cache/config_test.go
+++ b/matcher/cache/config_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/m3db/m3x/clock"
 	"github.com/m3db/m3x/instrument"
+
 	"github.com/stretchr/testify/require"
 )
 

--- a/matcher/cache/options.go
+++ b/matcher/cache/options.go
@@ -185,12 +185,12 @@ func (o *options) EvictionBatchSize() int {
 
 func (o *options) SetDeletionBatchSize(value int) Options {
 	opts := *o
-	opts.evictionBatchSize = value
+	opts.deletionBatchSize = value
 	return &opts
 }
 
 func (o *options) DeletionBatchSize() int {
-	return o.evictionBatchSize
+	return o.deletionBatchSize
 }
 
 func (o *options) SetInvalidationMode(value InvalidationMode) Options {

--- a/matcher/config.go
+++ b/matcher/config.go
@@ -82,6 +82,12 @@ func (cfg *Configuration) NewOptions(
 	clockOpts clock.Options,
 	instrumentOpts instrument.Options,
 ) (Options, error) {
+	// Configure rules kv store.
+	rulesStore, err := kvCluster.Store(cfg.RulesKVNamespace)
+	if err != nil {
+		return nil, err
+	}
+
 	// Configure rules options.
 	scope := instrumentOpts.MetricsScope().SubScope("sorted-tag-iterator-pool")
 	poolOpts := cfg.SortedTagIteratorPool.NewObjectPoolOptions(instrumentOpts.SetMetricsScope(scope))
@@ -108,12 +114,6 @@ func (cfg *Configuration) NewOptions(
 		SetTagsFilterOptions(tagsFilterOptions).
 		SetNewRollupIDFn(m3.NewRollupID).
 		SetIsRollupIDFn(isRollupIDFn)
-
-	// Configure rules kv store.
-	rulesStore, err := kvCluster.Store(cfg.RulesKVNamespace)
-	if err != nil {
-		return nil, err
-	}
 
 	// Configure ruleset key function.
 	ruleSetKeyFn := func(namespace []byte) string {

--- a/matcher/config.go
+++ b/matcher/config.go
@@ -1,0 +1,138 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package matcher
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/m3db/m3cluster/client"
+	"github.com/m3db/m3metrics/filters"
+	"github.com/m3db/m3metrics/metric/id"
+	"github.com/m3db/m3metrics/metric/id/m3"
+	"github.com/m3db/m3metrics/rules"
+	"github.com/m3db/m3x/clock"
+	"github.com/m3db/m3x/instrument"
+	"github.com/m3db/m3x/pool"
+)
+
+// Configuration is config used to create a Matcher.
+type Configuration struct {
+	InitWatchTimeout      time.Duration                `yaml:"initWatchTimeout"`
+	RulesKVNamespace      string                       `yaml:"rulesKVNamespace" validate:"nonzero"`
+	NamespacesKey         string                       `yaml:"namespacesKey" validate:"nonzero"`
+	RuleSetKeyFmt         string                       `yaml:"ruleSetKeyFmt" validate:"nonzero"`
+	NamespaceTag          string                       `yaml:"namespaceTag" validate:"nonzero"`
+	DefaultNamespace      string                       `yaml:"defaultNamespace" validate:"nonzero"`
+	NameTagKey            string                       `yaml:"nameTagKey" validate:"nonzero"`
+	SortedTagIteratorPool pool.ObjectPoolConfiguration `yaml:"sortedTagIteratorPool"`
+}
+
+// NewNamespaces creates a matcher.Namespaces.
+func (cfg *Configuration) NewNamespaces(
+	kvCluster client.Client,
+	clockOpts clock.Options,
+	instrumentOpts instrument.Options,
+) (Namespaces, error) {
+	opts, err := cfg.NewOptions(kvCluster, clockOpts, instrumentOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	namespaces := NewNamespaces(opts.NamespacesKey(), opts)
+	return namespaces, namespaces.Open()
+}
+
+// NewMatcher creates a Matcher.
+func (cfg *Configuration) NewMatcher(
+	cache Cache,
+	kvCluster client.Client,
+	clockOpts clock.Options,
+	instrumentOpts instrument.Options,
+) (Matcher, error) {
+	opts, err := cfg.NewOptions(kvCluster, clockOpts, instrumentOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewMatcher(cache, opts)
+}
+
+// NewOptions creates a Options.
+func (cfg *Configuration) NewOptions(
+	kvCluster client.Client,
+	clockOpts clock.Options,
+	instrumentOpts instrument.Options,
+) (Options, error) {
+	// Configure rules options.
+	scope := instrumentOpts.MetricsScope().SubScope("sorted-tag-iterator-pool")
+	poolOpts := cfg.SortedTagIteratorPool.NewObjectPoolOptions(instrumentOpts.SetMetricsScope(scope))
+	sortedTagIteratorPool := id.NewSortedTagIteratorPool(poolOpts)
+	sortedTagIteratorPool.Init(func() id.SortedTagIterator {
+		return m3.NewPooledSortedTagIterator(nil, sortedTagIteratorPool)
+	})
+	sortedTagIteratorFn := func(tagPairs []byte) id.SortedTagIterator {
+		it := sortedTagIteratorPool.Get()
+		it.Reset(tagPairs)
+		return it
+	}
+	tagsFilterOptions := filters.TagsFilterOptions{
+		NameTagKey:          []byte(cfg.NameTagKey),
+		NameAndTagsFn:       m3.NameAndTags,
+		SortedTagIteratorFn: sortedTagIteratorFn,
+	}
+
+	isRollupIDFn := func(name []byte, tags []byte) bool {
+		return m3.IsRollupID(name, tags, sortedTagIteratorPool)
+	}
+
+	ruleSetOpts := rules.NewOptions().
+		SetTagsFilterOptions(tagsFilterOptions).
+		SetNewRollupIDFn(m3.NewRollupID).
+		SetIsRollupIDFn(isRollupIDFn)
+
+	// Configure rules kv store.
+	rulesStore, err := kvCluster.Store(cfg.RulesKVNamespace)
+	if err != nil {
+		return nil, err
+	}
+
+	// Configure ruleset key function.
+	ruleSetKeyFn := func(namespace []byte) string {
+		return fmt.Sprintf(cfg.RuleSetKeyFmt, namespace)
+	}
+
+	opts := NewOptions().
+		SetClockOptions(clockOpts).
+		SetInstrumentOptions(instrumentOpts).
+		SetRuleSetOptions(ruleSetOpts).
+		SetKVStore(rulesStore).
+		SetNamespacesKey(cfg.NamespacesKey).
+		SetRuleSetKeyFn(ruleSetKeyFn).
+		SetNamespaceTag([]byte(cfg.NamespaceTag)).
+		SetDefaultNamespace([]byte(cfg.DefaultNamespace))
+
+	if cfg.InitWatchTimeout != 0 {
+		opts = opts.SetInitWatchTimeout(cfg.InitWatchTimeout)
+	}
+
+	return opts, nil
+}

--- a/matcher/config.go
+++ b/matcher/config.go
@@ -58,7 +58,7 @@ func (cfg *Configuration) NewNamespaces(
 	}
 
 	namespaces := NewNamespaces(opts.NamespacesKey(), opts)
-	return namespaces, namespaces.Open()
+	return namespaces, nil
 }
 
 // NewMatcher creates a Matcher.

--- a/matcher/config_test.go
+++ b/matcher/config_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/m3db/m3cluster/kv/mem"
 	"github.com/m3db/m3x/clock"
 	"github.com/m3db/m3x/instrument"
+
 	"github.com/stretchr/testify/require"
 )
 

--- a/matcher/namespaces.go
+++ b/matcher/namespaces.go
@@ -59,22 +59,26 @@ type Namespaces interface {
 }
 
 type namespacesMetrics struct {
-	notExists   tally.Counter
-	added       tally.Counter
-	removed     tally.Counter
-	watched     tally.Counter
-	watchErrors tally.Counter
-	unwatched   tally.Counter
+	notExists         tally.Counter
+	added             tally.Counter
+	removed           tally.Counter
+	watched           tally.Counter
+	watchErrors       tally.Counter
+	unwatched         tally.Counter
+	createWatchErrors tally.Counter
+	initWatchErrors   tally.Counter
 }
 
 func newNamespacesMetrics(scope tally.Scope) namespacesMetrics {
 	return namespacesMetrics{
-		notExists:   scope.Counter("not-exists"),
-		added:       scope.Counter("added"),
-		removed:     scope.Counter("removed"),
-		watched:     scope.Counter("watched"),
-		watchErrors: scope.Counter("watch-errors"),
-		unwatched:   scope.Counter("unwatched"),
+		notExists:         scope.Counter("not-exists"),
+		added:             scope.Counter("added"),
+		removed:           scope.Counter("removed"),
+		watched:           scope.Counter("watched"),
+		watchErrors:       scope.Counter("watch-errors"),
+		unwatched:         scope.Counter("unwatched"),
+		createWatchErrors: scope.Counter("create-watch-errors"),
+		initWatchErrors:   scope.Counter("init-watch-errors"),
 	}
 }
 
@@ -131,17 +135,16 @@ func (n *namespaces) Open() error {
 		return nil
 	}
 
-	scope := n.opts.InstrumentOptions().MetricsScope()
 	errCreateWatch, ok := err.(runtime.CreateWatchError)
 	if ok {
-		scope.Counter("create-watch-errors").Inc(1)
+		n.metrics.createWatchErrors.Inc(1)
 		return errCreateWatch
 	}
 	// NB(xichen): we managed to watch the key but weren't able
 	// to initialize the value. In this case, log the error instead
 	// to be more resilient to error conditions preventing process
 	// from starting up.
-	scope.Counter("init-watch-errors").Inc(1)
+	n.metrics.initWatchErrors.Inc(1)
 	n.opts.InstrumentOptions().Logger().WithFields(
 		xlog.NewLogField("key", n.key),
 		xlog.NewLogErrField(err),

--- a/metric/id/m3/id.go
+++ b/metric/id/m3/id.go
@@ -89,15 +89,14 @@ func IsRollupID(name []byte, tags []byte, iterPool id.SortedTagIteratorPool) boo
 		iter = iterPool.Get()
 		iter.Reset(tags)
 	}
+	defer iter.Close()
 
 	for iter.Next() {
 		name, val := iter.Current()
 		if bytes.Equal(name, rollupTagPair.Name) && bytes.Equal(val, rollupTagPair.Value) {
-			iter.Close()
 			return true
 		}
 	}
-	iter.Close()
 	return false
 }
 

--- a/metric/id/m3/id.go
+++ b/metric/id/m3/id.go
@@ -79,21 +79,25 @@ func NewRollupID(name []byte, tagPairs []id.TagPair) []byte {
 }
 
 // IsRollupID determines whether an id is a rollup id.
-// Caller may optionally pass in a pre-created sorted tag iterator for efficiency
-// reasons, in which case it is the caller's responsibility to close the iterator.
-func IsRollupID(name []byte, tags []byte, iter id.SortedTagIterator) bool {
-	if iter == nil {
+// Caller may optionally pass in a sorted tag iterator
+// pool for efficiency reasons.
+func IsRollupID(name []byte, tags []byte, iterPool id.SortedTagIteratorPool) bool {
+	var iter id.SortedTagIterator
+	if iterPool == nil {
 		iter = NewSortedTagIterator(tags)
-		defer iter.Close()
 	} else {
+		iter = iterPool.Get()
 		iter.Reset(tags)
 	}
+
 	for iter.Next() {
 		name, val := iter.Current()
 		if bytes.Equal(name, rollupTagPair.Name) && bytes.Equal(val, rollupTagPair.Value) {
+			iter.Close()
 			return true
 		}
 	}
+	iter.Close()
 	return false
 }
 

--- a/metric/id/m3/id_test.go
+++ b/metric/id/m3/id_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/m3db/m3metrics/metric/id"
+	"github.com/m3db/m3x/pool"
 
 	"github.com/stretchr/testify/require"
 )
@@ -66,10 +67,12 @@ func TestIsRollupIDExternalIterator(t *testing.T) {
 		{name: []byte("foo.bar.baz"), expected: false},
 		{name: []byte("foo"), tags: []byte("a1=b1,a2=b2"), expected: false},
 	}
-	it := NewSortedTagIterator(nil)
-	defer it.Close()
+	p := id.NewSortedTagIteratorPool(pool.NewObjectPoolOptions())
+	p.Init(func() id.SortedTagIterator {
+		return NewPooledSortedTagIterator(nil, p)
+	})
 	for _, input := range inputs {
-		require.Equal(t, input.expected, IsRollupID(input.name, input.tags, it))
+		require.Equal(t, input.expected, IsRollupID(input.name, input.tags, p))
 	}
 }
 


### PR DESCRIPTION
Move configs from statsdex so it can be reused in proxy collector and query.

Change IsRollupID to take in an iterator pool in order to make the function thread safe. It will be reusing the pool in the tags filter.

@xichen2020 