### PR TITLE
Slightly generalize NameAndTags for m3 ids

### DIFF
--- a/metric/id/m3/id.go
+++ b/metric/id/m3/id.go
@@ -135,7 +135,7 @@ func (id metricID) TagValue(tagName []byte) ([]byte, bool) {
 // NameAndTags returns the name and the tags of the given id.
 func NameAndTags(id []byte) ([]byte, []byte, error) {
 	firstSplitterIdx := bytes.IndexByte(id, componentSplitter)
-	if !bytes.Equal(m3Prefix, id[:firstSplitterIdx+1]) {
+	if !bytes.HasSuffix(id[:firstSplitterIdx+1], m3Prefix) {
 		return nil, nil, errInvalidM3Metric
 	}
 	secondSplitterIdx := bytes.IndexByte(id[firstSplitterIdx+1:], componentSplitter)

--- a/metric/id/m3/id_test.go
+++ b/metric/id/m3/id_test.go
@@ -127,6 +127,12 @@ func TestNameAndTags(t *testing.T) {
 		expectedErr  error
 	}{
 		{
+			id:           []byte("stats.m3+foo+tagName1=tagValue1"),
+			expectedName: []byte("foo"),
+			expectedTags: []byte("tagName1=tagValue1"),
+			expectedErr:  nil,
+		},
+		{
 			id:           []byte("m3+foo+tagName1=tagValue1"),
 			expectedName: []byte("foo"),
 			expectedTags: []byte("tagName1=tagValue1"),
@@ -140,6 +146,12 @@ func TestNameAndTags(t *testing.T) {
 		},
 		{
 			id:           []byte("illformed"),
+			expectedName: nil,
+			expectedTags: nil,
+			expectedErr:  errInvalidM3Metric,
+		},
+		{
+			id:           []byte("m34+illformed+tagName1=tagValue1"),
 			expectedName: nil,
 			expectedTags: nil,
 			expectedErr:  errInvalidM3Metric,


### PR DESCRIPTION
cc @cw9 @prateek @jeromefroe 

This PR generalizes `NameAndTags` slightly so it can handle M3 ids both before and after aggregation.