### PR TITLE
Aggregated encoder supports including encoding time in encoded data

### DIFF
--- a/protocol/msgpack/aggregated_encoder_test.go
+++ b/protocol/msgpack/aggregated_encoder_test.go
@@ -93,14 +93,6 @@ func TestAggregatedEncodeChunkedMetricWithPolicy(t *testing.T) {
 	require.Equal(t, expected, *results)
 }
 
-func TestAggregatedEncodeRawMetricWithPolicy(t *testing.T) {
-	encoder, results := testCapturingAggregatedEncoder()
-	rawMetric := toRawMetric(t, testMetric)
-	require.NoError(t, testAggregatedEncode(encoder, rawMetric, testPolicy))
-	expected := expectedResultsForAggregatedMetricWithPolicy(t, rawMetric, testPolicy)
-	require.Equal(t, expected, *results)
-}
-
 func TestAggregatedEncodeError(t *testing.T) {
 	// Intentionally return an error when encoding varint.
 	encoder := testAggregatedEncoder().(*aggregatedEncoder)

--- a/protocol/msgpack/aggregated_encoder_test.go
+++ b/protocol/msgpack/aggregated_encoder_test.go
@@ -35,7 +35,10 @@ func testCapturingAggregatedEncoder() (AggregatedEncoder, *[]interface{}) {
 	return encoder, result
 }
 
-func expectedResultsForRawMetricWithPolicy(m aggregated.RawMetric, p policy.StoragePolicy) []interface{} {
+func expectedResultsForRawMetricWithPolicy(
+	m aggregated.RawMetric,
+	p policy.StoragePolicy,
+) []interface{} {
 	results := []interface{}{
 		numFieldsForType(rawMetricWithStoragePolicyType),
 		m.Bytes(),
@@ -44,7 +47,11 @@ func expectedResultsForRawMetricWithPolicy(m aggregated.RawMetric, p policy.Stor
 	return results
 }
 
-func expectedResultsForAggregatedMetricWithPolicy(t *testing.T, m interface{}, p policy.StoragePolicy) []interface{} {
+func expectedResultsForAggregatedMetricWithPolicy(
+	t *testing.T,
+	m interface{},
+	p policy.StoragePolicy,
+) []interface{} {
 	results := []interface{}{
 		int64(aggregatedVersion),
 		numFieldsForType(rootObjectType),
@@ -57,8 +64,46 @@ func expectedResultsForAggregatedMetricWithPolicy(t *testing.T, m interface{}, p
 	case aggregated.ChunkedMetric:
 		rm := toRawMetric(t, m)
 		results = append(results, expectedResultsForRawMetricWithPolicy(rm, p)...)
-	case aggregated.RawMetric:
-		results = append(results, expectedResultsForRawMetricWithPolicy(m, p)...)
+	default:
+		require.Fail(t, "unrecognized input type %T", m)
+	}
+	return results
+}
+
+func expectedResultsForRawMetricWithPolicyAndEncodeTime(
+	m aggregated.RawMetric,
+	p policy.StoragePolicy,
+	encodedAtNanos int64,
+) []interface{} {
+	results := []interface{}{
+		numFieldsForType(rawMetricWithStoragePolicyAndEncodeTimeType),
+		m.Bytes(),
+	}
+	results = append(results, expectedResultsForPolicy(p)...)
+	results = append(results, encodedAtNanos)
+	return results
+}
+
+func expectedResultsForAggregatedMetricWithPolicyAndEncodeTime(
+	t *testing.T,
+	m interface{},
+	p policy.StoragePolicy,
+	encodedAtNanos int64,
+) []interface{} {
+	results := []interface{}{
+		int64(aggregatedVersion),
+		numFieldsForType(rootObjectType),
+		int64(rawMetricWithStoragePolicyAndEncodeTimeType),
+	}
+	switch m := m.(type) {
+	case aggregated.Metric:
+		rm := toRawMetric(t, m)
+		res := expectedResultsForRawMetricWithPolicyAndEncodeTime(rm, p, encodedAtNanos)
+		results = append(results, res...)
+	case aggregated.ChunkedMetric:
+		rm := toRawMetric(t, m)
+		res := expectedResultsForRawMetricWithPolicyAndEncodeTime(rm, p, encodedAtNanos)
+		results = append(results, res...)
 	default:
 		require.Fail(t, "unrecognized input type %T", m)
 	}
@@ -81,15 +126,31 @@ func TestAggregatedEncodeMetric(t *testing.T) {
 
 func TestAggregatedEncodeMetricWithPolicy(t *testing.T) {
 	encoder, results := testCapturingAggregatedEncoder()
-	require.NoError(t, testAggregatedEncode(encoder, testMetric, testPolicy))
+	require.NoError(t, testAggregatedEncodeMetricWithPolicy(encoder, testMetric, testPolicy))
 	expected := expectedResultsForAggregatedMetricWithPolicy(t, testMetric, testPolicy)
+	require.Equal(t, expected, *results)
+}
+
+func TestAggregatedEncodeMetricWithPolicyAndEncodeTime(t *testing.T) {
+	encoder, results := testCapturingAggregatedEncoder()
+	err := testAggregatedEncodeMetricWithPolicyAndEncodeTime(encoder, testMetric, testPolicy, testEncodedAtNanos)
+	require.NoError(t, err)
+	expected := expectedResultsForAggregatedMetricWithPolicyAndEncodeTime(t, testMetric, testPolicy, testEncodedAtNanos)
 	require.Equal(t, expected, *results)
 }
 
 func TestAggregatedEncodeChunkedMetricWithPolicy(t *testing.T) {
 	encoder, results := testCapturingAggregatedEncoder()
-	require.NoError(t, testAggregatedEncode(encoder, testChunkedMetric, testPolicy))
+	require.NoError(t, testAggregatedEncodeMetricWithPolicy(encoder, testChunkedMetric, testPolicy))
 	expected := expectedResultsForAggregatedMetricWithPolicy(t, testChunkedMetric, testPolicy)
+	require.Equal(t, expected, *results)
+}
+
+func TestAggregatedEncodeChunkedMetricWithPolicyAndEncodeTime(t *testing.T) {
+	encoder, results := testCapturingAggregatedEncoder()
+	err := testAggregatedEncodeMetricWithPolicyAndEncodeTime(encoder, testChunkedMetric, testPolicy, testEncodedAtNanos)
+	require.NoError(t, err)
+	expected := expectedResultsForAggregatedMetricWithPolicyAndEncodeTime(t, testChunkedMetric, testPolicy, testEncodedAtNanos)
 	require.Equal(t, expected, *results)
 }
 
@@ -102,18 +163,18 @@ func TestAggregatedEncodeError(t *testing.T) {
 	}
 
 	// Assert the error is expected.
-	require.Equal(t, errTestVarint, testAggregatedEncode(encoder, testMetric, testPolicy))
+	require.Equal(t, errTestVarint, testAggregatedEncodeMetricWithPolicy(encoder, testMetric, testPolicy))
 
 	// Assert re-encoding doesn't change the error.
-	require.Equal(t, errTestVarint, testAggregatedEncode(encoder, testMetric, testPolicy))
+	require.Equal(t, errTestVarint, testAggregatedEncodeMetricWithPolicy(encoder, testMetric, testPolicy))
 }
 
 func TestAggregatedEncoderReset(t *testing.T) {
 	encoder := testAggregatedEncoder().(*aggregatedEncoder)
 	baseEncoder := encoder.encoderBase.(*baseEncoder)
 	baseEncoder.encodeErr = errTestVarint
-	require.Equal(t, errTestVarint, testAggregatedEncode(encoder, testMetric, testPolicy))
+	require.Equal(t, errTestVarint, testAggregatedEncodeMetricWithPolicy(encoder, testMetric, testPolicy))
 
 	encoder.Reset(NewBufferedEncoder())
-	require.NoError(t, testAggregatedEncode(encoder, testMetric, testPolicy))
+	require.NoError(t, testAggregatedEncodeMetricWithPolicy(encoder, testMetric, testPolicy))
 }

--- a/protocol/msgpack/aggregated_iterator.go
+++ b/protocol/msgpack/aggregated_iterator.go
@@ -37,6 +37,7 @@ type aggregatedIterator struct {
 	iteratorPool        AggregatedIteratorPool
 	metric              aggregated.RawMetric
 	storagePolicy       policy.StoragePolicy
+	encodedAt           int64
 }
 
 // NewAggregatedIterator creates a new aggregated iterator.
@@ -60,8 +61,8 @@ func (it *aggregatedIterator) Reset(reader io.Reader) {
 	it.reset(reader)
 }
 
-func (it *aggregatedIterator) Value() (aggregated.RawMetric, policy.StoragePolicy) {
-	return it.metric, it.storagePolicy
+func (it *aggregatedIterator) Value() (aggregated.RawMetric, policy.StoragePolicy, int64) {
+	return it.metric, it.storagePolicy, it.encodedAt
 }
 
 func (it *aggregatedIterator) Next() bool {
@@ -110,6 +111,8 @@ func (it *aggregatedIterator) decodeRootObject() bool {
 	switch objType {
 	case rawMetricWithStoragePolicyType:
 		it.decodeRawMetricWithStoragePolicy()
+	case rawMetricWithStoragePolicyAndEncodeTimeType:
+		it.decodeRawMetricWithStoragePolicyAndEncodeTime()
 	default:
 		it.setErr(fmt.Errorf("unrecognized object type %v", objType))
 	}
@@ -125,6 +128,18 @@ func (it *aggregatedIterator) decodeRawMetricWithStoragePolicy() {
 	}
 	it.metric.Reset(it.decodeRawMetric())
 	it.storagePolicy = it.decodeStoragePolicy()
+	it.encodedAt = 0
+	it.skip(numActualFields - numExpectedFields)
+}
+
+func (it *aggregatedIterator) decodeRawMetricWithStoragePolicyAndEncodeTime() {
+	numExpectedFields, numActualFields, ok := it.checkNumFieldsForType(rawMetricWithStoragePolicyAndEncodeTimeType)
+	if !ok {
+		return
+	}
+	it.metric.Reset(it.decodeRawMetric())
+	it.storagePolicy = it.decodeStoragePolicy()
+	it.encodedAt = it.decodeVarint()
 	it.skip(numActualFields - numExpectedFields)
 }
 

--- a/protocol/msgpack/aggregated_iterator.go
+++ b/protocol/msgpack/aggregated_iterator.go
@@ -37,7 +37,7 @@ type aggregatedIterator struct {
 	iteratorPool        AggregatedIteratorPool
 	metric              aggregated.RawMetric
 	storagePolicy       policy.StoragePolicy
-	encodedAt           int64
+	encodedAtNanos      int64
 }
 
 // NewAggregatedIterator creates a new aggregated iterator.
@@ -62,7 +62,7 @@ func (it *aggregatedIterator) Reset(reader io.Reader) {
 }
 
 func (it *aggregatedIterator) Value() (aggregated.RawMetric, policy.StoragePolicy, int64) {
-	return it.metric, it.storagePolicy, it.encodedAt
+	return it.metric, it.storagePolicy, it.encodedAtNanos
 }
 
 func (it *aggregatedIterator) Next() bool {
@@ -128,7 +128,7 @@ func (it *aggregatedIterator) decodeRawMetricWithStoragePolicy() {
 	}
 	it.metric.Reset(it.decodeRawMetric())
 	it.storagePolicy = it.decodeStoragePolicy()
-	it.encodedAt = 0
+	it.encodedAtNanos = 0
 	it.skip(numActualFields - numExpectedFields)
 }
 
@@ -139,7 +139,7 @@ func (it *aggregatedIterator) decodeRawMetricWithStoragePolicyAndEncodeTime() {
 	}
 	it.metric.Reset(it.decodeRawMetric())
 	it.storagePolicy = it.decodeStoragePolicy()
-	it.encodedAt = it.decodeVarint()
+	it.encodedAtNanos = it.decodeVarint()
 	it.skip(numActualFields - numExpectedFields)
 }
 

--- a/protocol/msgpack/aggregated_iterator_test.go
+++ b/protocol/msgpack/aggregated_iterator_test.go
@@ -33,17 +33,18 @@ import (
 func validateAggregatedDecodeResults(
 	t *testing.T,
 	it AggregatedIterator,
-	expectedResults []metricWithPolicy,
+	expectedResults []metricWithPolicyAndEncodeTime,
 	expectedErr error,
 ) {
-	var results []metricWithPolicy
+	var results []metricWithPolicyAndEncodeTime
 	for it.Next() {
-		value, policy := it.Value()
+		value, policy, encodedAtNanos := it.Value()
 		m, err := value.Metric()
 		require.NoError(t, err)
-		results = append(results, metricWithPolicy{
-			metric: m,
-			policy: policy,
+		results = append(results, metricWithPolicyAndEncodeTime{
+			metric:         m,
+			policy:         policy,
+			encodedAtNanos: encodedAtNanos,
 		})
 	}
 	require.Equal(t, expectedErr, it.Err())
@@ -51,7 +52,7 @@ func validateAggregatedDecodeResults(
 }
 
 func TestAggregatedIteratorDecodeNewerVersionThanSupported(t *testing.T) {
-	input := metricWithPolicy{
+	input := metricWithPolicyAndEncodeTime{
 		metric: testMetric,
 		policy: testPolicy,
 	}
@@ -63,21 +64,21 @@ func TestAggregatedIteratorDecodeNewerVersionThanSupported(t *testing.T) {
 		enc.encodeNumObjectFields(numFieldsForType(rootObjectType))
 		enc.encodeObjectType(objType)
 	}
-	require.NoError(t, testAggregatedEncode(enc, input.metric.(aggregated.Metric), input.policy))
+	require.NoError(t, testAggregatedEncodeMetricWithPolicy(enc, input.metric.(aggregated.Metric), input.policy))
 
 	// Now restore the encode top-level function and encode another metric.
 	enc.encodeRootObjectFn = enc.encodeRootObject
-	require.NoError(t, testAggregatedEncode(enc, input.metric.(aggregated.Metric), input.policy))
+	require.NoError(t, testAggregatedEncodeMetricWithPolicy(enc, input.metric.(aggregated.Metric), input.policy))
 
 	it := testAggregatedIterator(enc.Encoder().Buffer())
 	it.(*aggregatedIterator).ignoreHigherVersion = true
 
 	// Check that we skipped the first metric and successfully decoded the second metric.
-	validateAggregatedDecodeResults(t, it, []metricWithPolicy{input}, io.EOF)
+	validateAggregatedDecodeResults(t, it, []metricWithPolicyAndEncodeTime{input}, io.EOF)
 }
 
 func TestAggregatedIteratorDecodeRootObjectMoreFieldsThanExpected(t *testing.T) {
-	input := metricWithPolicy{
+	input := metricWithPolicyAndEncodeTime{
 		metric: testMetric,
 		policy: testPolicy,
 	}
@@ -89,7 +90,7 @@ func TestAggregatedIteratorDecodeRootObjectMoreFieldsThanExpected(t *testing.T) 
 		enc.encodeNumObjectFields(numFieldsForType(rootObjectType) + 1)
 		enc.encodeObjectType(objType)
 	}
-	err := testAggregatedEncode(enc, input.metric.(aggregated.Metric), input.policy)
+	err := testAggregatedEncodeMetricWithPolicy(enc, input.metric.(aggregated.Metric), input.policy)
 	require.NoError(t, err)
 	enc.encodeVarint(0)
 	require.NoError(t, enc.err())
@@ -97,11 +98,11 @@ func TestAggregatedIteratorDecodeRootObjectMoreFieldsThanExpected(t *testing.T) 
 	it := testAggregatedIterator(enc.Encoder().Buffer())
 
 	// Check that we successfully decoded the metric.
-	validateAggregatedDecodeResults(t, it, []metricWithPolicy{input}, io.EOF)
+	validateAggregatedDecodeResults(t, it, []metricWithPolicyAndEncodeTime{input}, io.EOF)
 }
 
 func TestAggregatedIteratorDecodeRawMetricMoreFieldsThanExpected(t *testing.T) {
-	input := metricWithPolicy{
+	input := metricWithPolicyAndEncodeTime{
 		metric: testMetric,
 		policy: testPolicy,
 	}
@@ -113,7 +114,7 @@ func TestAggregatedIteratorDecodeRawMetricMoreFieldsThanExpected(t *testing.T) {
 		enc.encodeRawMetricFn(data)
 		enc.encodeStoragePolicy(p)
 	}
-	err := testAggregatedEncode(enc, input.metric.(aggregated.Metric), input.policy)
+	err := testAggregatedEncodeMetricWithPolicy(enc, input.metric.(aggregated.Metric), input.policy)
 	require.NoError(t, err)
 	enc.encodeVarint(0)
 	require.NoError(t, enc.err())
@@ -121,11 +122,37 @@ func TestAggregatedIteratorDecodeRawMetricMoreFieldsThanExpected(t *testing.T) {
 	it := testAggregatedIterator(enc.Encoder().Buffer())
 
 	// Check that we successfully decoded the metric.
-	validateAggregatedDecodeResults(t, it, []metricWithPolicy{input}, io.EOF)
+	validateAggregatedDecodeResults(t, it, []metricWithPolicyAndEncodeTime{input}, io.EOF)
+}
+
+func TestAggregatedIteratorDecodeRawMetricWithEncodeTimeMoreFieldsThanExpected(t *testing.T) {
+	input := metricWithPolicyAndEncodeTime{
+		metric:         testMetric,
+		policy:         testPolicy,
+		encodedAtNanos: testEncodedAtNanos,
+	}
+	enc := testAggregatedEncoder().(*aggregatedEncoder)
+
+	// Pretend we added an extra int field to the raw metric with policy object.
+	enc.encodeRawMetricWithStoragePolicyAndEncodeTimeFn = func(data []byte, p policy.StoragePolicy, encodedAtNanos int64) {
+		enc.encodeNumObjectFields(numFieldsForType(rawMetricWithStoragePolicyAndEncodeTimeType) + 1)
+		enc.encodeRawMetricFn(data)
+		enc.encodeStoragePolicy(p)
+		enc.encodeVarint(encodedAtNanos)
+	}
+	err := testAggregatedEncodeMetricWithPolicyAndEncodeTime(enc, input.metric.(aggregated.Metric), input.policy, input.encodedAtNanos)
+	require.NoError(t, err)
+	enc.encodeVarint(0)
+	require.NoError(t, enc.err())
+
+	it := testAggregatedIterator(enc.Encoder().Buffer())
+
+	// Check that we successfully decoded the metric.
+	validateAggregatedDecodeResults(t, it, []metricWithPolicyAndEncodeTime{input}, io.EOF)
 }
 
 func TestAggregatedIteratorDecodeMetricHigherVersionThanSupported(t *testing.T) {
-	input := metricWithPolicy{
+	input := metricWithPolicyAndEncodeTime{
 		metric: testMetric,
 		policy: testPolicy,
 	}
@@ -137,19 +164,19 @@ func TestAggregatedIteratorDecodeMetricHigherVersionThanSupported(t *testing.T) 
 		enc.buf.encodeVersion(metricVersion + 1)
 		return enc.buf.encoder().Bytes()
 	}
-	err := testAggregatedEncode(enc, input.metric.(aggregated.Metric), input.policy)
+	err := testAggregatedEncodeMetricWithPolicy(enc, input.metric.(aggregated.Metric), input.policy)
 	require.NoError(t, err)
 	require.NoError(t, enc.err())
 
 	it := testAggregatedIterator(enc.Encoder().Buffer())
 	require.True(t, it.Next())
-	rawMetric, _ := it.Value()
+	rawMetric, _, _ := it.Value()
 	_, err = rawMetric.Value()
 	require.Error(t, err)
 }
 
 func TestAggregatedIteratorDecodeMetricMoreFieldsThanExpected(t *testing.T) {
-	input := metricWithPolicy{
+	input := metricWithPolicyAndEncodeTime{
 		metric: testMetric,
 		policy: testPolicy,
 	}
@@ -161,14 +188,14 @@ func TestAggregatedIteratorDecodeMetricMoreFieldsThanExpected(t *testing.T) {
 		enc.buf.encodeVarint(0)
 		return enc.buf.encoder().Bytes()
 	}
-	err := testAggregatedEncode(enc, input.metric.(aggregated.Metric), input.policy)
+	err := testAggregatedEncodeMetricWithPolicy(enc, input.metric.(aggregated.Metric), input.policy)
 	require.NoError(t, err)
 	require.NoError(t, enc.err())
 
 	it := testAggregatedIterator(enc.Encoder().Buffer())
 
 	// Check that we successfully decoded the metric.
-	validateAggregatedDecodeResults(t, it, []metricWithPolicy{input}, io.EOF)
+	validateAggregatedDecodeResults(t, it, []metricWithPolicyAndEncodeTime{input}, io.EOF)
 }
 
 func TestAggregatedIteratorClose(t *testing.T) {

--- a/protocol/msgpack/aggregated_roundtrip_test.go
+++ b/protocol/msgpack/aggregated_roundtrip_test.go
@@ -50,12 +50,14 @@ var (
 		TimeNanos: time.Now().UnixNano(),
 		Value:     123.45,
 	}
-	testPolicy = policy.NewStoragePolicy(time.Second, xtime.Second, time.Hour)
+	testPolicy         = policy.NewStoragePolicy(time.Second, xtime.Second, time.Hour)
+	testEncodedAtNanos = time.Now().UnixNano()
 )
 
-type metricWithPolicy struct {
-	metric interface{}
-	policy policy.StoragePolicy
+type metricWithPolicyAndEncodeTime struct {
+	metric         interface{}
+	policy         policy.StoragePolicy
+	encodedAtNanos int64
 }
 
 func testAggregatedEncoder() AggregatedEncoder {
@@ -66,7 +68,11 @@ func testAggregatedIterator(reader io.Reader) AggregatedIterator {
 	return NewAggregatedIterator(reader, NewAggregatedIteratorOptions())
 }
 
-func testAggregatedEncode(encoder AggregatedEncoder, m interface{}, p policy.StoragePolicy) error {
+func testAggregatedEncodeMetricWithPolicy(
+	encoder AggregatedEncoder,
+	m interface{},
+	p policy.StoragePolicy,
+) error {
 	switch m := m.(type) {
 	case aggregated.Metric:
 		return encoder.EncodeMetricWithStoragePolicy(aggregated.MetricWithStoragePolicy{
@@ -78,6 +84,30 @@ func testAggregatedEncode(encoder AggregatedEncoder, m interface{}, p policy.Sto
 			ChunkedMetric: m,
 			StoragePolicy: p,
 		})
+	default:
+		return fmt.Errorf("unrecognized metric type: %T", m)
+	}
+}
+
+func testAggregatedEncodeMetricWithPolicyAndEncodeTime(
+	encoder AggregatedEncoder,
+	m interface{},
+	p policy.StoragePolicy,
+	encodedAtNanos int64,
+) error {
+	switch m := m.(type) {
+	case aggregated.Metric:
+		input := aggregated.MetricWithStoragePolicy{
+			Metric:        m,
+			StoragePolicy: p,
+		}
+		return encoder.EncodeMetricWithStoragePolicyAndEncodeTime(input, encodedAtNanos)
+	case aggregated.ChunkedMetric:
+		input := aggregated.ChunkedMetricWithStoragePolicy{
+			ChunkedMetric: m,
+			StoragePolicy: p,
+		}
+		return encoder.EncodeChunkedMetricWithStoragePolicyAndEncodeTime(input, encodedAtNanos)
 	default:
 		return fmt.Errorf("unrecognized metric type: %T", m)
 	}
@@ -98,7 +128,7 @@ func toRawMetric(t *testing.T, m interface{}) aggregated.RawMetric {
 	return NewRawMetric(data, 16)
 }
 
-func validateAggregatedRoundtrip(t *testing.T, inputs ...metricWithPolicy) {
+func validateAggregatedRoundtrip(t *testing.T, inputs ...metricWithPolicyAndEncodeTime) {
 	encoder := testAggregatedEncoder()
 	it := testAggregatedIterator(nil)
 	validateAggregatedRoundtripWithEncoderAndIterator(t, encoder, it, inputs...)
@@ -108,11 +138,11 @@ func validateAggregatedRoundtripWithEncoderAndIterator(
 	t *testing.T,
 	encoder AggregatedEncoder,
 	it AggregatedIterator,
-	inputs ...metricWithPolicy,
+	inputs ...metricWithPolicyAndEncodeTime,
 ) {
 	var (
-		expected []metricWithPolicy
-		results  []metricWithPolicy
+		expected []metricWithPolicyAndEncodeTime
+		results  []metricWithPolicyAndEncodeTime
 	)
 
 	// Encode the batch of metrics.
@@ -120,33 +150,35 @@ func validateAggregatedRoundtripWithEncoderAndIterator(
 	for _, input := range inputs {
 		switch inputMetric := input.metric.(type) {
 		case aggregated.Metric:
-			expected = append(expected, metricWithPolicy{
-				metric: inputMetric,
-				policy: input.policy,
+			expected = append(expected, metricWithPolicyAndEncodeTime{
+				metric:         inputMetric,
+				policy:         input.policy,
+				encodedAtNanos: input.encodedAtNanos,
 			})
-			require.NoError(t, testAggregatedEncode(encoder, inputMetric, input.policy))
+			if input.encodedAtNanos == 0 {
+				require.NoError(t, testAggregatedEncodeMetricWithPolicy(encoder, inputMetric, input.policy))
+			} else {
+				require.NoError(t, testAggregatedEncodeMetricWithPolicyAndEncodeTime(encoder, inputMetric, input.policy, input.encodedAtNanos))
+			}
 		case aggregated.ChunkedMetric:
 			var id id.RawID
 			id = append(id, inputMetric.ChunkedID.Prefix...)
 			id = append(id, inputMetric.ChunkedID.Data...)
 			id = append(id, inputMetric.ChunkedID.Suffix...)
-			expected = append(expected, metricWithPolicy{
+			expected = append(expected, metricWithPolicyAndEncodeTime{
 				metric: aggregated.Metric{
 					ID:        id,
 					TimeNanos: inputMetric.TimeNanos,
 					Value:     inputMetric.Value,
 				},
-				policy: input.policy,
+				policy:         input.policy,
+				encodedAtNanos: input.encodedAtNanos,
 			})
-			require.NoError(t, testAggregatedEncode(encoder, inputMetric, input.policy))
-		case aggregated.RawMetric:
-			m, err := inputMetric.Metric()
-			require.NoError(t, err)
-			expected = append(expected, metricWithPolicy{
-				metric: m,
-				policy: input.policy,
-			})
-			require.NoError(t, testAggregatedEncode(encoder, inputMetric, input.policy))
+			if input.encodedAtNanos == 0 {
+				require.NoError(t, testAggregatedEncodeMetricWithPolicy(encoder, inputMetric, input.policy))
+			} else {
+				require.NoError(t, testAggregatedEncodeMetricWithPolicyAndEncodeTime(encoder, inputMetric, input.policy, input.encodedAtNanos))
+			}
 		default:
 			require.Fail(t, "unrecognized input type %T", inputMetric)
 		}
@@ -156,12 +188,13 @@ func validateAggregatedRoundtripWithEncoderAndIterator(
 	encodedBytes := bytes.NewBuffer(encoder.Encoder().Bytes())
 	it.Reset(encodedBytes)
 	for it.Next() {
-		metric, p := it.Value()
+		metric, p, encodedAtNanos := it.Value()
 		m, err := metric.Metric()
 		require.NoError(t, err)
-		results = append(results, metricWithPolicy{
-			metric: m,
-			policy: p,
+		results = append(results, metricWithPolicyAndEncodeTime{
+			metric:         m,
+			policy:         p,
+			encodedAtNanos: encodedAtNanos,
 		})
 	}
 
@@ -171,16 +204,32 @@ func validateAggregatedRoundtripWithEncoderAndIterator(
 }
 
 func TestAggregatedEncodeDecodeMetricWithPolicy(t *testing.T) {
-	validateAggregatedRoundtrip(t, metricWithPolicy{
+	validateAggregatedRoundtrip(t, metricWithPolicyAndEncodeTime{
 		metric: testMetric,
 		policy: testPolicy,
 	})
 }
 
+func TestAggregatedEncodeDecodeMetricWithPolicyAndEncodeTime(t *testing.T) {
+	validateAggregatedRoundtrip(t, metricWithPolicyAndEncodeTime{
+		metric:         testMetric,
+		policy:         testPolicy,
+		encodedAtNanos: testEncodedAtNanos,
+	})
+}
+
 func TestAggregatedEncodeDecodeChunkedMetricWithPolicy(t *testing.T) {
-	validateAggregatedRoundtrip(t, metricWithPolicy{
+	validateAggregatedRoundtrip(t, metricWithPolicyAndEncodeTime{
 		metric: testChunkedMetric,
 		policy: testPolicy,
+	})
+}
+
+func TestAggregatedEncodeDecodeChunkedMetricWithPolicyAndEncodeTime(t *testing.T) {
+	validateAggregatedRoundtrip(t, metricWithPolicyAndEncodeTime{
+		metric:         testChunkedMetric,
+		policy:         testPolicy,
+		encodedAtNanos: testEncodedAtNanos,
 	})
 }
 
@@ -193,17 +242,30 @@ func TestAggregatedEncodeDecodeStress(t *testing.T) {
 	)
 
 	for i := 0; i < numIter; i++ {
-		var inputs []metricWithPolicy
+		var inputs []metricWithPolicyAndEncodeTime
 		for j := 0; j < numMetrics; j++ {
-			if j%2 == 0 {
-				inputs = append(inputs, metricWithPolicy{
+			switch j % 4 {
+			case 0:
+				inputs = append(inputs, metricWithPolicyAndEncodeTime{
 					metric: testMetric,
 					policy: testPolicy,
 				})
-			} else {
-				inputs = append(inputs, metricWithPolicy{
+			case 1:
+				inputs = append(inputs, metricWithPolicyAndEncodeTime{
+					metric:         testMetric,
+					policy:         testPolicy,
+					encodedAtNanos: testEncodedAtNanos,
+				})
+			case 2:
+				inputs = append(inputs, metricWithPolicyAndEncodeTime{
 					metric: testChunkedMetric,
 					policy: testPolicy,
+				})
+			case 3:
+				inputs = append(inputs, metricWithPolicyAndEncodeTime{
+					metric:         testChunkedMetric,
+					policy:         testPolicy,
+					encodedAtNanos: testEncodedAtNanos,
 				})
 			}
 		}

--- a/protocol/msgpack/aggregated_roundtrip_test.go
+++ b/protocol/msgpack/aggregated_roundtrip_test.go
@@ -50,11 +50,6 @@ var (
 		TimeNanos: time.Now().UnixNano(),
 		Value:     123.45,
 	}
-	testMetric2 = aggregated.Metric{
-		ID:        id.RawID("bar"),
-		TimeNanos: time.Now().UnixNano(),
-		Value:     678.90,
-	}
 	testPolicy = policy.NewStoragePolicy(time.Second, xtime.Second, time.Hour)
 )
 
@@ -81,11 +76,6 @@ func testAggregatedEncode(encoder AggregatedEncoder, m interface{}, p policy.Sto
 	case aggregated.ChunkedMetric:
 		return encoder.EncodeChunkedMetricWithStoragePolicy(aggregated.ChunkedMetricWithStoragePolicy{
 			ChunkedMetric: m,
-			StoragePolicy: p,
-		})
-	case aggregated.RawMetric:
-		return encoder.EncodeRawMetricWithStoragePolicy(aggregated.RawMetricWithStoragePolicy{
-			RawMetric:     m,
 			StoragePolicy: p,
 		})
 	default:
@@ -194,13 +184,6 @@ func TestAggregatedEncodeDecodeChunkedMetricWithPolicy(t *testing.T) {
 	})
 }
 
-func TestAggregatedEncodeDecodeRawMetricWithPolicy(t *testing.T) {
-	validateAggregatedRoundtrip(t, metricWithPolicy{
-		metric: toRawMetric(t, testMetric),
-		policy: testPolicy,
-	})
-}
-
 func TestAggregatedEncodeDecodeStress(t *testing.T) {
 	var (
 		numIter    = 10
@@ -212,19 +195,14 @@ func TestAggregatedEncodeDecodeStress(t *testing.T) {
 	for i := 0; i < numIter; i++ {
 		var inputs []metricWithPolicy
 		for j := 0; j < numMetrics; j++ {
-			if j%3 == 0 {
+			if j%2 == 0 {
 				inputs = append(inputs, metricWithPolicy{
 					metric: testMetric,
 					policy: testPolicy,
 				})
-			} else if j%3 == 1 {
-				inputs = append(inputs, metricWithPolicy{
-					metric: testChunkedMetric,
-					policy: testPolicy,
-				})
 			} else {
 				inputs = append(inputs, metricWithPolicy{
-					metric: toRawMetric(t, testMetric2),
+					metric: testChunkedMetric,
 					policy: testPolicy,
 				})
 			}

--- a/protocol/msgpack/schema.go
+++ b/protocol/msgpack/schema.go
@@ -64,31 +64,35 @@ const (
 	longAggregationID
 	policyType
 
+	// Additional object types.
+	rawMetricWithStoragePolicyAndEncodeTimeType
+
 	// Total number of object types.
 	numObjectTypes = iota
 )
 
 const (
-	numRootObjectFields                 = 2
-	numCounterWithPoliciesListFields    = 2
-	numBatchTimerWithPoliciesListFields = 2
-	numGaugeWithPoliciesListFields      = 2
-	numRawMetricWithStoragePolicyFields = 2
-	numCounterFields                    = 2
-	numBatchTimerFields                 = 2
-	numGaugeFields                      = 2
-	numMetricFields                     = 3
-	numDefaultStagedPoliciesListFields  = 1
-	numCustomStagedPoliciesListFields   = 2
-	numStagedPoliciesFields             = 3
-	numStoragePolicyFields              = 2
-	numKnownResolutionFields            = 2
-	numUnknownResolutionFields          = 3
-	numKnownRetentionFields             = 2
-	numDefaultAggregationIDFields       = 1
-	numShortAggregationIDFields         = 2
-	numLongAggregationIDFields          = 2
-	numPolicyFields                     = 2
+	numRootObjectFields                              = 2
+	numCounterWithPoliciesListFields                 = 2
+	numBatchTimerWithPoliciesListFields              = 2
+	numGaugeWithPoliciesListFields                   = 2
+	numRawMetricWithStoragePolicyFields              = 2
+	numRawMetricWithStoragePolicyAndEncodeTimeFields = 3
+	numCounterFields                                 = 2
+	numBatchTimerFields                              = 2
+	numGaugeFields                                   = 2
+	numMetricFields                                  = 3
+	numDefaultStagedPoliciesListFields               = 1
+	numCustomStagedPoliciesListFields                = 2
+	numStagedPoliciesFields                          = 3
+	numStoragePolicyFields                           = 2
+	numKnownResolutionFields                         = 2
+	numUnknownResolutionFields                       = 3
+	numKnownRetentionFields                          = 2
+	numDefaultAggregationIDFields                    = 1
+	numShortAggregationIDFields                      = 2
+	numLongAggregationIDFields                       = 2
+	numPolicyFields                                  = 2
 )
 
 // NB(xichen): use a slice instead of a map to avoid lookup overhead.
@@ -110,6 +114,7 @@ func init() {
 	setNumFieldsForType(batchTimerWithPoliciesListType, numBatchTimerWithPoliciesListFields)
 	setNumFieldsForType(gaugeWithPoliciesListType, numGaugeWithPoliciesListFields)
 	setNumFieldsForType(rawMetricWithStoragePolicyType, numRawMetricWithStoragePolicyFields)
+	setNumFieldsForType(rawMetricWithStoragePolicyAndEncodeTimeType, numRawMetricWithStoragePolicyAndEncodeTimeFields)
 	setNumFieldsForType(counterType, numCounterFields)
 	setNumFieldsForType(batchTimerType, numBatchTimerFields)
 	setNumFieldsForType(gaugeType, numGaugeFields)

--- a/protocol/msgpack/types.go
+++ b/protocol/msgpack/types.go
@@ -326,11 +326,22 @@ type AggregatedEncoder interface {
 	// EncodeMetricWithStoragePolicy encodes a metric with an applicable storage policy.
 	EncodeMetricWithStoragePolicy(mp aggregated.MetricWithStoragePolicy) error
 
+	// EncodeMetricWithStoragePolicyAndEncodeTime encodes a metric with an applicable
+	// storage policy, alongside the time at which encoding happens.
+	EncodeMetricWithStoragePolicyAndEncodeTime(
+		mp aggregated.MetricWithStoragePolicy,
+		encodedAtNanos int64,
+	) error
+
 	// EncodeChunkedMetricWithStoragePolicy encodes a chunked metric with an applicable storage policy.
 	EncodeChunkedMetricWithStoragePolicy(cmp aggregated.ChunkedMetricWithStoragePolicy) error
 
-	// EncodeRawMetricWithStoragePolicy encodes a raw metric with an applicable storage policy.
-	EncodeRawMetricWithStoragePolicy(rp aggregated.RawMetricWithStoragePolicy) error
+	// EncodeChunkedMetricWithStoragePolicyAndEncodeTime encodes a chunked metric with
+	// an applicable storage policy, alongside the time at which encoding happens.
+	EncodeChunkedMetricWithStoragePolicyAndEncodeTime(
+		cmp aggregated.ChunkedMetricWithStoragePolicy,
+		encodedAtNanos int64,
+	) error
 
 	// Encoder returns the encoder.
 	Encoder() BufferedEncoder
@@ -344,8 +355,9 @@ type AggregatedIterator interface {
 	// Next returns true if there are more metrics to decode.
 	Next() bool
 
-	// Value returns the current raw metric and the applicable policy.
-	Value() (aggregated.RawMetric, policy.StoragePolicy)
+	// Value returns the current raw metric, the corresponding policy, and timestamp at
+	// which the metric and the policy were encoded if applicable.
+	Value() (aggregated.RawMetric, policy.StoragePolicy, int64)
 
 	// Err returns the error encountered during decoding, if any.
 	Err() error


### PR DESCRIPTION
cc @jeromefroe @cw9 

This PR adds two new APIs to support including encoding time when encoding metrics and policies. Such encoding time will be used to compute e2e latencies (e.g., prior to ingest etc).