### PR TITLE
Rule objects to schema

### DIFF
--- a/matcher/ruleset_test.go
+++ b/matcher/ruleset_test.go
@@ -169,6 +169,7 @@ func (r mockRuleSet) Version() int                            { return r.version
 func (r mockRuleSet) CutoverNanos() int64                     { return r.cutoverNanos }
 func (r mockRuleSet) TombStoned() bool                        { return r.tombstoned }
 func (r mockRuleSet) ActiveSet(timeNanos int64) rules.Matcher { return r.matcher }
+func (r mockRuleSet) Schema() (*schema.RuleSet, error)        { return nil, nil }
 
 func testRuleSet() (kv.Store, Cache, *ruleSet, Options) {
 	store := mem.NewStore()

--- a/policy/aggregation_type.go
+++ b/policy/aggregation_type.go
@@ -364,6 +364,12 @@ func (aggTypes AggregationTypes) PooledQuantiles(p pool.FloatsPool) ([]float64, 
 
 // Schema returns the schema of the aggregation types.
 func (aggTypes AggregationTypes) Schema() ([]schema.AggregationType, error) {
+	// This is the same as returning an empty slice from the functionality perspective.
+	// It makes creating testing fixtures much simpler.
+	if aggTypes == nil {
+		return nil, nil
+	}
+
 	res := make([]schema.AggregationType, len(aggTypes))
 	for i, aggType := range aggTypes {
 		s, err := aggType.Schema()

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -155,7 +155,6 @@ func TestParsePolicyIntoSchema(t *testing.T) {
 						Period: time.Hour.Nanoseconds(),
 					},
 				},
-				AggregationTypes: []schema.AggregationType{},
 			},
 		},
 		{
@@ -226,7 +225,7 @@ func TestParsePolicyIntoSchema(t *testing.T) {
 
 		sp, err := p.Schema()
 		require.NoError(t, err)
-		require.Equal(t, input.expected, sp)
+		require.Equal(t, input.expected, sp, input.str)
 	}
 }
 

--- a/rules/mapping.go
+++ b/rules/mapping.go
@@ -69,6 +69,28 @@ func newMappingRuleSnapshot(
 	}, nil
 }
 
+// Schema returns the given MappingRuleSnapshot in protobuf form.
+func (mrs mappingRuleSnapshot) Schema() (*schema.MappingRuleSnapshot, error) {
+	res := &schema.MappingRuleSnapshot{
+		Name:        mrs.name,
+		Tombstoned:  mrs.tombstoned,
+		CutoverTime: mrs.cutoverNanos,
+		TagFilters:  mrs.rawFilters,
+	}
+
+	policies := make([]*schema.Policy, len(mrs.policies))
+	for i, p := range mrs.policies {
+		policy, err := p.Schema()
+		if err != nil {
+			return nil, err
+		}
+		policies[i] = policy
+	}
+	res.Policies = policies
+
+	return res, nil
+}
+
 // mappingRule stores mapping rule snapshots.
 type mappingRule struct {
 	uuid      string
@@ -124,28 +146,6 @@ func (mc *mappingRule) activeIndex(timeNanos int64) int {
 		idx--
 	}
 	return idx
-}
-
-// Schema returns the given MappingRuleSnapshot in protobuf form.
-func (mrs mappingRuleSnapshot) Schema() (*schema.MappingRuleSnapshot, error) {
-	res := &schema.MappingRuleSnapshot{
-		Name:        mrs.name,
-		Tombstoned:  mrs.tombstoned,
-		CutoverTime: mrs.cutoverNanos,
-		TagFilters:  mrs.rawFilters,
-	}
-
-	policies := make([]*schema.Policy, len(mrs.policies))
-	for i, p := range mrs.policies {
-		policy, err := p.Schema()
-		if err != nil {
-			return nil, err
-		}
-		policies[i] = policy
-	}
-	res.Policies = policies
-
-	return res, nil
 }
 
 // Schema returns the given MappingRule in protobuf form.

--- a/rules/mapping.go
+++ b/rules/mapping.go
@@ -40,6 +40,7 @@ type mappingRuleSnapshot struct {
 	tombstoned   bool
 	cutoverNanos int64
 	filter       filters.Filter
+	rawFilters   map[string]string
 	policies     []policy.Policy
 }
 
@@ -64,6 +65,7 @@ func newMappingRuleSnapshot(
 		cutoverNanos: r.CutoverTime,
 		filter:       filter,
 		policies:     policies,
+		rawFilters:   r.TagFilters,
 	}, nil
 }
 
@@ -122,4 +124,45 @@ func (mc *mappingRule) activeIndex(timeNanos int64) int {
 		idx--
 	}
 	return idx
