### PR TITLE
Allow policies to have same resolution with different retentions

### DIFF
--- a/.metalinter.json
+++ b/.metalinter.json
@@ -9,7 +9,7 @@
     , "misspell"
     , "unparam"
     , "megacheck"
-    , "aligncheck"
+    , "maligned"
     , "errcheck" ],
   "Deadline": "3m",
   "EnableGC": true

--- a/policy/aggregation_id_compress.go
+++ b/policy/aggregation_id_compress.go
@@ -77,10 +77,10 @@ func (c *aggregationIDCompressor) Compress(aggTypes AggregationTypes) (Aggregati
 
 func (c *aggregationIDCompressor) MustCompress(aggTypes AggregationTypes) AggregationID {
 	id, err := c.Compress(aggTypes)
-	if err == nil {
-		return id
+	if err != nil {
+		panic(fmt.Errorf("unable to compress %v: %v", aggTypes, err))
 	}
-	panic(fmt.Errorf("unable to compress %v: %v", aggTypes, err))
+	return id
 }
 
 type aggregationIDDecompressor struct {

--- a/policy/aggregation_id_compress.go
+++ b/policy/aggregation_id_compress.go
@@ -28,7 +28,12 @@ import (
 
 // AggregationIDCompressor can compress AggregationTypes into an AggregationID.
 type AggregationIDCompressor interface {
+	// Compress compresses a set of aggregation types into an aggregation id.
 	Compress(aggTypes AggregationTypes) (AggregationID, error)
+
+	// MustCompress compresses a set of aggregation types into an aggregation id,
+	// and panics if an error is encountered.
+	MustCompress(aggTypes AggregationTypes) AggregationID
 }
 
 // AggregationIDDecompressor can decompress AggregationID.
@@ -68,6 +73,14 @@ func (c *aggregationIDCompressor) Compress(aggTypes AggregationTypes) (Aggregati
 		id[i] = codes[i]
 	}
 	return id, nil
+}
+
+func (c *aggregationIDCompressor) MustCompress(aggTypes AggregationTypes) AggregationID {
+	id, err := c.Compress(aggTypes)
+	if err == nil {
+		return id
+	}
+	panic(fmt.Errorf("unable to compress %v: %v", aggTypes, err))
 }
 
 type aggregationIDDecompressor struct {

--- a/policy/aggregation_type.go
+++ b/policy/aggregation_type.go
@@ -444,24 +444,6 @@ func (id AggregationID) IsDefault() bool {
 	return id == DefaultAggregationID
 }
 
-// Merge returns the result of merging another AggregationID, with an indicater whether
-// any new aggregation type was found in the other AggregationID.
-func (id AggregationID) Merge(other AggregationID) (AggregationID, bool) {
-	var merged bool
-	for i, code := range id {
-		otherCode := other[i]
-		if otherCode == 0 {
-			continue
-		}
-		mergeResult := code | otherCode
-		if code != mergeResult {
-			merged = true
-			id[i] = mergeResult
-		}
-	}
-	return id, merged
-}
-
 // Contains checks if the given aggregation type is contained in the aggregation id.
 func (id AggregationID) Contains(aggType AggregationType) bool {
 	if !aggType.IsValid() {

--- a/policy/aggregation_type_config.go
+++ b/policy/aggregation_type_config.go
@@ -128,9 +128,8 @@ func parseTypeStringOverride(m map[AggregationType]string) map[AggregationType][
 type transformFnType string
 
 var (
-	unknownTransformType transformFnType = "unknown"
-	noopTransformType    transformFnType = "noop"
-	suffixTransformType  transformFnType = "suffix"
+	noopTransformType   transformFnType = "noop"
+	suffixTransformType transformFnType = "suffix"
 
 	validTypes = []transformFnType{
 		noopTransformType,

--- a/policy/aggregation_type_test.go
+++ b/policy/aggregation_type_test.go
@@ -203,25 +203,3 @@ func TestCompressedAggregationTypesIsDefault(t *testing.T) {
 	id[0] = 0
 	require.True(t, id.IsDefault())
 }
-
-func TestCompressedAggregationTypesMerge(t *testing.T) {
-	testcases := []struct {
-		input  AggregationID
-		other  AggregationID
-		result AggregationID
-		merged bool
-	}{
-		{DefaultAggregationID, DefaultAggregationID, DefaultAggregationID, false},
-		{MustCompressAggregationTypes(Mean), DefaultAggregationID, MustCompressAggregationTypes(Mean), false},
-		{DefaultAggregationID, MustCompressAggregationTypes(Mean), MustCompressAggregationTypes(Mean), true},
-		{MustCompressAggregationTypes(Min), MustCompressAggregationTypes(Max), MustCompressAggregationTypes(Min, Max), true},
-		{MustCompressAggregationTypes(Min), MustCompressAggregationTypes(Min, Max), MustCompressAggregationTypes(Min, Max), true},
-		{MustCompressAggregationTypes(Min, Max), MustCompressAggregationTypes(Min), MustCompressAggregationTypes(Min, Max), false},
-	}
-
-	for _, test := range testcases {
-		res, merged := test.input.Merge(test.other)
-		require.Equal(t, test.result, res)
-		require.Equal(t, test.merged, merged)
-	}
-}

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -185,16 +185,14 @@ func IsDefaultPolicies(ps []Policy) bool {
 	return len(ps) == 0
 }
 
-// ByResolutionAsc implements the sort.Sort interface to sort
-// policies by resolution in ascending order, finest resolution first.
-// If two policies have the same resolution, the one with longer
-// retention period comes first.
-type ByResolutionAsc []Policy
+// ByResolutionAscRetentionDesc implements the sort.Sort interface to sort policies first
+// by resolution in ascending order, then by rention in descending order.
+type ByResolutionAscRetentionDesc []Policy
 
-func (pr ByResolutionAsc) Len() int      { return len(pr) }
-func (pr ByResolutionAsc) Swap(i, j int) { pr[i], pr[j] = pr[j], pr[i] }
+func (pr ByResolutionAscRetentionDesc) Len() int      { return len(pr) }
+func (pr ByResolutionAscRetentionDesc) Swap(i, j int) { pr[i], pr[j] = pr[j], pr[i] }
 
-func (pr ByResolutionAsc) Less(i, j int) bool {
+func (pr ByResolutionAscRetentionDesc) Less(i, j int) bool {
 	p1, p2 := pr[i], pr[j]
 	sp1, sp2 := p1.StoragePolicy, p2.StoragePolicy
 	rw1, rw2 := sp1.Resolution().Window, sp2.Resolution().Window

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -242,6 +242,6 @@ func TestPoliciesByResolutionAsc(t *testing.T) {
 		NewPolicy(NewStoragePolicy(10*time.Minute, xtime.Minute, 48*time.Hour), AggregationID{100}),
 	}
 	expected := []Policy{inputs[2], inputs[0], inputs[1], inputs[5], inputs[4], inputs[3], inputs[7], inputs[6], inputs[8]}
-	sort.Sort(ByResolutionAsc(inputs))
+	sort.Sort(ByResolutionAscRetentionDesc(inputs))
 	require.Equal(t, expected, inputs)
 }

--- a/rules/ruleset_test.go
+++ b/rules/ruleset_test.go
@@ -37,13 +37,12 @@ import (
 )
 
 var (
-	compressor                = policy.NewAggregationIDCompressor()
-	compressedMax, _          = compressor.Compress(policy.AggregationTypes{policy.Max})
-	compressedCount, _        = compressor.Compress(policy.AggregationTypes{policy.Count})
-	compressedMin, _          = compressor.Compress(policy.AggregationTypes{policy.Min})
-	compressedMean, _         = compressor.Compress(policy.AggregationTypes{policy.Mean})
-	compressedP999, _         = compressor.Compress(policy.AggregationTypes{policy.P999})
-	compressedCountAndMean, _ = compressor.Compress(policy.AggregationTypes{policy.Count, policy.Mean})
+	compressor      = policy.NewAggregationIDCompressor()
+	compressedMax   = compressor.MustCompress(policy.AggregationTypes{policy.Max})
+	compressedCount = compressor.MustCompress(policy.AggregationTypes{policy.Count})
+	compressedMin   = compressor.MustCompress(policy.AggregationTypes{policy.Min})
+	compressedMean  = compressor.MustCompress(policy.AggregationTypes{policy.Mean})
+	compressedP999  = compressor.MustCompress(policy.AggregationTypes{policy.P999})
 
 	now      = time.Now().UnixNano()
 	testUser = "test_user"
@@ -62,7 +61,10 @@ func TestActiveRuleSetForwardMappingPoliciesForNonRollupID(t *testing.T) {
 					false,
 					[]policy.Policy{
 						policy.NewPolicy(policy.NewStoragePolicy(10*time.Second, xtime.Second, 12*time.Hour), policy.DefaultAggregationID),
+						policy.NewPolicy(policy.NewStoragePolicy(10*time.Second, xtime.Second, 6*time.Hour), policy.DefaultAggregationID),
+						policy.NewPolicy(policy.NewStoragePolicy(10*time.Second, xtime.Second, 2*time.Hour), policy.DefaultAggregationID),
 						policy.NewPolicy(policy.NewStoragePolicy(time.Minute, xtime.Minute, 24*time.Hour), policy.DefaultAggregationID),
+						policy.NewPolicy(policy.NewStoragePolicy(time.Minute, xtime.Minute, time.Hour), policy.DefaultAggregationID),
 						policy.NewPolicy(policy.NewStoragePolicy(5*time.Minute, xtime.Minute, 48*time.Hour), policy.DefaultAggregationID),
 						policy.NewPolicy(policy.NewStoragePolicy(10*time.Minute, xtime.Minute, 48*time.Hour), policy.DefaultAggregationID),
 					},
@@ -125,8 +127,8 @@ func TestActiveRuleSetForwardMappingPoliciesForNonRollupID(t *testing.T) {
 					15000,
 					false,
 					[]policy.Policy{
-						// different policies same resolution, merge aggregation types
-						policy.NewPolicy(policy.NewStoragePolicy(10*time.Second, xtime.Second, 24*time.Hour), compressedCountAndMean),
+						policy.NewPolicy(policy.NewStoragePolicy(10*time.Second, xtime.Second, 12*time.Hour), compressedMean),
+						policy.NewPolicy(policy.NewStoragePolicy(10*time.Second, xtime.Second, 12*time.Hour), compressedCount),
 					},
 				),
 				policy.NewStagedPolicies(
@@ -134,6 +136,7 @@ func TestActiveRuleSetForwardMappingPoliciesForNonRollupID(t *testing.T) {
 					false,
 					[]policy.Policy{
 						policy.NewPolicy(policy.NewStoragePolicy(10*time.Second, xtime.Second, 12*time.Hour), compressedMean),
+						policy.NewPolicy(policy.NewStoragePolicy(10*time.Second, xtime.Second, 6*time.Hour), policy.DefaultAggregationID),
 						policy.NewPolicy(policy.NewStoragePolicy(5*time.Minute, xtime.Minute, 48*time.Hour), policy.DefaultAggregationID),
 						policy.NewPolicy(policy.NewStoragePolicy(10*time.Minute, xtime.Minute, 48*time.Hour), policy.DefaultAggregationID),
 					},
@@ -143,7 +146,10 @@ func TestActiveRuleSetForwardMappingPoliciesForNonRollupID(t *testing.T) {
 					false,
 					[]policy.Policy{
 						policy.NewPolicy(policy.NewStoragePolicy(10*time.Second, xtime.Second, 12*time.Hour), policy.DefaultAggregationID),
+						policy.NewPolicy(policy.NewStoragePolicy(10*time.Second, xtime.Second, 6*time.Hour), policy.DefaultAggregationID),
+						policy.NewPolicy(policy.NewStoragePolicy(10*time.Second, xtime.Second, 2*time.Hour), policy.DefaultAggregationID),
 						policy.NewPolicy(policy.NewStoragePolicy(time.Minute, xtime.Minute, 24*time.Hour), policy.DefaultAggregationID),
+						policy.NewPolicy(policy.NewStoragePolicy(time.Minute, xtime.Minute, time.Hour), policy.DefaultAggregationID),
 						policy.NewPolicy(policy.NewStoragePolicy(5*time.Minute, xtime.Minute, 48*time.Hour), policy.DefaultAggregationID),
 						policy.NewPolicy(policy.NewStoragePolicy(10*time.Minute, xtime.Minute, 48*time.Hour), policy.DefaultAggregationID),
 					},
@@ -153,8 +159,10 @@ func TestActiveRuleSetForwardMappingPoliciesForNonRollupID(t *testing.T) {
 					false,
 					[]policy.Policy{
 						policy.NewPolicy(policy.NewStoragePolicy(10*time.Second, xtime.Second, 12*time.Hour), policy.DefaultAggregationID),
+						policy.NewPolicy(policy.NewStoragePolicy(10*time.Second, xtime.Second, 2*time.Hour), policy.DefaultAggregationID),
 						policy.NewPolicy(policy.NewStoragePolicy(30*time.Second, xtime.Second, 6*time.Hour), policy.DefaultAggregationID),
 						policy.NewPolicy(policy.NewStoragePolicy(time.Minute, xtime.Minute, 24*time.Hour), policy.DefaultAggregationID),
+						policy.NewPolicy(policy.NewStoragePolicy(time.Minute, xtime.Minute, time.Hour), policy.DefaultAggregationID),
 						policy.NewPolicy(policy.NewStoragePolicy(5*time.Minute, xtime.Minute, 48*time.Hour), policy.DefaultAggregationID),
 					},
 				),
@@ -221,7 +229,10 @@ func TestActiveRuleSetReverseMappingPoliciesForNonRollupID(t *testing.T) {
 					false,
 					[]policy.Policy{
 						policy.NewPolicy(policy.NewStoragePolicy(10*time.Second, xtime.Second, 12*time.Hour), policy.DefaultAggregationID),
+						policy.NewPolicy(policy.NewStoragePolicy(10*time.Second, xtime.Second, 6*time.Hour), policy.DefaultAggregationID),
+						policy.NewPolicy(policy.NewStoragePolicy(10*time.Second, xtime.Second, 2*time.Hour), policy.DefaultAggregationID),
 						policy.NewPolicy(policy.NewStoragePolicy(time.Minute, xtime.Minute, 24*time.Hour), policy.DefaultAggregationID),
+						policy.NewPolicy(policy.NewStoragePolicy(time.Minute, xtime.Minute, time.Hour), policy.DefaultAggregationID),
 						policy.NewPolicy(policy.NewStoragePolicy(5*time.Minute, xtime.Minute, 48*time.Hour), policy.DefaultAggregationID),
 						policy.NewPolicy(policy.NewStoragePolicy(10*time.Minute, xtime.Minute, 48*time.Hour), policy.DefaultAggregationID),
 					},
@@ -303,6 +314,7 @@ func TestActiveRuleSetReverseMappingPoliciesForNonRollupID(t *testing.T) {
 					20000,
 					false,
 					[]policy.Policy{
+						policy.NewPolicy(policy.NewStoragePolicy(10*time.Second, xtime.Second, 6*time.Hour), policy.DefaultAggregationID),
 						policy.NewPolicy(policy.NewStoragePolicy(5*time.Minute, xtime.Minute, 48*time.Hour), policy.DefaultAggregationID),
 						policy.NewPolicy(policy.NewStoragePolicy(10*time.Minute, xtime.Minute, 48*time.Hour), policy.DefaultAggregationID),
 					},
@@ -329,13 +341,14 @@ func TestActiveRuleSetReverseMappingPoliciesForNonRollupID(t *testing.T) {
 					false,
 					[]policy.Policy{
 						// different policies same resolution, merge aggregation types
-						policy.NewPolicy(policy.NewStoragePolicy(10*time.Second, xtime.Second, 24*time.Hour), compressedCountAndMean),
+						policy.NewPolicy(policy.NewStoragePolicy(10*time.Second, xtime.Second, 12*time.Hour), compressedCount),
 					},
 				),
 				policy.NewStagedPolicies(
 					20000,
 					false,
 					[]policy.Policy{
+						policy.NewPolicy(policy.NewStoragePolicy(10*time.Second, xtime.Second, 6*time.Hour), policy.DefaultAggregationID),
 						policy.NewPolicy(policy.NewStoragePolicy(5*time.Minute, xtime.Minute, 48*time.Hour), policy.DefaultAggregationID),
 						policy.NewPolicy(policy.NewStoragePolicy(10*time.Minute, xtime.Minute, 48*time.Hour), policy.DefaultAggregationID),
 					},
@@ -345,7 +358,10 @@ func TestActiveRuleSetReverseMappingPoliciesForNonRollupID(t *testing.T) {
 					false,
 					[]policy.Policy{
 						policy.NewPolicy(policy.NewStoragePolicy(10*time.Second, xtime.Second, 12*time.Hour), policy.DefaultAggregationID),
+						policy.NewPolicy(policy.NewStoragePolicy(10*time.Second, xtime.Second, 6*time.Hour), policy.DefaultAggregationID),
+						policy.NewPolicy(policy.NewStoragePolicy(10*time.Second, xtime.Second, 2*time.Hour), policy.DefaultAggregationID),
 						policy.NewPolicy(policy.NewStoragePolicy(time.Minute, xtime.Minute, 24*time.Hour), policy.DefaultAggregationID),
+						policy.NewPolicy(policy.NewStoragePolicy(time.Minute, xtime.Minute, time.Hour), policy.DefaultAggregationID),
 						policy.NewPolicy(policy.NewStoragePolicy(5*time.Minute, xtime.Minute, 48*time.Hour), policy.DefaultAggregationID),
 						policy.NewPolicy(policy.NewStoragePolicy(10*time.Minute, xtime.Minute, 48*time.Hour), policy.DefaultAggregationID),
 					},
@@ -355,8 +371,10 @@ func TestActiveRuleSetReverseMappingPoliciesForNonRollupID(t *testing.T) {
 					false,
 					[]policy.Policy{
 						policy.NewPolicy(policy.NewStoragePolicy(10*time.Second, xtime.Second, 12*time.Hour), policy.DefaultAggregationID),
+						policy.NewPolicy(policy.NewStoragePolicy(10*time.Second, xtime.Second, 2*time.Hour), policy.DefaultAggregationID),
 						policy.NewPolicy(policy.NewStoragePolicy(30*time.Second, xtime.Second, 6*time.Hour), policy.DefaultAggregationID),
 						policy.NewPolicy(policy.NewStoragePolicy(time.Minute, xtime.Minute, 24*time.Hour), policy.DefaultAggregationID),
+						policy.NewPolicy(policy.NewStoragePolicy(time.Minute, xtime.Minute, time.Hour), policy.DefaultAggregationID),
 						policy.NewPolicy(policy.NewStoragePolicy(5*time.Minute, xtime.Minute, 48*time.Hour), policy.DefaultAggregationID),
 					},
 				),
@@ -562,7 +580,10 @@ func TestActiveRuleSetRollupResults(t *testing.T) {
 							false,
 							[]policy.Policy{
 								policy.NewPolicy(policy.NewStoragePolicy(10*time.Second, xtime.Second, 12*time.Hour), policy.DefaultAggregationID),
+								policy.NewPolicy(policy.NewStoragePolicy(10*time.Second, xtime.Second, 6*time.Hour), policy.DefaultAggregationID),
+								policy.NewPolicy(policy.NewStoragePolicy(10*time.Second, xtime.Second, 2*time.Hour), policy.DefaultAggregationID),
 								policy.NewPolicy(policy.NewStoragePolicy(time.Minute, xtime.Minute, 24*time.Hour), policy.DefaultAggregationID),
+								policy.NewPolicy(policy.NewStoragePolicy(time.Minute, xtime.Minute, time.Hour), policy.DefaultAggregationID),
 								policy.NewPolicy(policy.NewStoragePolicy(5*time.Minute, xtime.Minute, 48*time.Hour), policy.DefaultAggregationID),
 								policy.NewPolicy(policy.NewStoragePolicy(10*time.Minute, xtime.Minute, 48*time.Hour), policy.DefaultAggregationID),
 							},
@@ -627,10 +648,19 @@ func TestActiveRuleSetRollupResults(t *testing.T) {
 							},
 						),
 						policy.NewStagedPolicies(
+							15000,
+							false,
+							[]policy.Policy{
+								policy.NewPolicy(policy.NewStoragePolicy(10*time.Second, xtime.Second, 24*time.Hour), policy.DefaultAggregationID),
+								policy.NewPolicy(policy.NewStoragePolicy(10*time.Second, xtime.Second, 12*time.Hour), policy.DefaultAggregationID),
+							},
+						),
+						policy.NewStagedPolicies(
 							20000,
 							false,
 							[]policy.Policy{
 								policy.NewPolicy(policy.NewStoragePolicy(10*time.Second, xtime.Second, 12*time.Hour), policy.DefaultAggregationID),
+								policy.NewPolicy(policy.NewStoragePolicy(10*time.Second, xtime.Second, 6*time.Hour), policy.DefaultAggregationID),
 								policy.NewPolicy(policy.NewStoragePolicy(5*time.Minute, xtime.Minute, 48*time.Hour), policy.DefaultAggregationID),
 								policy.NewPolicy(policy.NewStoragePolicy(10*time.Minute, xtime.Minute, 48*time.Hour), policy.DefaultAggregationID),
 							},
@@ -640,7 +670,10 @@ func TestActiveRuleSetRollupResults(t *testing.T) {
 							false,
 							[]policy.Policy{
 								policy.NewPolicy(policy.NewStoragePolicy(10*time.Second, xtime.Second, 12*time.Hour), policy.DefaultAggregationID),
+								policy.NewPolicy(policy.NewStoragePolicy(10*time.Second, xtime.Second, 6*time.Hour), policy.DefaultAggregationID),
+								policy.NewPolicy(policy.NewStoragePolicy(10*time.Second, xtime.Second, 2*time.Hour), policy.DefaultAggregationID),
 								policy.NewPolicy(policy.NewStoragePolicy(time.Minute, xtime.Minute, 24*time.Hour), policy.DefaultAggregationID),
+								policy.NewPolicy(policy.NewStoragePolicy(time.Minute, xtime.Minute, time.Hour), policy.DefaultAggregationID),
 								policy.NewPolicy(policy.NewStoragePolicy(5*time.Minute, xtime.Minute, 48*time.Hour), policy.DefaultAggregationID),
 								policy.NewPolicy(policy.NewStoragePolicy(10*time.Minute, xtime.Minute, 48*time.Hour), policy.DefaultAggregationID),
 							},
@@ -650,8 +683,10 @@ func TestActiveRuleSetRollupResults(t *testing.T) {
 							false,
 							[]policy.Policy{
 								policy.NewPolicy(policy.NewStoragePolicy(10*time.Second, xtime.Second, 12*time.Hour), policy.DefaultAggregationID),
+								policy.NewPolicy(policy.NewStoragePolicy(10*time.Second, xtime.Second, 2*time.Hour), policy.DefaultAggregationID),
 								policy.NewPolicy(policy.NewStoragePolicy(30*time.Second, xtime.Second, 6*time.Hour), policy.DefaultAggregationID),
 								policy.NewPolicy(policy.NewStoragePolicy(time.Minute, xtime.Minute, 24*time.Hour), policy.DefaultAggregationID),
+								policy.NewPolicy(policy.NewStoragePolicy(time.Minute, xtime.Minute, time.Hour), policy.DefaultAggregationID),
 								policy.NewPolicy(policy.NewStoragePolicy(5*time.Minute, xtime.Minute, 48*time.Hour), policy.DefaultAggregationID),
 							},
 						),
@@ -804,8 +839,10 @@ func TestRuleSetActiveSet(t *testing.T) {
 							false,
 							[]policy.Policy{
 								policy.NewPolicy(policy.NewStoragePolicy(10*time.Second, xtime.Second, 12*time.Hour), compressedMax),
-								// the aggregation type came in from policy merging
-								policy.NewPolicy(policy.NewStoragePolicy(time.Minute, xtime.Minute, 24*time.Hour), compressedMin),
+								policy.NewPolicy(policy.NewStoragePolicy(10*time.Second, xtime.Second, 6*time.Hour), policy.DefaultAggregationID),
+								policy.NewPolicy(policy.NewStoragePolicy(10*time.Second, xtime.Second, 2*time.Hour), policy.DefaultAggregationID),
+								policy.NewPolicy(policy.NewStoragePolicy(time.Minute, xtime.Minute, 24*time.Hour), policy.DefaultAggregationID),
+								policy.NewPolicy(policy.NewStoragePolicy(time.Minute, xtime.Minute, time.Hour), compressedMin),
 								policy.NewPolicy(policy.NewStoragePolicy(5*time.Minute, xtime.Minute, 48*time.Hour), policy.DefaultAggregationID),
 								policy.NewPolicy(policy.NewStoragePolicy(10*time.Minute, xtime.Minute, 48*time.Hour), policy.DefaultAggregationID),
 							},
@@ -867,7 +904,10 @@ func TestRuleSetActiveSet(t *testing.T) {
 									false,
 									[]policy.Policy{
 										policy.NewPolicy(policy.NewStoragePolicy(10*time.Second, xtime.Second, 12*time.Hour), policy.DefaultAggregationID),
+										policy.NewPolicy(policy.NewStoragePolicy(10*time.Second, xtime.Second, 6*time.Hour), policy.DefaultAggregationID),
+										policy.NewPolicy(policy.NewStoragePolicy(10*time.Second, xtime.Second, 2*time.Hour), policy.DefaultAggregationID),
 										policy.NewPolicy(policy.NewStoragePolicy(time.Minute, xtime.Minute, 24*time.Hour), policy.DefaultAggregationID),
+										policy.NewPolicy(policy.NewStoragePolicy(time.Minute, xtime.Minute, time.Hour), policy.DefaultAggregationID),
 										policy.NewPolicy(policy.NewStoragePolicy(5*time.Minute, xtime.Minute, 48*time.Hour), policy.DefaultAggregationID),
 										policy.NewPolicy(policy.NewStoragePolicy(10*time.Minute, xtime.Minute, 48*time.Hour), policy.DefaultAggregationID),
 									},
@@ -1026,6 +1066,7 @@ func TestRuleSetActiveSet(t *testing.T) {
 							false,
 							[]policy.Policy{
 								policy.NewPolicy(policy.NewStoragePolicy(10*time.Second, xtime.Second, 24*time.Hour), policy.DefaultAggregationID),
+								policy.NewPolicy(policy.NewStoragePolicy(10*time.Second, xtime.Second, 2*time.Hour), policy.DefaultAggregationID),
 								policy.NewPolicy(policy.NewStoragePolicy(30*time.Second, xtime.Second, 6*time.Hour), policy.DefaultAggregationID),
 								policy.NewPolicy(policy.NewStoragePolicy(time.Minute, xtime.Minute, time.Hour), policy.DefaultAggregationID),
 							},
@@ -1167,6 +1208,15 @@ func testMappingRules(t *testing.T) []*mappingRule {
 				filter:       filter1,
 				policies: []policy.Policy{
 					policy.NewPolicy(policy.NewStoragePolicy(10*time.Second, xtime.Second, 24*time.Hour), compressedCount),
+				},
+			},
+			&mappingRuleSnapshot{
+				name:         "mappingRule1.snapshot1",
+				tombstoned:   false,
+				cutoverNanos: 15000,
+				filter:       filter1,
+				policies: []policy.Policy{
+					policy.NewPolicy(policy.NewStoragePolicy(10*time.Second, xtime.Second, 12*time.Hour), compressedCount),
 				},
 			},
 			&mappingRuleSnapshot{


### PR DESCRIPTION
cc @cw9 @jeromefroe

This PR relaxes the constraint for policy resolution to allow policies to have same resolution but with different retention periods. As such, when querying an id for 3-day data with a layered policy list with [1m:2d, 1m:40d], the policy resolver could use the 1m:2d for the first two days and the 1m:40d for data older than 2 days in case the data in the 1m:40d is lagging behind the 1m:2d data during the migration phase. 