### PR TITLE
Generalize metric types function to return a slice of types

### DIFF
--- a/metric/types.go
+++ b/metric/types.go
@@ -20,6 +20,11 @@
 
 package metric
 
+import (
+	"fmt"
+	"strings"
+)
+
 // Type is a metric type.
 type Type int
 
@@ -30,3 +35,41 @@ const (
 	TimerType
 	GaugeType
 )
+
+// ValidTypes is a list of valid types.
+var ValidTypes = []Type{
+	CounterType,
+	TimerType,
+	GaugeType,
+}
+
+func (t Type) String() string {
+	switch t {
+	case CounterType:
+		return "counter"
+	case TimerType:
+		return "timer"
+	case GaugeType:
+		return "gauge"
+	default:
+		return "unknown"
+	}
+}
+
+// UnmarshalYAML unmarshals YAML object into a metric type.
+func (t *Type) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var str string
+	if err := unmarshal(&str); err != nil {
+		return err
+	}
+	validTypes := make([]string, 0, len(ValidTypes))
+	for _, valid := range ValidTypes {
+		if str == string(valid) {
+			*t = valid
+			return nil
+		}
+		validTypes = append(validTypes, string(valid))
+	}
+	return fmt.Errorf("invalid metric type '%s' valid types are: %s",
+		str, strings.Join(validTypes, ", "))
+}

--- a/rules/validator.go
+++ b/rules/validator.go
@@ -78,10 +78,12 @@ func (v *validator) validateMappingRules(mrv map[string]*MappingRuleView) error 
 		}
 
 		// Validate that the policies are valid.
-		t := v.opts.MetricTypeFn()(view.Filters)
-		for _, p := range view.Policies {
-			if err := v.validatePolicy(t, p); err != nil {
-				return err
+		types := v.opts.MetricTypesFn()(view.Filters)
+		for _, t := range types {
+			for _, p := range view.Policies {
+				if err := v.validatePolicy(t, p); err != nil {
+					return err
+				}
 			}
 		}
 	}
@@ -106,11 +108,13 @@ func (v *validator) validateRollupRules(rrv map[string]*RollupRuleView) error {
 		}
 
 		// Validate that the policies are valid.
-		t := v.opts.MetricTypeFn()(view.Filters)
-		for _, target := range view.Targets {
-			for _, p := range target.Policies {
-				if err := v.validatePolicy(t, p); err != nil {
-					return err
+		types := v.opts.MetricTypesFn()(view.Filters)
+		for _, t := range types {
+			for _, target := range view.Targets {
+				for _, p := range target.Policies {
+					if err := v.validatePolicy(t, p); err != nil {
+						return err
+					}
 				}
 			}
 		}

--- a/rules/validator_options.go
+++ b/rules/validator_options.go
@@ -25,8 +25,8 @@ import (
 	"github.com/m3db/m3metrics/policy"
 )
 
-// MetricTypeFn determines the metric type based on a set of tag based filters.
-type MetricTypeFn func(tagFilters map[string]string) metric.Type
+// MetricTypesFn determines the possible metric types based on a set of tag based filters.
+type MetricTypesFn func(tagFilters map[string]string) []metric.Type
 
 // ValidatorOptions provide a set of options for the validator.
 type ValidatorOptions interface {
@@ -44,11 +44,11 @@ type ValidatorOptions interface {
 	// types for a given metric type.
 	SetAllowedCustomAggregationTypesFor(t metric.Type, aggTypes policy.AggregationTypes) ValidatorOptions
 
-	// SetMetricTypeFn sets the metric type function.
-	SetMetricTypeFn(value MetricTypeFn) ValidatorOptions
+	// SetMetricTypesFn sets the metric types function.
+	SetMetricTypesFn(value MetricTypesFn) ValidatorOptions
 
-	// MetricTypeFn returns the metric type function.
-	MetricTypeFn() MetricTypeFn
+	// MetricTypesFn returns the metric types function.
+	MetricTypesFn() MetricTypesFn
 
 	// IsAllowedStoragePolicyFor determines whether a given storage policy is allowed for the
 	// given metric type.
@@ -67,7 +67,7 @@ type validationMetadata struct {
 type validatorOptions struct {
 	defaultAllowedStoragePolicies        map[policy.StoragePolicy]struct{}
 	defaultAllowedCustomAggregationTypes map[policy.AggregationType]struct{}
-	metricTypeFn                         MetricTypeFn
+	metricTypesFn                        MetricTypesFn
 	metadatasByType                      map[metric.Type]validationMetadata
 }
 
@@ -102,13 +102,13 @@ func (o *validatorOptions) SetAllowedCustomAggregationTypesFor(t metric.Type, ag
 	return o
 }
 
-func (o *validatorOptions) SetMetricTypeFn(value MetricTypeFn) ValidatorOptions {
-	o.metricTypeFn = value
+func (o *validatorOptions) SetMetricTypesFn(value MetricTypesFn) ValidatorOptions {
+	o.metricTypesFn = value
 	return o
 }
 
-func (o *validatorOptions) MetricTypeFn() MetricTypeFn {
-	return o.metricTypeFn
+func (o *validatorOptions) MetricTypesFn() MetricTypesFn {
+	return o.metricTypesFn
 }
 
 func (o *validatorOptions) IsAllowedStoragePolicyFor(t metric.Type, p policy.StoragePolicy) bool {

--- a/rules/validator_test.go
+++ b/rules/validator_test.go
@@ -572,24 +572,24 @@ func testValidatorOptions() ValidatorOptions {
 	return NewValidatorOptions().
 		SetDefaultAllowedStoragePolicies(testStoragePolicies).
 		SetDefaultAllowedCustomAggregationTypes(nil).
-		SetMetricTypeFn(testMetricTypeFn())
+		SetMetricTypesFn(testMetricTypesFn())
 }
 
-func testMetricTypeFn() MetricTypeFn {
-	return func(filters map[string]string) metric.Type {
+func testMetricTypesFn() MetricTypesFn {
+	return func(filters map[string]string) []metric.Type {
 		typ, exists := filters[testTypeTag]
 		if !exists {
-			return metric.UnknownType
+			return []metric.Type{metric.UnknownType}
 		}
 		switch typ {
 		case testCounterType:
-			return metric.CounterType
+			return []metric.Type{metric.CounterType}
 		case testTimerType:
-			return metric.TimerType
+			return []metric.Type{metric.TimerType}
 		case testGaugeType:
-			return metric.GaugeType
+			return []metric.Type{metric.GaugeType}
 		default:
-			return metric.UnknownType
+			return []metric.Type{metric.UnknownType}
 		}
 	}
 }


### PR DESCRIPTION
cc @dgromov 

This PR generalizes the metric types function a little to return a slice of types instead of just a single type. This is to handle the edge case where the users don't have a type tag or have a regex matching multiple metric types in the metric filter.