### PR TITLE
[travis] Add go 1.8 and 1.9 to travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go:
-  - 1.7
-  - 1.8
+  - 1.7.6
+  - 1.8.3
   - 1.9
 install: make install-ci
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: go
 go:
   - 1.7
+  - 1.8
+  - 1.9
 install: make install-ci
 env:
  # Set higher timeouts for Travis

--- a/filters/filter_benchmark_test.go
+++ b/filters/filter_benchmark_test.go
@@ -51,7 +51,7 @@ func BenchmarkEqualityFilter(b *testing.B) {
 
 	val := []byte("test")
 	for n := 0; n < b.N; n++ {
-		testUnionFilter(val, []Filter{f1, f2})
+		_ = testUnionFilter(val, []Filter{f1, f2})
 	}
 }
 
@@ -61,7 +61,7 @@ func BenchmarkEqualityFilterByValue(b *testing.B) {
 
 	val := []byte("test")
 	for n := 0; n < b.N; n++ {
-		testUnionFilter(val, []Filter{f1, f2})
+		_ = testUnionFilter(val, []Filter{f1, f2})
 	}
 }
 
@@ -159,7 +159,11 @@ func benchMultiRangeFilter(b *testing.B, patterns []byte, backwards bool, vals [
 
 // nolint: unparam
 func benchMultiRangeFilterSelect(b *testing.B, patterns []byte, backwards bool, vals [][]byte) {
-	f, _ := newTestMultiCharRangeSelectFilter(patterns, backwards)
+	f, err := newTestMultiCharRangeSelectFilter(patterns, backwards)
+	if err != nil {
+		b.Errorf("encountered error creating filter: %v", err)
+	}
+
 	for n := 0; n < b.N; n++ {
 		for _, val := range vals {
 			f.matches(val)
@@ -169,7 +173,11 @@ func benchMultiRangeFilterSelect(b *testing.B, patterns []byte, backwards bool, 
 
 // nolint: unparam
 func benchMultiRangeFilterTrie(b *testing.B, patterns []byte, backwards bool, vals [][]byte) {
-	f, _ := newTestMultiCharRangeTrieFilter(patterns, backwards)
+	f, err := newTestMultiCharRangeTrieFilter(patterns, backwards)
+	if err != nil {
+		b.Errorf("encountered error creating filter: %v", err)
+	}
+
 	for n := 0; n < b.N; n++ {
 		for _, val := range vals {
 			f.matches(val)
@@ -189,7 +197,11 @@ func benchRangeFilterStructs(b *testing.B, pattern, val []byte, expectedMatch bo
 
 func benchRangeFilterRange(b *testing.B, pattern, val []byte, expectedMatch bool) {
 	for n := 0; n < b.N; n++ {
-		match, _ := validateRangeByScan(pattern, val)
+		match, err := validateRangeByScan(pattern, val)
+		if err != nil {
+			b.Errorf("unexpected error: %v", err)
+		}
+
 		if match != expectedMatch {
 			b.FailNow()
 		}
@@ -202,6 +214,7 @@ func benchTagsFilter(b *testing.B, id []byte, tagsFilter Filter) {
 	}
 }
 
+// nolint: unparam
 func testUnionFilter(val []byte, filters []Filter) bool {
 	for _, filter := range filters {
 		if !filter.Matches(val) {

--- a/matcher/ruleset_test.go
+++ b/matcher/ruleset_test.go
@@ -42,7 +42,7 @@ var (
 )
 
 func TestRuleSetProperties(t *testing.T) {
-	_, _, rs, _ := testRuleSet()
+	_, _, rs := testRuleSet()
 	rs.namespace = testNamespace
 	rs.version = 2
 	rs.cutoverNanos = 12345
@@ -55,13 +55,13 @@ func TestRuleSetProperties(t *testing.T) {
 }
 
 func TestRuleSetMatchNoMatcher(t *testing.T) {
-	_, _, rs, _ := testRuleSet()
+	_, _, rs := testRuleSet()
 	nowNanos := rs.nowFn().UnixNano()
 	require.Equal(t, rules.EmptyMatchResult, rs.Match([]byte("foo"), nowNanos, nowNanos))
 }
 
 func TestRuleSetMatchWithMatcher(t *testing.T) {
-	_, _, rs, _ := testRuleSet()
+	_, _, rs := testRuleSet()
 	mockMatcher := &mockMatcher{res: rules.EmptyMatchResult}
 	rs.matcher = mockMatcher
 
@@ -79,19 +79,19 @@ func TestRuleSetMatchWithMatcher(t *testing.T) {
 }
 
 func TestToRuleSetNilValue(t *testing.T) {
-	_, _, rs, _ := testRuleSet()
+	_, _, rs := testRuleSet()
 	_, err := rs.toRuleSet(nil)
 	require.Equal(t, errNilValue, err)
 }
 
 func TestToRuleSetUnmarshalError(t *testing.T) {
-	_, _, rs, _ := testRuleSet()
+	_, _, rs := testRuleSet()
 	_, err := rs.toRuleSet(&mockValue{})
 	require.Error(t, err)
 }
 
 func TestToRuleSetSuccess(t *testing.T) {
-	store, _, rs, _ := testRuleSet()
+	store, _, rs := testRuleSet()
 	proto := &schema.RuleSet{
 		Namespace:   string(testNamespace),
 		Tombstoned:  false,
@@ -121,7 +121,7 @@ func TestRuleSetProcess(t *testing.T) {
 		}
 	)
 
-	_, cache, rs, _ := testRuleSet()
+	_, cache, rs := testRuleSet()
 	memCache := cache.(*memCache)
 	for _, input := range inputs {
 		err := rs.process(input)
@@ -172,7 +172,7 @@ func (r mockRuleSet) Tombstoned() bool                        { return r.tombsto
 func (r mockRuleSet) ActiveSet(timeNanos int64) rules.Matcher { return r.matcher }
 func (r mockRuleSet) ToMutableRuleSet() rules.MutableRuleSet  { return nil }
 
-func testRuleSet() (kv.Store, Cache, *ruleSet, Options) {
+func testRuleSet() (kv.Store, Cache, *ruleSet) {
 	store := mem.NewStore()
 	cache := newMemCache()
 	opts := NewOptions().
@@ -182,5 +182,5 @@ func testRuleSet() (kv.Store, Cache, *ruleSet, Options) {
 		SetOnRuleSetUpdatedFn(func(namespace []byte, ruleSet RuleSet) { cache.Register(namespace, ruleSet) }).
 		SetMatchMode(rules.ReverseMatch).
 		SetMatchRangePast(0)
-	return store, cache, newRuleSet(testNamespace, testNamespacesKey, opts).(*ruleSet), opts
+	return store, cache, newRuleSet(testNamespace, testNamespacesKey, opts).(*ruleSet)
 }


### PR DESCRIPTION
This PR adds Go 1.8 and 1.9 to the versions of Go we test against in Travis.

In addition, it seems the `unparam` linter has been updated and caught some new cases, so this PR also addresses the new issues found by it.