### PR TITLE
Add MatchRangePast to config

### DIFF
--- a/matcher/config.go
+++ b/matcher/config.go
@@ -43,6 +43,7 @@ type Configuration struct {
 	NamespaceTag          string                       `yaml:"namespaceTag" validate:"nonzero"`
 	DefaultNamespace      string                       `yaml:"defaultNamespace" validate:"nonzero"`
 	NameTagKey            string                       `yaml:"nameTagKey" validate:"nonzero"`
+	MatchRangePast        *time.Duration               `yaml:"matchRangePast"`
 	SortedTagIteratorPool pool.ObjectPoolConfiguration `yaml:"sortedTagIteratorPool"`
 	MatchMode             rules.MatchMode              `yaml:"matchMode"`
 }
@@ -134,6 +135,9 @@ func (cfg *Configuration) NewOptions(
 
 	if cfg.InitWatchTimeout != 0 {
 		opts = opts.SetInitWatchTimeout(cfg.InitWatchTimeout)
+	}
+	if cfg.MatchRangePast != nil {
+		opts = opts.SetMatchRangePast(*cfg.MatchRangePast)
 	}
 
 	return opts, nil

--- a/matcher/match_test.go
+++ b/matcher/match_test.go
@@ -111,7 +111,8 @@ func testMatcher(t *testing.T, cache Cache) Matcher {
 			SetNamespaceTag([]byte("namespace")).
 			SetDefaultNamespace([]byte("default")).
 			SetRuleSetKeyFn(defaultRuleSetKeyFn).
-			SetRuleSetOptions(rules.NewOptions())
+			SetRuleSetOptions(rules.NewOptions()).
+			SetMatchRangePast(0)
 		proto = &schema.Namespaces{
 			Namespaces: []*schema.Namespace{
 				&schema.Namespace{

--- a/matcher/namespaces.go
+++ b/matcher/namespaces.go
@@ -273,8 +273,8 @@ func (n *namespaces) process(value interface{}) error {
 			continue
 		}
 		// Process the namespaces not in the incoming update.
-		earliest := n.nowFn().Add(-n.matchRangePast)
-		if ruleSet.Tombstoned() && ruleSet.CutoverNanos() <= earliest.UnixNano() {
+		earliestNanos := n.nowFn().Add(-n.matchRangePast).UnixNano()
+		if ruleSet.Tombstoned() && ruleSet.CutoverNanos() <= earliestNanos {
 			if n.onNamespaceRemovedFn != nil {
 				n.onNamespaceRemovedFn(ruleSet.Namespace())
 			}

--- a/matcher/namespaces_test.go
+++ b/matcher/namespaces_test.go
@@ -221,6 +221,7 @@ func testNamespaces() (kv.Store, Cache, *namespaces, Options) {
 		SetInitWatchTimeout(100 * time.Millisecond).
 		SetKVStore(store).
 		SetNamespacesKey(testNamespacesKey).
+		SetMatchRangePast(0).
 		SetOnNamespaceAddedFn(func(namespace []byte, ruleSet RuleSet) {
 			cache.Register(namespace, ruleSet)
 		}).

--- a/matcher/options.go
+++ b/matcher/options.go
@@ -22,6 +22,7 @@ package matcher
 
 import (
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/m3db/m3cluster/kv"
@@ -37,7 +38,7 @@ const (
 	defaultValueRetryExpiry = 3 * time.Hour
 	defaultNamespacesKey    = "/namespaces"
 	defaultRuleSetKeyFormat = "/ruleset/%s"
-	defaultMatchRangePast   = 0
+	defaultMatchRangePast   = time.Duration(math.MaxInt64)
 )
 
 var (

--- a/matcher/ruleset.go
+++ b/matcher/ruleset.go
@@ -185,7 +185,7 @@ func (r *ruleSet) process(value interface{}) error {
 	r.version = ruleSet.Version()
 	r.cutoverNanos = ruleSet.CutoverNanos()
 	r.tombstoned = ruleSet.TombStoned()
-	r.matcher = ruleSet.ActiveSet(r.nowFn().Add(-r.matchRangePast))
+	r.matcher = ruleSet.ActiveSet(r.nowFn().Add(-r.matchRangePast).UnixNano())
 	if r.onRuleSetUpdatedFn != nil {
 		r.onRuleSetUpdatedFn(r.namespace, r)
 	}

--- a/matcher/ruleset_test.go
+++ b/matcher/ruleset_test.go
@@ -164,11 +164,11 @@ type mockRuleSet struct {
 	matcher      *mockMatcher
 }
 
-func (r mockRuleSet) Namespace() []byte                   { return []byte(r.namespace) }
-func (r mockRuleSet) Version() int                        { return r.version }
-func (r mockRuleSet) CutoverNanos() int64                 { return r.cutoverNanos }
-func (r mockRuleSet) TombStoned() bool                    { return r.tombstoned }
-func (r mockRuleSet) ActiveSet(t time.Time) rules.Matcher { return r.matcher }
+func (r mockRuleSet) Namespace() []byte                       { return []byte(r.namespace) }
+func (r mockRuleSet) Version() int                            { return r.version }
+func (r mockRuleSet) CutoverNanos() int64                     { return r.cutoverNanos }
+func (r mockRuleSet) TombStoned() bool                        { return r.tombstoned }
+func (r mockRuleSet) ActiveSet(timeNanos int64) rules.Matcher { return r.matcher }
 
 func testRuleSet() (kv.Store, Cache, *ruleSet, Options) {
 	store := mem.NewStore()
@@ -178,6 +178,7 @@ func testRuleSet() (kv.Store, Cache, *ruleSet, Options) {
 		SetKVStore(store).
 		SetRuleSetKeyFn(func(ns []byte) string { return fmt.Sprintf("/rules/%s", ns) }).
 		SetOnRuleSetUpdatedFn(func(namespace []byte, ruleSet RuleSet) { cache.Register(namespace, ruleSet) }).
-		SetMatchMode(rules.ReverseMatch)
+		SetMatchMode(rules.ReverseMatch).
+		SetMatchRangePast(0)
 	return store, cache, newRuleSet(testNamespace, testNamespacesKey, opts).(*ruleSet), opts
 }

--- a/rules/ruleset.go
+++ b/rules/ruleset.go
@@ -26,7 +26,6 @@ import (
 	"fmt"
 	"math"
 	"sort"
-	"time"
 
 	"github.com/m3db/m3metrics/filters"
 	"github.com/m3db/m3metrics/generated/proto/schema"
@@ -445,7 +444,7 @@ type RuleSet interface {
 	TombStoned() bool
 
 	// ActiveSet returns the active ruleset at a given time.
-	ActiveSet(t time.Time) Matcher
+	ActiveSet(timeNanos int64) Matcher
 }
 
 type ruleSet struct {
@@ -506,8 +505,7 @@ func (rs *ruleSet) Version() int        { return rs.version }
 func (rs *ruleSet) CutoverNanos() int64 { return rs.cutoverNanos }
 func (rs *ruleSet) TombStoned() bool    { return rs.tombstoned }
 
-func (rs *ruleSet) ActiveSet(t time.Time) Matcher {
-	timeNanos := t.UnixNano()
+func (rs *ruleSet) ActiveSet(timeNanos int64) Matcher {
 	mappingRules := make([]*mappingRule, 0, len(rs.mappingRules))
 	for _, mappingRule := range rs.mappingRules {
 		activeRule := mappingRule.ActiveRule(timeNanos)

--- a/rules/ruleset_test.go
+++ b/rules/ruleset_test.go
@@ -879,7 +879,7 @@ func TestRuleSetActiveSet(t *testing.T) {
 	}
 
 	for _, inputs := range allInputs {
-		as := newRuleSet.ActiveSet(inputs.activeSetTime)
+		as := newRuleSet.ActiveSet(inputs.activeSetTime.UnixNano())
 		for _, input := range inputs.mappingInputs {
 			res := as.MatchAll(b(input.id), input.matchFrom, input.matchTo, input.matchMode)
 			require.Equal(t, input.expireAtNanos, res.expireAtNanos)


### PR DESCRIPTION
cc @cw9 @prateek @jeromefroe 

This PR adds `MatchRangePast` to the matcher configuration. It also uses `time.MaxInt64` as the default value for `MatchRangePast`, which means there is no lower bound on the match range by default.