### PR TITLE
[buffered encoder pool] Check if options are nil

### DIFF
--- a/protocol/msgpack/buffered_encoder_pool.go
+++ b/protocol/msgpack/buffered_encoder_pool.go
@@ -29,6 +29,9 @@ type bufferedEncoderPool struct {
 
 // NewBufferedEncoderPool creates a new pool for buffered encoders.
 func NewBufferedEncoderPool(opts BufferedEncoderPoolOptions) BufferedEncoderPool {
+	if opts == nil {
+		opts = NewBufferedEncoderPoolOptions()
+	}
 	return &bufferedEncoderPool{
 		maxCapacity: opts.MaxCapacity(),
 		pool:        pool.NewObjectPool(opts.ObjectPoolOptions()),


### PR DESCRIPTION
We should check for options being `nil` so callers can pass `nil` to express that they want to use the default options.

cc @xichen2020 