### PR TITLE
[buffered encoder pool] Add maximum capacity check to buffers returned to pool

### DIFF
--- a/protocol/msgpack/buffered_encoder_pool.go
+++ b/protocol/msgpack/buffered_encoder_pool.go
@@ -23,7 +23,7 @@ package msgpack
 import "github.com/m3db/m3x/pool"
 
 type bufferedEncoderPool struct {
-	maxCapacity int64
+	maxCapacity int
 	pool        pool.ObjectPool
 }
 
@@ -46,7 +46,7 @@ func (p *bufferedEncoderPool) Get() BufferedEncoder {
 }
 
 func (p *bufferedEncoderPool) Put(encoder BufferedEncoder) {
-	if int64(encoder.Buffer().Cap()) > p.maxCapacity {
+	if encoder.Buffer().Cap() > p.maxCapacity {
 		return
 	}
 	p.pool.Put(encoder)

--- a/protocol/msgpack/buffered_encoder_pool.go
+++ b/protocol/msgpack/buffered_encoder_pool.go
@@ -23,15 +23,15 @@ package msgpack
 import "github.com/m3db/m3x/pool"
 
 type bufferedEncoderPool struct {
-	maxBufferCapacity int
-	pool              pool.ObjectPool
+	maxCapacity int64
+	pool        pool.ObjectPool
 }
 
 // NewBufferedEncoderPool creates a new pool for buffered encoders.
 func NewBufferedEncoderPool(opts BufferedEncoderPoolOptions) BufferedEncoderPool {
 	return &bufferedEncoderPool{
-		maxBufferCapacity: opts.MaxBufferCapacity(),
-		pool:              pool.NewObjectPool(opts.ObjectPoolOptions()),
+		maxCapacity: opts.MaxCapacity(),
+		pool:        pool.NewObjectPool(opts.ObjectPoolOptions()),
 	}
 }
 
@@ -46,7 +46,7 @@ func (p *bufferedEncoderPool) Get() BufferedEncoder {
 }
 
 func (p *bufferedEncoderPool) Put(encoder BufferedEncoder) {
-	if p.maxBufferCapacity != 0 && cap(encoder.Buffer().Bytes()) > p.maxBufferCapacity {
+	if int64(encoder.Buffer().Cap()) > p.maxCapacity {
 		return
 	}
 	p.pool.Put(encoder)

--- a/protocol/msgpack/buffered_encoder_pool_test.go
+++ b/protocol/msgpack/buffered_encoder_pool_test.go
@@ -21,7 +21,6 @@
 package msgpack
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/m3db/m3x/pool"
@@ -59,7 +58,7 @@ func TestBufferedEncoderPool(t *testing.T) {
 func TestBufferedEncoderPoolMaxCapacity(t *testing.T) {
 	poolOpts := pool.NewObjectPoolOptions().SetSize(1)
 	opts := NewBufferedEncoderPoolOptions().
-		SetMaxBufferCapacity(2).
+		SetMaxCapacity(2).
 		SetObjectPoolOptions(poolOpts)
 
 	p := NewBufferedEncoderPool(opts)
@@ -78,6 +77,5 @@ func TestBufferedEncoderPoolMaxCapacity(t *testing.T) {
 	// Retrieve an encoder and assert it's a different encoder since
 	// the previous one exceeded the maximum capacity of the pool.
 	encoder = p.Get()
-	fmt.Println(encoder.Buffer().Len())
-	require.Equal(t, 0, encoder.Buffer().Len())
+	require.Equal(t, 0, encoder.Buffer().Cap())
 }

--- a/protocol/msgpack/options.go
+++ b/protocol/msgpack/options.go
@@ -28,8 +28,7 @@ import (
 
 const (
 	// The maximum capacity of buffers that can be returned to the buffered
-	// encoder pool. A value of 0 indicates no maximum so all buffered
-	// encoders will be returned to the pool.
+	// encoder pool.
 	defaultBufferedEncoderPoolMaxCapacity = math.MaxInt64
 
 	// Whether the iterator should ignore higher-than-supported version

--- a/protocol/msgpack/options.go
+++ b/protocol/msgpack/options.go
@@ -21,12 +21,13 @@
 package msgpack
 
 import xpool "github.com/m3db/m3x/pool"
+import "math"
 
 const (
 	// The maximum capacity of buffers that can be returned to the buffered
 	// encoder pool. A value of 0 indicates no maximum so all buffered
 	// encoders will be returned to the pool.
-	defaultBufferedEncoderPoolMaxCapacity = 0
+	defaultBufferedEncoderPoolMaxCapacity = math.MaxInt64
 
 	// Whether the iterator should ignore higher-than-supported version
 	// by default for unaggregated iterator.
@@ -48,26 +49,26 @@ const (
 )
 
 type bufferedEncoderPoolOptions struct {
-	maxBufferCapacity int
-	poolOpts          xpool.ObjectPoolOptions
+	maxCapacity int64
+	poolOpts    xpool.ObjectPoolOptions
 }
 
 // NewBufferedEncoderPoolOptions creates a new set of buffered encoder pool options.
 func NewBufferedEncoderPoolOptions() BufferedEncoderPoolOptions {
 	return &bufferedEncoderPoolOptions{
-		maxBufferCapacity: defaultBufferedEncoderPoolMaxCapacity,
-		poolOpts:          xpool.NewObjectPoolOptions(),
+		maxCapacity: defaultBufferedEncoderPoolMaxCapacity,
+		poolOpts:    xpool.NewObjectPoolOptions(),
 	}
 }
 
-func (o *bufferedEncoderPoolOptions) SetMaxBufferCapacity(value int) BufferedEncoderPoolOptions {
+func (o *bufferedEncoderPoolOptions) SetMaxCapacity(value int64) BufferedEncoderPoolOptions {
 	opts := *o
-	opts.maxBufferCapacity = value
+	opts.maxCapacity = value
 	return &opts
 }
 
-func (o *bufferedEncoderPoolOptions) MaxBufferCapacity() int {
-	return o.maxBufferCapacity
+func (o *bufferedEncoderPoolOptions) MaxCapacity() int64 {
+	return o.maxCapacity
 }
 
 func (o *bufferedEncoderPoolOptions) SetObjectPoolOptions(value xpool.ObjectPoolOptions) BufferedEncoderPoolOptions {

--- a/protocol/msgpack/options.go
+++ b/protocol/msgpack/options.go
@@ -23,6 +23,11 @@ package msgpack
 import xpool "github.com/m3db/m3x/pool"
 
 const (
+	// The maximum capacity of buffers that can be returned to the buffered
+	// encoder pool. A value of 0 indicates no maximum so all buffered
+	// encoders will be returned to the pool.
+	defaultBufferedEncoderPoolMaxCapacity = 0
+
 	// Whether the iterator should ignore higher-than-supported version
 	// by default for unaggregated iterator.
 	defaultUnaggregatedIgnoreHigherVersion = false
@@ -41,6 +46,39 @@ const (
 	// Default reader buffer size for the aggregated iterator.
 	defaultAggregatedReaderBufferSize = 1440
 )
+
+type bufferedEncoderPoolOptions struct {
+	maxBufferCapacity int
+	poolOpts          xpool.ObjectPoolOptions
+}
+
+// NewBufferedEncoderPoolOptions creates a new set of buffered encoder pool options.
+func NewBufferedEncoderPoolOptions() BufferedEncoderPoolOptions {
+	return &bufferedEncoderPoolOptions{
+		maxBufferCapacity: defaultBufferedEncoderPoolMaxCapacity,
+		poolOpts:          xpool.NewObjectPoolOptions(),
+	}
+}
+
+func (o *bufferedEncoderPoolOptions) SetMaxBufferCapacity(value int) BufferedEncoderPoolOptions {
+	opts := *o
+	opts.maxBufferCapacity = value
+	return &opts
+}
+
+func (o *bufferedEncoderPoolOptions) MaxBufferCapacity() int {
+	return o.maxBufferCapacity
+}
+
+func (o *bufferedEncoderPoolOptions) SetObjectPoolOptions(value xpool.ObjectPoolOptions) BufferedEncoderPoolOptions {
+	opts := *o
+	opts.poolOpts = value
+	return &opts
+}
+
+func (o *bufferedEncoderPoolOptions) ObjectPoolOptions() xpool.ObjectPoolOptions {
+	return o.poolOpts
+}
 
 type unaggregatedIteratorOptions struct {
 	ignoreHigherVersion bool

--- a/protocol/msgpack/options.go
+++ b/protocol/msgpack/options.go
@@ -20,8 +20,11 @@
 
 package msgpack
 
-import xpool "github.com/m3db/m3x/pool"
-import "math"
+import (
+	"math"
+
+	xpool "github.com/m3db/m3x/pool"
+)
 
 const (
 	// The maximum capacity of buffers that can be returned to the buffered
@@ -49,7 +52,7 @@ const (
 )
 
 type bufferedEncoderPoolOptions struct {
-	maxCapacity int64
+	maxCapacity int
 	poolOpts    xpool.ObjectPoolOptions
 }
 
@@ -61,13 +64,13 @@ func NewBufferedEncoderPoolOptions() BufferedEncoderPoolOptions {
 	}
 }
 
-func (o *bufferedEncoderPoolOptions) SetMaxCapacity(value int64) BufferedEncoderPoolOptions {
+func (o *bufferedEncoderPoolOptions) SetMaxCapacity(value int) BufferedEncoderPoolOptions {
 	opts := *o
 	opts.maxCapacity = value
 	return &opts
 }
 
-func (o *bufferedEncoderPoolOptions) MaxCapacity() int64 {
+func (o *bufferedEncoderPoolOptions) MaxCapacity() int {
 	return o.maxCapacity
 }
 

--- a/protocol/msgpack/types.go
+++ b/protocol/msgpack/types.go
@@ -88,6 +88,21 @@ type BufferedEncoderPool interface {
 	Put(enc BufferedEncoder)
 }
 
+// BufferedEncoderPoolOptions provides options for buffered encoder pools.
+type BufferedEncoderPoolOptions interface {
+	// SetMaxBufferCapacity sets the maximum buffer capacity.
+	SetMaxBufferCapacity(value int) BufferedEncoderPoolOptions
+
+	// MaxBufferCapacity returns the maximum buffer capacity.
+	MaxBufferCapacity() int
+
+	// SetObjectPoolOptions sets the object pool options.
+	SetObjectPoolOptions(value pool.ObjectPoolOptions) BufferedEncoderPoolOptions
+
+	// ObjectPoolOptions returns the object pool options.
+	ObjectPoolOptions() pool.ObjectPoolOptions
+}
+
 // encoderBase is the base encoder interface.
 type encoderBase interface {
 	// Encoder returns the encoder.

--- a/protocol/msgpack/types.go
+++ b/protocol/msgpack/types.go
@@ -90,11 +90,11 @@ type BufferedEncoderPool interface {
 
 // BufferedEncoderPoolOptions provides options for buffered encoder pools.
 type BufferedEncoderPoolOptions interface {
-	// SetMaxBufferCapacity sets the maximum buffer capacity.
-	SetMaxBufferCapacity(value int) BufferedEncoderPoolOptions
+	// SetMaxCapacity sets the maximum capacity of buffers that can be returned to the pool.
+	SetMaxCapacity(value int64) BufferedEncoderPoolOptions
 
-	// MaxBufferCapacity returns the maximum buffer capacity.
-	MaxBufferCapacity() int
+	// MaxBufferCapacity returns the maximum capacity of buffers that can be returned to the pool.
+	MaxCapacity() int64
 
 	// SetObjectPoolOptions sets the object pool options.
 	SetObjectPoolOptions(value pool.ObjectPoolOptions) BufferedEncoderPoolOptions

--- a/protocol/msgpack/types.go
+++ b/protocol/msgpack/types.go
@@ -91,10 +91,10 @@ type BufferedEncoderPool interface {
 // BufferedEncoderPoolOptions provides options for buffered encoder pools.
 type BufferedEncoderPoolOptions interface {
 	// SetMaxCapacity sets the maximum capacity of buffers that can be returned to the pool.
-	SetMaxCapacity(value int64) BufferedEncoderPoolOptions
+	SetMaxCapacity(value int) BufferedEncoderPoolOptions
 
 	// MaxBufferCapacity returns the maximum capacity of buffers that can be returned to the pool.
-	MaxCapacity() int64
+	MaxCapacity() int
 
 	// SetObjectPoolOptions sets the object pool options.
 	SetObjectPoolOptions(value pool.ObjectPoolOptions) BufferedEncoderPoolOptions


### PR DESCRIPTION
This PR adds a maximum capacity check to the buffered encoder pool. When set, buffers with a capacity greater than the maximum capacity will not be returned to the pool. This PR is to address memory growth in the proxycollectors when they receive large timer batches, write them into a single buffer, and return that buffer to the pool.

cc @xichen2020 