+}
+
+// Schema returns the given MappingRuleSnapshot in protobuf form.
+func (mrs mappingRuleSnapshot) Schema() (*schema.MappingRuleSnapshot, error) {
+	res := &schema.MappingRuleSnapshot{
+		Name:        mrs.name,
+		Tombstoned:  mrs.tombstoned,
+		CutoverTime: mrs.cutoverNanos,
+		TagFilters:  mrs.rawFilters,
+	}
+
+	policies := make([]*schema.Policy, len(mrs.policies))
+	for i, p := range mrs.policies {
+		policy, err := p.Schema()
+		if err != nil {
+			return nil, err
+		}
+		policies[i] = policy
+	}
+	res.Policies = policies
+
+	return res, nil
+}
+
+// Schema returns the given MappingRule in protobuf form.
+func (mc mappingRule) Schema() (*schema.MappingRule, error) {
+	res := &schema.MappingRule{
+		Uuid: mc.uuid,
+	}
+
+	snapshots := make([]*schema.MappingRuleSnapshot, len(mc.snapshots))
+	for i, s := range mc.snapshots {
+		snapshot, err := s.Schema()
+		if err != nil {
+			return nil, err
+		}
+		snapshots[i] = snapshot
+	}
+	res.Snapshots = snapshots
+
+	return res, nil
 }

--- a/rules/mapping_test.go
+++ b/rules/mapping_test.go
@@ -193,14 +193,9 @@ func TestMappingRuleSnapshotSchema(t *testing.T) {
 }
 
 func TestMappingRuleSchema(t *testing.T) {
-	expected := &schema.MappingRule{
-		Uuid:      testMappingRuleSchema.Uuid,
-		Snapshots: testMappingRuleSchema.Snapshots[:1],
-	}
-
-	mr, err := newMappingRule(expected, testTagsFilterOptions())
+	mr, err := newMappingRule(testMappingRuleSchema, testTagsFilterOptions())
 	require.NoError(t, err)
 	schema, err := mr.Schema()
 	require.NoError(t, err)
-	require.Equal(t, expected, schema)
+	require.Equal(t, testMappingRuleSchema, schema)
 }

--- a/rules/mapping_test.go
+++ b/rules/mapping_test.go
@@ -182,3 +182,25 @@ func TestMappingRuleActiveRuleFound_First(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, mr, mr.ActiveRule(20000))
 }
+
+func TestMappingRuleSnapshotSchema(t *testing.T) {
+	expectedSchema := testMappingRuleSchema.Snapshots[0]
+	mr, err := newMappingRule(testMappingRuleSchema, testTagsFilterOptions())
+	require.NoError(t, err)
+	schema, err := mr.snapshots[0].Schema()
+	require.NoError(t, err)
+	require.EqualValues(t, expectedSchema, schema)
+}
+
+func TestMappingRuleSchema(t *testing.T) {
+	expected := &schema.MappingRule{
+		Uuid:      testMappingRuleSchema.Uuid,
+		Snapshots: testMappingRuleSchema.Snapshots[:1],
+	}
+
+	mr, err := newMappingRule(expected, testTagsFilterOptions())
+	require.NoError(t, err)
+	schema, err := mr.Schema()
+	require.NoError(t, err)
+	require.Equal(t, expected, schema)
+}

--- a/rules/namespace_test.go
+++ b/rules/namespace_test.go
@@ -127,3 +127,78 @@ func TestNewNamespacesValidSchema(t *testing.T) {
 	}
 	require.Equal(t, expected, ns.Namespaces())
 }
+
+func TestNamespaceSchema(t *testing.T) {
+	testNs := &schema.Namespace{
+		Name: "foo",
+		Snapshots: []*schema.NamespaceSnapshot{
+			&schema.NamespaceSnapshot{
+				ForRulesetVersion: 123,
+				Tombstoned:        false,
+			},
+			&schema.NamespaceSnapshot{
+				ForRulesetVersion: 456,
+				Tombstoned:        true,
+			},
+		},
+	}
+
+	ns, err := newNameSpace(testNs)
+
+	require.NoError(t, err)
+	res, err := ns.Schema()
+
+	require.Equal(t, testNs, res)
+}
+
+func TestNamespaceSchemaNoSnapshots(t *testing.T) {
+	badNs := Namespace{
+		name: []byte("foo"),
+	}
+	res, err := badNs.Schema()
+	require.EqualError(t, err, errNilNamespaceSnapshot.Error())
+	require.Nil(t, res)
+}
+
+func TestNamespaceSnapshotSchema(t *testing.T) {
+	s := NamespaceSnapshot{
+		forRuleSetVersion: 3,
+		tombstoned:        false,
+	}
+	sSchema := &schema.NamespaceSnapshot{
+		ForRulesetVersion: 3,
+		Tombstoned:        false,
+	}
+
+	res := s.Schema()
+
+	require.Equal(t, sSchema, res)
+}
+
+func TestNamespacesSchema(t *testing.T) {
+	testNss := &schema.Namespaces{
+		Namespaces: []*schema.Namespace{
+			&schema.Namespace{
+				Name: "foo",
+				Snapshots: []*schema.NamespaceSnapshot{
+					&schema.NamespaceSnapshot{ForRulesetVersion: 123, Tombstoned: false},
+					&schema.NamespaceSnapshot{ForRulesetVersion: 4, Tombstoned: false},
+				},
+			},
+			&schema.Namespace{
+				Name: "foo2",
+				Snapshots: []*schema.NamespaceSnapshot{
+					&schema.NamespaceSnapshot{ForRulesetVersion: 123, Tombstoned: false},
+					&schema.NamespaceSnapshot{ForRulesetVersion: 4, Tombstoned: false},
+				},
+			},
+		},
+	}
+
+	nss, err := NewNamespaces(1, testNss)
+	require.NoError(t, err)
+
+	res, err := nss.Schema()
+	require.NoError(t, err)
+	require.Equal(t, testNss, res)
+}

--- a/rules/rollup.go
+++ b/rules/rollup.go
@@ -94,6 +94,25 @@ func (t *rollupTarget) clone() rollupTarget {
 	}
 }
 
+func (t rollupTarget) Schema() (*schema.RollupTarget, error) {
+	res := &schema.RollupTarget{
+		Name: string(t.Name),
+	}
+
+	policies := make([]*schema.Policy, len(t.Policies))
+	for i, p := range t.Policies {
+		policy, err := p.Schema()
+		if err != nil {
+			return nil, err
+		}
+		policies[i] = policy
+	}
+	res.Policies = policies
+	res.Tags = stringArrayFromBytesArray(t.Tags)
+
+	return res, nil
+}
+
 // rollupRuleSnapshot defines a rule snapshot such that if a metric matches the
 // provided filters, it is rolled up using the provided list of rollup targets.
 type rollupRuleSnapshot struct {
@@ -132,6 +151,28 @@ func newRollupRuleSnapshot(
 		targets:      targets,
 		rawFilters:   r.TagFilters,
 	}, nil
+}
+
+// Schema returns the given MappingRuleSnapshot in protobuf form.
+func (rrs rollupRuleSnapshot) Schema() (*schema.RollupRuleSnapshot, error) {
+	res := &schema.RollupRuleSnapshot{
+		Name:        rrs.name,
+		Tombstoned:  rrs.tombstoned,
+		CutoverTime: rrs.cutoverNanos,
+		TagFilters:  rrs.rawFilters,
+	}
+
+	targets := make([]*schema.RollupTarget, len(rrs.targets))
+	for i, t := range rrs.targets {
+		target, err := t.Schema()
+		if err != nil {
+			return nil, err
+		}
+		targets[i] = target
+	}
+	res.Targets = targets
+
+	return res, nil
 }
 
 // rollupRule stores rollup rule snapshots.
@@ -189,6 +230,25 @@ func (rc *rollupRule) activeIndex(timeNanos int64) int {
 	return idx
 }
 
+// Schema returns the given RollupRule in protobuf form.
+func (rc rollupRule) Schema() (*schema.RollupRule, error) {
+	res := &schema.RollupRule{
+		Uuid: rc.uuid,
+	}
+
+	snapshots := make([]*schema.RollupRuleSnapshot, len(rc.snapshots))
+	for i, s := range rc.snapshots {
+		snapshot, err := s.Schema()
+		if err != nil {
+			return nil, err
+		}
+		snapshots[i] = snapshot
+	}
+	res.Snapshots = snapshots
+
+	return res, nil
+}
+
 func bytesArrayFromStringArray(values []string) [][]byte {
 	result := make([][]byte, len(values))
 	for i, str := range values {
@@ -212,64 +272,4 @@ func bytesArrayCopy(values [][]byte) [][]byte {
 		copy(result[i], b)
 	}
 	return result
-}
-
-func (t rollupTarget) Schema() (*schema.RollupTarget, error) {
-	res := &schema.RollupTarget{
-		Name: string(t.Name),
-	}
-
-	policies := make([]*schema.Policy, len(t.Policies))
-	for i, p := range t.Policies {
-		policy, err := p.Schema()
-		if err != nil {
-			return nil, err
-		}
-		policies[i] = policy
-	}
-	res.Policies = policies
-	res.Tags = stringArrayFromBytesArray(t.Tags)
-
-	return res, nil
-}
-
-// Schema returns the given MappingRuleSnapshot in protobuf form.
-func (rrs rollupRuleSnapshot) Schema() (*schema.RollupRuleSnapshot, error) {
-	res := &schema.RollupRuleSnapshot{
-		Name:        rrs.name,
-		Tombstoned:  rrs.tombstoned,
-		CutoverTime: rrs.cutoverNanos,
-		TagFilters:  rrs.rawFilters,
-	}
-
-	targets := make([]*schema.RollupTarget, len(rrs.targets))
-	for i, t := range rrs.targets {
-		target, err := t.Schema()
-		if err != nil {
-			return nil, err
-		}
-		targets[i] = target
-	}
-	res.Targets = targets
-
-	return res, nil
-}
-
-// Schema returns the given RollupRule in protobuf form.
-func (rc rollupRule) Schema() (*schema.RollupRule, error) {
-	res := &schema.RollupRule{
-		Uuid: rc.uuid,
-	}
-
-	snapshots := make([]*schema.RollupRuleSnapshot, len(rc.snapshots))
-	for i, s := range rc.snapshots {
-		snapshot, err := s.Schema()
-		if err != nil {
-			return nil, err
-		}
-		snapshots[i] = snapshot
-	}
-	res.Snapshots = snapshots
-
-	return res, nil
 }

--- a/rules/rollup_test.go
+++ b/rules/rollup_test.go
@@ -253,3 +253,29 @@ type testRollupTargetData struct {
 	target rollupTarget
 	result bool
 }
+
+func TestRollupTargetSchema(t *testing.T) {
+	expectedSchema := testRollupRuleSchema.Snapshots[0].Targets[0]
+	rt, err := newRollupTarget(expectedSchema)
+	require.NoError(t, err)
+	schema, err := rt.Schema()
+	require.NoError(t, err)
+	require.EqualValues(t, expectedSchema, schema)
+}
+
+func TestRollupRuleSnapshotSchema(t *testing.T) {
+	expectedSchema := testRollupRuleSchema.Snapshots[0]
+	rr, err := newRollupRule(testRollupRuleSchema, testTagsFilterOptions())
+	require.NoError(t, err)
+	schema, err := rr.snapshots[0].Schema()
+	require.NoError(t, err)
+	require.EqualValues(t, expectedSchema, schema)
+}
+
+func TestRollupRuleSchema(t *testing.T) {
+	rr, err := newRollupRule(testRollupRuleSchema, testTagsFilterOptions())
+	require.NoError(t, err)
+	schema, err := rr.Schema()
+	require.NoError(t, err)
+	require.Equal(t, testRollupRuleSchema, schema)
+}

--- a/rules/ruleset_test.go
+++ b/rules/ruleset_test.go
@@ -513,6 +513,28 @@ func TestRuleSetProperties(t *testing.T) {
 	require.Equal(t, false, ruleSet.TombStoned())
 }
 
+func TestRuleSetSchema(t *testing.T) {
+	opts := testRuleSetOptions()
+	version := 1
+
+	expectedRs := &schema.RuleSet{
+		Uuid:          "ruleset",
+		Namespace:     "namespace",
+		CreatedAt:     1234,
+		LastUpdatedAt: 5678,
+		Tombstoned:    false,
+		CutoverTime:   34923,
+		MappingRules:  testMappingRulesConfig(),
+		RollupRules:   testRollupRulesConfig(),
+	}
+
+	rs, err := NewRuleSet(version, expectedRs, opts)
+	require.NoError(t, err)
+	res, err := rs.Schema()
+	require.NoError(t, err)
+	require.Equal(t, expectedRs, res)
+}
+
 func TestRuleSetActiveSet(t *testing.T) {
 	opts := testRuleSetOptions()
 	version := 1
@@ -1430,7 +1452,7 @@ func testMappingRulesConfig() []*schema.MappingRule {
 					Tombstoned:  true,
 					CutoverTime: 35000,
 					TagFilters:  map[string]string{"mtagName1": "mtagValue1"},
-					Policies:    nil,
+					Policies:    []*schema.Policy{},
 				},
 			},
 		},
@@ -1758,7 +1780,7 @@ func testRollupRulesConfig() []*schema.RollupRule {
 						"rtagName1": "rtagValue1",
 						"rtagName2": "rtagValue2",
 					},
-					Targets: nil,
+					Targets: []*schema.RollupTarget{},
 				},
 			},
 		},


### PR DESCRIPTION
Allow converting m3metrics/rules structures into their kv schema counterparts. 