### PR TITLE
Support aggregation type filtering in ReverseMatch

### DIFF
--- a/matcher/cache/cache.go
+++ b/matcher/cache/cache.go
@@ -138,7 +138,7 @@ func NewCache(opts Options) matcher.Cache {
 	return c
 }
 
-func (c *cache) Match(namespace, id []byte, fromNanos, toNanos int64) rules.MatchResult {
+func (c *cache) ForwardMatch(namespace, id []byte, fromNanos, toNanos int64) rules.MatchResult {
 	c.RLock()
 	res, found := c.tryGetWithLock(namespace, id, fromNanos, toNanos, dontSetIfNotFound)
 	c.RUnlock()
@@ -262,7 +262,7 @@ func (c *cache) setWithLock(
 	if invalidate {
 		results = c.invalidateWithLock(nsHash, idHash, results)
 	}
-	res := results.source.Match(id, fromNanos, toNanos)
+	res := results.source.ForwardMatch(id, fromNanos, toNanos)
 	newElem := &element{nsHash: nsHash, idHash: idHash, result: res}
 	newElem.SetPromotionExpiry(c.newPromotionExpiry(c.nowFn()))
 	results.elems[idHash] = newElem

--- a/matcher/config.go
+++ b/matcher/config.go
@@ -29,6 +29,7 @@ import (
 	"github.com/m3db/m3metrics/filters"
 	"github.com/m3db/m3metrics/metric/id"
 	"github.com/m3db/m3metrics/metric/id/m3"
+	"github.com/m3db/m3metrics/policy"
 	"github.com/m3db/m3metrics/rules"
 	"github.com/m3db/m3x/clock"
 	"github.com/m3db/m3x/instrument"
@@ -46,7 +47,7 @@ type Configuration struct {
 	NameTagKey            string                       `yaml:"nameTagKey" validate:"nonzero"`
 	MatchRangePast        *time.Duration               `yaml:"matchRangePast"`
 	SortedTagIteratorPool pool.ObjectPoolConfiguration `yaml:"sortedTagIteratorPool"`
-	MatchMode             rules.MatchMode              `yaml:"matchMode"`
+	Policy                policy.Configuration         `yaml:"policy"`
 }
 
 // NewNamespaces creates a matcher.Namespaces.
@@ -116,7 +117,8 @@ func (cfg *Configuration) NewOptions(
 	ruleSetOpts := rules.NewOptions().
 		SetTagsFilterOptions(tagsFilterOptions).
 		SetNewRollupIDFn(m3.NewRollupID).
-		SetIsRollupIDFn(isRollupIDFn)
+		SetIsRollupIDFn(isRollupIDFn).
+		SetPolicyOptions(cfg.Policy.NewOptions())
 
 	// Configure ruleset key function.
 	ruleSetKeyFn := func(namespace []byte) string {
@@ -131,8 +133,7 @@ func (cfg *Configuration) NewOptions(
 		SetNamespacesKey(cfg.NamespacesKey).
 		SetRuleSetKeyFn(ruleSetKeyFn).
 		SetNamespaceTag([]byte(cfg.NamespaceTag)).
-		SetDefaultNamespace([]byte(cfg.DefaultNamespace)).
-		SetMatchMode(cfg.MatchMode)
+		SetDefaultNamespace([]byte(cfg.DefaultNamespace))
 
 	if cfg.InitWatchTimeout != 0 {
 		opts = opts.SetInitWatchTimeout(cfg.InitWatchTimeout)

--- a/matcher/config.go
+++ b/matcher/config.go
@@ -38,16 +38,16 @@ import (
 
 // Configuration is config used to create a Matcher.
 type Configuration struct {
-	InitWatchTimeout      time.Duration                `yaml:"initWatchTimeout"`
-	RulesKVConfig         kv.Configuration             `yaml:"rulesKVConfig"`
-	NamespacesKey         string                       `yaml:"namespacesKey" validate:"nonzero"`
-	RuleSetKeyFmt         string                       `yaml:"ruleSetKeyFmt" validate:"nonzero"`
-	NamespaceTag          string                       `yaml:"namespaceTag" validate:"nonzero"`
-	DefaultNamespace      string                       `yaml:"defaultNamespace" validate:"nonzero"`
-	NameTagKey            string                       `yaml:"nameTagKey" validate:"nonzero"`
-	MatchRangePast        *time.Duration               `yaml:"matchRangePast"`
-	SortedTagIteratorPool pool.ObjectPoolConfiguration `yaml:"sortedTagIteratorPool"`
-	Policy                policy.Configuration         `yaml:"policy"`
+	InitWatchTimeout      time.Duration                        `yaml:"initWatchTimeout"`
+	RulesKVConfig         kv.Configuration                     `yaml:"rulesKVConfig"`
+	NamespacesKey         string                               `yaml:"namespacesKey" validate:"nonzero"`
+	RuleSetKeyFmt         string                               `yaml:"ruleSetKeyFmt" validate:"nonzero"`
+	NamespaceTag          string                               `yaml:"namespaceTag" validate:"nonzero"`
+	DefaultNamespace      string                               `yaml:"defaultNamespace" validate:"nonzero"`
+	NameTagKey            string                               `yaml:"nameTagKey" validate:"nonzero"`
+	MatchRangePast        *time.Duration                       `yaml:"matchRangePast"`
+	SortedTagIteratorPool pool.ObjectPoolConfiguration         `yaml:"sortedTagIteratorPool"`
+	AggregationTypes      policy.AggregationTypesConfiguration `yaml:"aggregationTypes"`
 }
 
 // NewNamespaces creates a matcher.Namespaces.
@@ -118,7 +118,7 @@ func (cfg *Configuration) NewOptions(
 		SetTagsFilterOptions(tagsFilterOptions).
 		SetNewRollupIDFn(m3.NewRollupID).
 		SetIsRollupIDFn(isRollupIDFn).
-		SetPolicyOptions(cfg.Policy.NewOptions())
+		SetAggregationTypesOptions(cfg.AggregationTypes.NewOptions())
 
 	// Configure ruleset key function.
 	ruleSetKeyFn := func(namespace []byte) string {

--- a/matcher/config_test.go
+++ b/matcher/config_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/m3db/m3cluster/client"
 	"github.com/m3db/m3cluster/kv"
 	"github.com/m3db/m3cluster/kv/mem"
-	"github.com/m3db/m3metrics/rules"
 	"github.com/m3db/m3x/clock"
 	"github.com/m3db/m3x/instrument"
 
@@ -46,7 +45,6 @@ func TestConfigurationNewNamespaces(t *testing.T) {
 		NamespaceTag:     "NamespaceTag",
 		DefaultNamespace: "DefaultNamespace",
 		NameTagKey:       "NameTagKey",
-		MatchMode:        "forward",
 	}
 
 	ctrl := gomock.NewController(t)
@@ -63,5 +61,4 @@ func TestConfigurationNewNamespaces(t *testing.T) {
 	require.Equal(t, cfg.NamespacesKey, opts.NamespacesKey())
 	require.Equal(t, []byte(cfg.NamespaceTag), opts.NamespaceTag())
 	require.Equal(t, []byte(cfg.DefaultNamespace), opts.DefaultNamespace())
-	require.Equal(t, rules.ForwardMatch, opts.MatchMode())
 }

--- a/matcher/match.go
+++ b/matcher/match.go
@@ -27,9 +27,9 @@ import (
 
 // Matcher matches rules against metric IDs.
 type Matcher interface {
-	// Match matches rules against metric ID for time range [fromNanos, toNanos)
+	// ForwardMatch matches rules against metric ID for time range [fromNanos, toNanos)
 	// and returns the match result.
-	Match(id id.ID, fromNanos, toNanos int64) rules.MatchResult
+	ForwardMatch(id id.ID, fromNanos, toNanos int64) rules.MatchResult
 
 	// Close closes the matcher.
 	Close() error
@@ -74,12 +74,12 @@ func NewMatcher(cache Cache, opts Options) (Matcher, error) {
 	}, nil
 }
 
-func (m *matcher) Match(id id.ID, fromNanos, toNanos int64) rules.MatchResult {
+func (m *matcher) ForwardMatch(id id.ID, fromNanos, toNanos int64) rules.MatchResult {
 	ns, found := id.TagValue(m.namespaceTag)
 	if !found {
 		ns = m.defaultNamespace
 	}
-	return m.cache.Match(ns, id.Bytes(), fromNanos, toNanos)
+	return m.cache.ForwardMatch(ns, id.Bytes(), fromNanos, toNanos)
 }
 
 func (m *matcher) Close() error {

--- a/matcher/match_test.go
+++ b/matcher/match_test.go
@@ -73,7 +73,7 @@ func TestMatcherMatchDoesNotExist(t *testing.T) {
 	}
 	now := time.Now()
 	matcher := testMatcher(t, newMemCache())
-	require.Equal(t, rules.EmptyMatchResult, matcher.Match(id, now.UnixNano(), now.UnixNano()))
+	require.Equal(t, rules.EmptyMatchResult, matcher.ForwardMatch(id, now.UnixNano(), now.UnixNano()))
 }
 
 func TestMatcherMatchExists(t *testing.T) {
@@ -91,7 +91,7 @@ func TestMatcherMatchExists(t *testing.T) {
 	matcher := testMatcher(t, cache)
 	c := cache.(*memCache)
 	c.namespaces[ns] = memRes
-	require.Equal(t, res, matcher.Match(id, now.UnixNano(), now.UnixNano()))
+	require.Equal(t, res, matcher.ForwardMatch(id, now.UnixNano(), now.UnixNano()))
 }
 
 func TestMatcherClose(t *testing.T) {

--- a/matcher/namespaces.go
+++ b/matcher/namespaces.go
@@ -57,7 +57,7 @@ type Namespaces interface {
 	ForwardMatch(namespace, id []byte, fromNanos, toNanos int64) rules.MatchResult
 
 	// ReverseMatch reverse matches the matching policies for a given id in a given namespace
-	// between [fromNanos, toNanos), with aware of the metric type and aggregation type for the given id.
+	// between [fromNanos, toNanos), taking into account the metric type and aggregation type for the given id.
 	ReverseMatch(namespace, id []byte, fromNanos, toNanos int64, mt metric.Type, at policy.AggregationType) rules.MatchResult
 
 	// Close closes the namespaces.

--- a/matcher/namespaces.go
+++ b/matcher/namespaces.go
@@ -28,6 +28,8 @@ import (
 	"github.com/m3db/m3cluster/kv"
 	"github.com/m3db/m3cluster/kv/util/runtime"
 	"github.com/m3db/m3metrics/generated/proto/schema"
+	"github.com/m3db/m3metrics/metric"
+	"github.com/m3db/m3metrics/policy"
 	"github.com/m3db/m3metrics/rules"
 	"github.com/m3db/m3x/clock"
 	xid "github.com/m3db/m3x/id"
@@ -50,9 +52,13 @@ type Namespaces interface {
 	// Version returns the current version for a give namespace.
 	Version(namespace []byte) int
 
-	// Match returns the matching policies for a given id in a given namespace
+	// ForwardMatch forward matches the matching policies for a given id in a given namespace
 	// between [fromNanos, toNanos).
-	Match(namespace, id []byte, fromNanos, toNanos int64) rules.MatchResult
+	ForwardMatch(namespace, id []byte, fromNanos, toNanos int64) rules.MatchResult
+
+	// ReverseMatch reverse matches the matching policies for a given id in a given namespace
+	// between [fromNanos, toNanos), with aware of the metric type and aggregation type for the given id.
+	ReverseMatch(namespace, id []byte, fromNanos, toNanos int64, mt metric.Type, at policy.AggregationType) rules.MatchResult
 
 	// Close closes the namespaces.
 	Close()
@@ -163,19 +169,31 @@ func (n *namespaces) Version(namespace []byte) int {
 	return ruleSet.Version()
 }
 
-func (n *namespaces) Match(namespace, id []byte, fromNanos, toNanos int64) rules.MatchResult {
-	var (
-		res    = rules.EmptyMatchResult
-		nsHash = xid.HashFn(namespace)
-	)
+func (n *namespaces) ForwardMatch(namespace, id []byte, fromNanos, toNanos int64) rules.MatchResult {
+	ruleSet, exists := n.ruleSet(namespace)
+	if !exists {
+		return rules.EmptyMatchResult
+	}
+	return ruleSet.ForwardMatch(id, fromNanos, toNanos)
+}
+
+func (n *namespaces) ReverseMatch(namespace, id []byte, fromNanos, toNanos int64, mt metric.Type, at policy.AggregationType) rules.MatchResult {
+	ruleSet, exists := n.ruleSet(namespace)
+	if !exists {
+		return rules.EmptyMatchResult
+	}
+	return ruleSet.ReverseMatch(id, fromNanos, toNanos, mt, at)
+}
+
+func (n *namespaces) ruleSet(namespace []byte) (RuleSet, bool) {
+	nsHash := xid.HashFn(namespace)
 	n.RLock()
 	ruleSet, exists := n.rules[nsHash]
 	n.RUnlock()
 	if !exists {
 		n.metrics.notExists.Inc(1)
-		return res
 	}
-	return ruleSet.Match(id, fromNanos, toNanos)
+	return ruleSet, exists
 }
 
 func (n *namespaces) Close() {

--- a/matcher/namespaces_test.go
+++ b/matcher/namespaces_test.go
@@ -249,7 +249,7 @@ func newMemCache() Cache {
 	return &memCache{namespaces: make(map[string]memResults)}
 }
 
-func (c *memCache) Match(namespace, id []byte, fromNanos, toNanos int64) rules.MatchResult {
+func (c *memCache) ForwardMatch(namespace, id []byte, fromNanos, toNanos int64) rules.MatchResult {
 	c.RLock()
 	defer c.RUnlock()
 	if results, exists := c.namespaces[string(namespace)]; exists {

--- a/matcher/options.go
+++ b/matcher/options.go
@@ -58,12 +58,6 @@ type OnRuleSetUpdatedFn func(namespace []byte, ruleSet RuleSet)
 
 // Options provide a set of options for the matcher.
 type Options interface {
-	// SetMatchMode sets the match mode.
-	SetMatchMode(value rules.MatchMode) Options
-
-	// MatchMode returns the match mode.
-	MatchMode() rules.MatchMode
-
 	// SetClockOptions sets the clock options.
 	SetClockOptions(value clock.Options) Options
 
@@ -144,7 +138,6 @@ type Options interface {
 }
 
 type options struct {
-	matchMode            rules.MatchMode
 	clockOpts            clock.Options
 	instrumentOpts       instrument.Options
 	ruleSetOpts          rules.Options
@@ -163,7 +156,6 @@ type options struct {
 // NewOptions creates a new set of options.
 func NewOptions() Options {
 	return &options{
-		matchMode:        rules.ForwardMatch,
 		clockOpts:        clock.NewOptions(),
 		instrumentOpts:   instrument.NewOptions(),
 		ruleSetOpts:      rules.NewOptions(),
@@ -175,16 +167,6 @@ func NewOptions() Options {
 		defaultNamespace: defaultDefaultNamespace,
 		matchRangePast:   defaultMatchRangePast,
 	}
-}
-
-func (o *options) SetMatchMode(value rules.MatchMode) Options {
-	opts := *o
-	opts.matchMode = value
-	return &opts
-}
-
-func (o *options) MatchMode() rules.MatchMode {
-	return o.matchMode
 }
 
 func (o *options) SetClockOptions(value clock.Options) Options {

--- a/policy/aggregation_type.go
+++ b/policy/aggregation_type.go
@@ -276,6 +276,16 @@ func (aggTypes *AggregationTypes) UnmarshalYAML(unmarshal func(interface{}) erro
 	return nil
 }
 
+// Contains checks if the given type is contained in the aggregation types.
+func (aggTypes AggregationTypes) Contains(aggType AggregationType) bool {
+	for _, at := range aggTypes {
+		if at == aggType {
+			return true
+		}
+	}
+	return false
+}
+
 // IsDefault checks if the AggregationTypes is the default aggregation type.
 func (aggTypes AggregationTypes) IsDefault() bool {
 	return len(aggTypes) == 0
@@ -415,6 +425,16 @@ func NewAggregationIDFromSchema(input []schema.AggregationType) (AggregationID, 
 	return id, nil
 }
 
+// MustCompressAggregationTypes compresses a list of aggregation types to
+// an AggregationID, it panics if an error was encountered.
+func MustCompressAggregationTypes(aggTypes ...AggregationType) AggregationID {
+	res, err := NewAggregationIDCompressor().Compress(aggTypes)
+	if err != nil {
+		panic(err.Error())
+	}
+	return res
+}
+
 // IsDefault checks if the AggregationID is the default aggregation type.
 func (id AggregationID) IsDefault() bool {
 	return id == DefaultAggregationID
@@ -436,6 +456,15 @@ func (id AggregationID) Merge(other AggregationID) (AggregationID, bool) {
 		}
 	}
 	return id, merged
+}
+
+// Contains checks if the given aggregation type is contained in the aggregation id.
+func (id AggregationID) Contains(aggType AggregationType) bool {
+	if !aggType.IsValid() {
+		return false
+	}
+
+	return (id[int(aggType)/64] & (1 << (uint(aggType) % 64))) > 0
 }
 
 // AggregationTypes returns the aggregation types defined by the id.

--- a/policy/aggregation_type.go
+++ b/policy/aggregation_type.go
@@ -71,7 +71,7 @@ const (
 
 	aggregationTypesSeparator = ","
 
-	// aggregation id uses an array of int64 to represent aggregation types
+	// aggregation id uses an array of int64 to represent aggregation types.
 	aggIDBitShift = 6
 	aggIDBitMask  = 63
 )
@@ -85,7 +85,7 @@ var (
 	// DefaultAggregationID is a default AggregationID.
 	DefaultAggregationID AggregationID
 
-	// ValidAggregationTypes is the list of all the valid aggregation types
+	// ValidAggregationTypes is the list of all the valid aggregation types.
 	ValidAggregationTypes = map[AggregationType]struct{}{
 		Last:   emptyStruct,
 		Min:    emptyStruct,

--- a/policy/aggregation_type.go
+++ b/policy/aggregation_type.go
@@ -70,6 +70,10 @@ const (
 	AggregationIDLen = (MaxAggregationTypeID)/64 + 1
 
 	aggregationTypesSeparator = ","
+
+	// aggregation id uses an array of int64 to represent aggregation types
+	aggIDBitShift = 6
+	aggIDBitMask  = 63
 )
 
 var (
@@ -463,8 +467,8 @@ func (id AggregationID) Contains(aggType AggregationType) bool {
 	if !aggType.IsValid() {
 		return false
 	}
-	idx := int(aggType) >> 6
-	offset := uint(aggType) & 0x3F
+	idx := int(aggType) >> aggIDBitShift   // aggType / 64
+	offset := uint(aggType) & aggIDBitMask // aggType % 64
 	return (id[idx] & (1 << offset)) > 0
 }
 

--- a/policy/aggregation_type.go
+++ b/policy/aggregation_type.go
@@ -463,8 +463,9 @@ func (id AggregationID) Contains(aggType AggregationType) bool {
 	if !aggType.IsValid() {
 		return false
 	}
-
-	return (id[int(aggType)/64] & (1 << (uint(aggType) % 64))) > 0
+	idx := int(aggType) >> 6
+	offset := uint(aggType) & 0x3F
+	return (id[idx] & (1 << offset)) > 0
 }
 
 // AggregationTypes returns the aggregation types defined by the id.

--- a/policy/aggregation_type_config.go
+++ b/policy/aggregation_type_config.go
@@ -20,29 +20,29 @@
 
 package policy
 
-// Configuration contains configuration.
-type Configuration struct {
+// AggregationTypesConfiguration contains configuration for aggregation types.
+type AggregationTypesConfiguration struct {
 	// Default aggregation types for counter metrics.
-	CounterAggregationTypes *AggregationTypes `yaml:"counterAggregationTypes" validate:"nonzero"`
+	DefaultCounterAggregationTypes *AggregationTypes `yaml:"defaultCounterAggregationTypes"`
 
 	// Default aggregation types for timer metrics.
-	TimerAggregationTypes *AggregationTypes `yaml:"timerAggregationTypes" validate:"nonzero"`
+	DefaultTimerAggregationTypes *AggregationTypes `yaml:"defaultTimerAggregationTypes"`
 
 	// Default aggregation types for gauge metrics.
-	GaugeAggregationTypes *AggregationTypes `yaml:"gaugeAggregationTypes" validate:"nonzero"`
+	DefaultGaugeAggregationTypes *AggregationTypes `yaml:"defaultGaugeAggregationTypes"`
 }
 
 // NewOptions creates a new Option.
-func (c Configuration) NewOptions() Options {
-	opts := NewOptions()
-	if c.CounterAggregationTypes != nil {
-		opts = opts.SetDefaultCounterAggregationTypes(*c.CounterAggregationTypes)
+func (c AggregationTypesConfiguration) NewOptions() AggregationTypesOptions {
+	opts := NewAggregationTypesOptions()
+	if c.DefaultCounterAggregationTypes != nil {
+		opts = opts.SetDefaultCounterAggregationTypes(*c.DefaultCounterAggregationTypes)
 	}
-	if c.GaugeAggregationTypes != nil {
-		opts = opts.SetDefaultGaugeAggregationTypes(*c.GaugeAggregationTypes)
+	if c.DefaultGaugeAggregationTypes != nil {
+		opts = opts.SetDefaultGaugeAggregationTypes(*c.DefaultGaugeAggregationTypes)
 	}
-	if c.TimerAggregationTypes != nil {
-		opts = opts.SetDefaultTimerAggregationTypes(*c.TimerAggregationTypes)
+	if c.DefaultTimerAggregationTypes != nil {
+		opts = opts.SetDefaultTimerAggregationTypes(*c.DefaultTimerAggregationTypes)
 	}
 	return opts
 }

--- a/policy/aggregation_type_config_test.go
+++ b/policy/aggregation_type_config_test.go
@@ -27,13 +27,13 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
-func TestConfig(t *testing.T) {
+func TestAggregationTypesConfiguration(t *testing.T) {
 	str := `
-gaugeAggregationTypes: Max
-timerAggregationTypes: P50,P99,P9999
+defaultGaugeAggregationTypes: Max
+defaultTimerAggregationTypes: P50,P99,P9999
 `
 
-	var cfg Configuration
+	var cfg AggregationTypesConfiguration
 	require.NoError(t, yaml.Unmarshal([]byte(str), &cfg))
 	opts := cfg.NewOptions()
 	require.Equal(t, defaultDefaultCounterAggregationTypes, opts.DefaultCounterAggregationTypes())

--- a/policy/config.go
+++ b/policy/config.go
@@ -18,29 +18,31 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package matcher
+package policy
 
-import "github.com/m3db/m3metrics/rules"
+// Configuration contains configuration.
+type Configuration struct {
+	// Default aggregation types for counter metrics.
+	CounterAggregationTypes *AggregationTypes `yaml:"counterAggregationTypes" validate:"nonzero"`
 
-// Source is a datasource providing match results.
-type Source interface {
-	// ForwardMatch returns the match result for a given id within time range
-	// [fromNanos, toNanos).
-	ForwardMatch(id []byte, fromNanos, toNanos int64) rules.MatchResult
+	// Default aggregation types for timer metrics.
+	TimerAggregationTypes *AggregationTypes `yaml:"timerAggregationTypes" validate:"nonzero"`
+
+	// Default aggregation types for gauge metrics.
+	GaugeAggregationTypes *AggregationTypes `yaml:"gaugeAggregationTypes" validate:"nonzero"`
 }
 
-// Cache caches the rule matching result associated with metrics.
-type Cache interface {
-	// ForwardMatch returns the rule matching result associated with a metric id
-	// between [fromNanos, toNanos).
-	ForwardMatch(namespace, id []byte, fromNanos, toNanos int64) rules.MatchResult
-
-	// Register sets the result source for a given namespace.
-	Register(namespace []byte, source Source)
-
-	// Unregister deletes the cached results for a given namespace.
-	Unregister(namespace []byte)
-
-	// Close closes the cache.
-	Close() error
+// NewOptions creates a new Option.
+func (c Configuration) NewOptions() Options {
+	opts := NewOptions()
+	if c.CounterAggregationTypes != nil {
+		opts = opts.SetDefaultCounterAggregationTypes(*c.CounterAggregationTypes)
+	}
+	if c.GaugeAggregationTypes != nil {
+		opts = opts.SetDefaultGaugeAggregationTypes(*c.GaugeAggregationTypes)
+	}
+	if c.TimerAggregationTypes != nil {
+		opts = opts.SetDefaultTimerAggregationTypes(*c.TimerAggregationTypes)
+	}
+	return opts
 }

--- a/policy/config_test.go
+++ b/policy/config_test.go
@@ -18,29 +18,25 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package matcher
+package policy
 
-import "github.com/m3db/m3metrics/rules"
+import (
+	"testing"
 
-// Source is a datasource providing match results.
-type Source interface {
-	// ForwardMatch returns the match result for a given id within time range
-	// [fromNanos, toNanos).
-	ForwardMatch(id []byte, fromNanos, toNanos int64) rules.MatchResult
-}
+	"github.com/stretchr/testify/require"
+	yaml "gopkg.in/yaml.v2"
+)
 
-// Cache caches the rule matching result associated with metrics.
-type Cache interface {
-	// ForwardMatch returns the rule matching result associated with a metric id
-	// between [fromNanos, toNanos).
-	ForwardMatch(namespace, id []byte, fromNanos, toNanos int64) rules.MatchResult
+func TestConfig(t *testing.T) {
+	str := `
+gaugeAggregationTypes: Max
+timerAggregationTypes: P50,P99,P9999
+`
 
-	// Register sets the result source for a given namespace.
-	Register(namespace []byte, source Source)
-
-	// Unregister deletes the cached results for a given namespace.
-	Unregister(namespace []byte)
-
-	// Close closes the cache.
-	Close() error
+	var cfg Configuration
+	require.NoError(t, yaml.Unmarshal([]byte(str), &cfg))
+	opts := cfg.NewOptions()
+	require.Equal(t, defaultDefaultCounterAggregationTypes, opts.DefaultCounterAggregationTypes())
+	require.Equal(t, AggregationTypes{Max}, opts.DefaultGaugeAggregationTypes())
+	require.Equal(t, AggregationTypes{P50, P99, P9999}, opts.DefaultTimerAggregationTypes())
 }

--- a/policy/options.go
+++ b/policy/options.go
@@ -1,0 +1,109 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package policy
+
+// Options provides a set of options for
+type Options interface {
+	// SetDefaultCounterAggregationTypes sets the counter aggregation types.
+	SetDefaultCounterAggregationTypes(value AggregationTypes) Options
+
+	// DefaultCounterAggregationTypes returns the aggregation types for counters.
+	DefaultCounterAggregationTypes() AggregationTypes
+
+	// SetDefaultTimerAggregationTypes sets the timer aggregation types.
+	SetDefaultTimerAggregationTypes(value AggregationTypes) Options
+
+	// DefaultTimerAggregationTypes returns the aggregation types for timers.
+	DefaultTimerAggregationTypes() AggregationTypes
+
+	// SetDefaultGaugeAggregationTypes sets the gauge aggregation types.
+	SetDefaultGaugeAggregationTypes(value AggregationTypes) Options
+
+	// DefaultGaugeAggregationTypes returns the aggregation types for gauges.
+	DefaultGaugeAggregationTypes() AggregationTypes
+}
+
+var (
+	defaultDefaultCounterAggregationTypes = AggregationTypes{
+		Sum,
+	}
+	defaultDefaultTimerAggregationTypes = AggregationTypes{
+		Sum,
+		SumSq,
+		Mean,
+		Min,
+		Max,
+		Count,
+		Stdev,
+		Median,
+		P50,
+		P95,
+		P99,
+	}
+	defaultDefaultGaugeAggregationTypes = AggregationTypes{
+		Last,
+	}
+)
+
+type options struct {
+	defaultCounterAggregationTypes AggregationTypes
+	defaultTimerAggregationTypes   AggregationTypes
+	defaultGaugeAggregationTypes   AggregationTypes
+}
+
+// NewOptions returns a default Options.
+func NewOptions() Options {
+	return &options{
+		defaultCounterAggregationTypes: defaultDefaultCounterAggregationTypes,
+		defaultGaugeAggregationTypes:   defaultDefaultGaugeAggregationTypes,
+		defaultTimerAggregationTypes:   defaultDefaultTimerAggregationTypes,
+	}
+}
+
+func (o *options) SetDefaultCounterAggregationTypes(aggTypes AggregationTypes) Options {
+	opts := *o
+	opts.defaultCounterAggregationTypes = aggTypes
+	return &opts
+}
+
+func (o *options) DefaultCounterAggregationTypes() AggregationTypes {
+	return o.defaultCounterAggregationTypes
+}
+
+func (o *options) SetDefaultTimerAggregationTypes(aggTypes AggregationTypes) Options {
+	opts := *o
+	opts.defaultTimerAggregationTypes = aggTypes
+	return &opts
+}
+
+func (o *options) DefaultTimerAggregationTypes() AggregationTypes {
+	return o.defaultTimerAggregationTypes
+}
+
+func (o *options) SetDefaultGaugeAggregationTypes(aggTypes AggregationTypes) Options {
+	opts := *o
+	opts.defaultGaugeAggregationTypes = aggTypes
+	return &opts
+}
+
+func (o *options) DefaultGaugeAggregationTypes() AggregationTypes {
+	return o.defaultGaugeAggregationTypes
+}

--- a/policy/options.go
+++ b/policy/options.go
@@ -20,25 +20,33 @@
 
 package policy
 
-// Options provides a set of options for
-type Options interface {
-	// SetDefaultCounterAggregationTypes sets the counter aggregation types.
-	SetDefaultCounterAggregationTypes(value AggregationTypes) Options
+import (
+	"github.com/m3db/m3metrics/metric"
+)
 
-	// DefaultCounterAggregationTypes returns the aggregation types for counters.
+// AggregationTypesOptions provides a set of options for aggregation types.
+type AggregationTypesOptions interface {
+	// SetDefaultCounterAggregationTypes sets the default aggregation types for counters.
+	SetDefaultCounterAggregationTypes(value AggregationTypes) AggregationTypesOptions
+
+	// DefaultCounterAggregationTypes returns the default aggregation types for counters.
 	DefaultCounterAggregationTypes() AggregationTypes
 
-	// SetDefaultTimerAggregationTypes sets the timer aggregation types.
-	SetDefaultTimerAggregationTypes(value AggregationTypes) Options
+	// SetDefaultTimerAggregationTypes sets the default aggregation types for timers.
+	SetDefaultTimerAggregationTypes(value AggregationTypes) AggregationTypesOptions
 
-	// DefaultTimerAggregationTypes returns the aggregation types for timers.
+	// DefaultTimerAggregationTypes returns the default aggregation types for timers.
 	DefaultTimerAggregationTypes() AggregationTypes
 
-	// SetDefaultGaugeAggregationTypes sets the gauge aggregation types.
-	SetDefaultGaugeAggregationTypes(value AggregationTypes) Options
+	// SetDefaultGaugeAggregationTypes sets the default aggregation types for gauges.
+	SetDefaultGaugeAggregationTypes(value AggregationTypes) AggregationTypesOptions
 
-	// DefaultGaugeAggregationTypes returns the aggregation types for gauges.
+	// DefaultGaugeAggregationTypes returns the default aggregation types for gauges.
 	DefaultGaugeAggregationTypes() AggregationTypes
+
+	// IsContainedInDefaultAggregationTypes checks if the given aggregation type is
+	// contained in the default aggregation types for the metric type.
+	IsContainedInDefaultAggregationTypes(at AggregationType, mt metric.Type) bool
 }
 
 var (
@@ -69,8 +77,8 @@ type options struct {
 	defaultGaugeAggregationTypes   AggregationTypes
 }
 
-// NewOptions returns a default Options.
-func NewOptions() Options {
+// NewAggregationTypesOptions returns a default Options.
+func NewAggregationTypesOptions() AggregationTypesOptions {
 	return &options{
 		defaultCounterAggregationTypes: defaultDefaultCounterAggregationTypes,
 		defaultGaugeAggregationTypes:   defaultDefaultGaugeAggregationTypes,
@@ -78,7 +86,7 @@ func NewOptions() Options {
 	}
 }
 
-func (o *options) SetDefaultCounterAggregationTypes(aggTypes AggregationTypes) Options {
+func (o *options) SetDefaultCounterAggregationTypes(aggTypes AggregationTypes) AggregationTypesOptions {
 	opts := *o
 	opts.defaultCounterAggregationTypes = aggTypes
 	return &opts
@@ -88,7 +96,7 @@ func (o *options) DefaultCounterAggregationTypes() AggregationTypes {
 	return o.defaultCounterAggregationTypes
 }
 
-func (o *options) SetDefaultTimerAggregationTypes(aggTypes AggregationTypes) Options {
+func (o *options) SetDefaultTimerAggregationTypes(aggTypes AggregationTypes) AggregationTypesOptions {
 	opts := *o
 	opts.defaultTimerAggregationTypes = aggTypes
 	return &opts
@@ -98,7 +106,7 @@ func (o *options) DefaultTimerAggregationTypes() AggregationTypes {
 	return o.defaultTimerAggregationTypes
 }
 
-func (o *options) SetDefaultGaugeAggregationTypes(aggTypes AggregationTypes) Options {
+func (o *options) SetDefaultGaugeAggregationTypes(aggTypes AggregationTypes) AggregationTypesOptions {
 	opts := *o
 	opts.defaultGaugeAggregationTypes = aggTypes
 	return &opts
@@ -106,4 +114,18 @@ func (o *options) SetDefaultGaugeAggregationTypes(aggTypes AggregationTypes) Opt
 
 func (o *options) DefaultGaugeAggregationTypes() AggregationTypes {
 	return o.defaultGaugeAggregationTypes
+}
+
+func (o *options) IsContainedInDefaultAggregationTypes(at AggregationType, mt metric.Type) bool {
+	var aggTypes AggregationTypes
+	switch mt {
+	case metric.CounterType:
+		aggTypes = o.DefaultCounterAggregationTypes()
+	case metric.GaugeType:
+		aggTypes = o.DefaultGaugeAggregationTypes()
+	case metric.TimerType:
+		aggTypes = o.DefaultTimerAggregationTypes()
+	}
+
+	return aggTypes.Contains(at)
 }

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -180,6 +180,11 @@ func NewPoliciesFromSchema(policies []*schema.Policy) ([]Policy, error) {
 	return res, nil
 }
 
+// IsDefaultPolicies checks if the policies is default.
+func IsDefaultPolicies(ps []Policy) bool {
+	return len(ps) == 0
+}
+
 // ByResolutionAsc implements the sort.Sort interface to sort
 // policies by resolution in ascending order, finest resolution first.
 // If two policies have the same resolution, the one with longer

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -180,7 +180,7 @@ func NewPoliciesFromSchema(policies []*schema.Policy) ([]Policy, error) {
 	return res, nil
 }
 
-// IsDefaultPolicies checks if the policies is default.
+// IsDefaultPolicies checks if the policies are the default policies.
 func IsDefaultPolicies(ps []Policy) bool {
 	return len(ps) == 0
 }

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -38,8 +38,8 @@ func TestPolicyString(t *testing.T) {
 		expected string
 	}{
 		{p: NewPolicy(NewStoragePolicy(10*time.Second, xtime.Second, time.Hour), DefaultAggregationID), expected: "10s@1s:1h0m0s"},
-		{p: NewPolicy(NewStoragePolicy(time.Minute, xtime.Minute, 12*time.Hour), mustCompress(Mean, P999)), expected: "1m0s@1m:12h0m0s|Mean,P999"},
-		{p: NewPolicy(NewStoragePolicy(time.Minute, xtime.Minute, 12*time.Hour), mustCompress(Mean)), expected: "1m0s@1m:12h0m0s|Mean"},
+		{p: NewPolicy(NewStoragePolicy(time.Minute, xtime.Minute, 12*time.Hour), MustCompressAggregationTypes(Mean, P999)), expected: "1m0s@1m:12h0m0s|Mean,P999"},
+		{p: NewPolicy(NewStoragePolicy(time.Minute, xtime.Minute, 12*time.Hour), MustCompressAggregationTypes(Mean)), expected: "1m0s@1m:12h0m0s|Mean"},
 	}
 	for _, input := range inputs {
 		require.Equal(t, input.expected, input.p.String())
@@ -57,19 +57,19 @@ func TestPolicyUnmarshalYAML(t *testing.T) {
 		},
 		{
 			str:      "10s:1d|Mean",
-			expected: NewPolicy(NewStoragePolicy(10*time.Second, xtime.Second, 24*time.Hour), mustCompress(Mean)),
+			expected: NewPolicy(NewStoragePolicy(10*time.Second, xtime.Second, 24*time.Hour), MustCompressAggregationTypes(Mean)),
 		},
 		{
 			str:      "60s:24h|Mean,Count",
-			expected: NewPolicy(NewStoragePolicy(time.Minute, xtime.Minute, 24*time.Hour), mustCompress(Mean, Count)),
+			expected: NewPolicy(NewStoragePolicy(time.Minute, xtime.Minute, 24*time.Hour), MustCompressAggregationTypes(Mean, Count)),
 		},
 		{
 			str:      "1m:1d|Count,Mean",
-			expected: NewPolicy(NewStoragePolicy(time.Minute, xtime.Minute, 24*time.Hour), mustCompress(Mean, Count)),
+			expected: NewPolicy(NewStoragePolicy(time.Minute, xtime.Minute, 24*time.Hour), MustCompressAggregationTypes(Mean, Count)),
 		},
 		{
 			str:      "1s@1s:1h|P999,P9999",
-			expected: NewPolicy(NewStoragePolicy(time.Second, xtime.Second, time.Hour), mustCompress(P999, P9999)),
+			expected: NewPolicy(NewStoragePolicy(time.Second, xtime.Second, time.Hour), MustCompressAggregationTypes(P999, P9999)),
 		},
 	}
 	for _, input := range inputs {
@@ -133,8 +133,8 @@ func TestNewPoliciesFromSchema(t *testing.T) {
 	res, err := NewPoliciesFromSchema(input)
 	require.NoError(t, err)
 	require.Equal(t, []Policy{
-		NewPolicy(NewStoragePolicy(10*time.Second, xtime.Second, 24*time.Hour), mustCompress(Mean, P999)),
-		NewPolicy(NewStoragePolicy(time.Minute, xtime.Minute, 240*time.Hour), mustCompress(Mean, P9999)),
+		NewPolicy(NewStoragePolicy(10*time.Second, xtime.Second, 24*time.Hour), MustCompressAggregationTypes(Mean, P999)),
+		NewPolicy(NewStoragePolicy(time.Minute, xtime.Minute, 240*time.Hour), MustCompressAggregationTypes(Mean, P9999)),
 	}, res)
 }
 

--- a/policy/staged_policy.go
+++ b/policy/staged_policy.go
@@ -95,7 +95,7 @@ func (p StagedPolicies) String() string {
 }
 
 func (p StagedPolicies) hasDefaultPolicies() bool {
-	return len(p.policies) == 0
+	return IsDefaultPolicies(p.policies)
 }
 
 // MarshalJSON returns the JSON encoding of staged policies.

--- a/policy/staged_policy_test.go
+++ b/policy/staged_policy_test.go
@@ -63,10 +63,10 @@ func TestStagedPoliciesSamePoliciesDefaultPolicies(t *testing.T) {
 		{
 			sp: [2]StagedPolicies{
 				NewStagedPolicies(0, false, []Policy{
-					NewPolicy(NewStoragePolicy(10*time.Second, xtime.Second, 6*time.Hour), mustCompress(Min, Max)),
+					NewPolicy(NewStoragePolicy(10*time.Second, xtime.Second, 6*time.Hour), MustCompressAggregationTypes(Min, Max)),
 				}),
 				NewStagedPolicies(0, false, []Policy{
-					NewPolicy(NewStoragePolicy(10*time.Second, xtime.Second, 6*time.Hour), mustCompress(Max, Min)),
+					NewPolicy(NewStoragePolicy(10*time.Second, xtime.Second, 6*time.Hour), MustCompressAggregationTypes(Max, Min)),
 				}),
 			},
 			expected: true,
@@ -74,10 +74,10 @@ func TestStagedPoliciesSamePoliciesDefaultPolicies(t *testing.T) {
 		{
 			sp: [2]StagedPolicies{
 				NewStagedPolicies(0, false, []Policy{
-					NewPolicy(NewStoragePolicy(10*time.Second, xtime.Second, 6*time.Hour), mustCompress(Max)),
+					NewPolicy(NewStoragePolicy(10*time.Second, xtime.Second, 6*time.Hour), MustCompressAggregationTypes(Max)),
 				}),
 				NewStagedPolicies(0, false, []Policy{
-					NewPolicy(NewStoragePolicy(10*time.Second, xtime.Second, 6*time.Hour), mustCompress(Last)),
+					NewPolicy(NewStoragePolicy(10*time.Second, xtime.Second, 6*time.Hour), MustCompressAggregationTypes(Last)),
 				}),
 			},
 			expected: false,
@@ -85,10 +85,10 @@ func TestStagedPoliciesSamePoliciesDefaultPolicies(t *testing.T) {
 		{
 			sp: [2]StagedPolicies{
 				NewStagedPolicies(0, false, []Policy{
-					NewPolicy(NewStoragePolicy(10*time.Second, xtime.Second, 6*time.Hour), mustCompress(Max)),
+					NewPolicy(NewStoragePolicy(10*time.Second, xtime.Second, 6*time.Hour), MustCompressAggregationTypes(Max)),
 				}),
 				NewStagedPolicies(0, false, []Policy{
-					NewPolicy(NewStoragePolicy(10*time.Second, xtime.Second, 6*time.Hour), mustCompress(Max, Min)),
+					NewPolicy(NewStoragePolicy(10*time.Second, xtime.Second, 6*time.Hour), MustCompressAggregationTypes(Max, Min)),
 				}),
 			},
 			expected: false,
@@ -234,14 +234,14 @@ func TestPoliciesListJSONMarshaling(t *testing.T) {
 					false,
 					[]Policy{
 						NewPolicy(NewStoragePolicy(10*time.Second, xtime.Second, 6*time.Hour), DefaultAggregationID),
-						NewPolicy(NewStoragePolicy(time.Minute, xtime.Minute, 24*time.Hour), mustCompress(Count, Mean)),
+						NewPolicy(NewStoragePolicy(time.Minute, xtime.Minute, 24*time.Hour), MustCompressAggregationTypes(Count, Mean)),
 					},
 				),
 				NewStagedPolicies(
 					100,
 					true,
 					[]Policy{
-						NewPolicy(NewStoragePolicy(10*time.Second, xtime.Second, 6*time.Hour), mustCompress(Sum)),
+						NewPolicy(NewStoragePolicy(10*time.Second, xtime.Second, 6*time.Hour), MustCompressAggregationTypes(Sum)),
 					},
 				),
 				NewStagedPolicies(

--- a/rules/options.go
+++ b/rules/options.go
@@ -46,24 +46,24 @@ type Options interface {
 	// IsRollupIDFn returns the function that determines whether an id is a rollup id.
 	IsRollupIDFn() id.MatchIDFn
 
-	// SetPolicyOptions sets the policy options.
-	SetPolicyOptions(v policy.Options) Options
+	// SetAggregationTypesOptions sets the aggregation types options.
+	SetAggregationTypesOptions(v policy.AggregationTypesOptions) Options
 
-	// PolicyOptions returns the policy options.
-	PolicyOptions() policy.Options
+	// PolicyOptions returns the aggregation types options.
+	AggregationTypesOptions() policy.AggregationTypesOptions
 }
 
 type options struct {
 	tagsFilterOpts filters.TagsFilterOptions
 	newRollupIDFn  id.NewIDFn
 	isRollupIDFn   id.MatchIDFn
-	pOpts          policy.Options
+	aggOpts        policy.AggregationTypesOptions
 }
 
 // NewOptions creates a new set of options.
 func NewOptions() Options {
 	return &options{
-		pOpts: policy.NewOptions(),
+		aggOpts: policy.NewAggregationTypesOptions(),
 	}
 }
 
@@ -97,12 +97,12 @@ func (o *options) IsRollupIDFn() id.MatchIDFn {
 	return o.isRollupIDFn
 }
 
-func (o *options) SetPolicyOptions(value policy.Options) Options {
+func (o *options) SetAggregationTypesOptions(value policy.AggregationTypesOptions) Options {
 	opts := *o
-	opts.pOpts = value
+	opts.aggOpts = value
 	return &opts
 }
 
-func (o *options) PolicyOptions() policy.Options {
-	return o.pOpts
+func (o *options) AggregationTypesOptions() policy.AggregationTypesOptions {
+	return o.aggOpts
 }

--- a/rules/options.go
+++ b/rules/options.go
@@ -57,13 +57,13 @@ type options struct {
 	tagsFilterOpts filters.TagsFilterOptions
 	newRollupIDFn  id.NewIDFn
 	isRollupIDFn   id.MatchIDFn
-	aggOpts        policy.AggregationTypesOptions
+	aggTypesOpts   policy.AggregationTypesOptions
 }
 
 // NewOptions creates a new set of options.
 func NewOptions() Options {
 	return &options{
-		aggOpts: policy.NewAggregationTypesOptions(),
+		aggTypesOpts: policy.NewAggregationTypesOptions(),
 	}
 }
 
@@ -99,10 +99,10 @@ func (o *options) IsRollupIDFn() id.MatchIDFn {
 
 func (o *options) SetAggregationTypesOptions(value policy.AggregationTypesOptions) Options {
 	opts := *o
-	opts.aggOpts = value
+	opts.aggTypesOpts = value
 	return &opts
 }
 
 func (o *options) AggregationTypesOptions() policy.AggregationTypesOptions {
-	return o.aggOpts
+	return o.aggTypesOpts
 }

--- a/rules/options.go
+++ b/rules/options.go
@@ -23,6 +23,7 @@ package rules
 import (
 	"github.com/m3db/m3metrics/filters"
 	"github.com/m3db/m3metrics/metric/id"
+	"github.com/m3db/m3metrics/policy"
 )
 
 // Options provide a set of options for rule matching.
@@ -44,17 +45,26 @@ type Options interface {
 
 	// IsRollupIDFn returns the function that determines whether an id is a rollup id.
 	IsRollupIDFn() id.MatchIDFn
+
+	// SetPolicyOptions sets the policy options.
+	SetPolicyOptions(v policy.Options) Options
+
+	// PolicyOptions returns the policy options.
+	PolicyOptions() policy.Options
 }
 
 type options struct {
 	tagsFilterOpts filters.TagsFilterOptions
 	newRollupIDFn  id.NewIDFn
 	isRollupIDFn   id.MatchIDFn
+	pOpts          policy.Options
 }
 
 // NewOptions creates a new set of options.
 func NewOptions() Options {
-	return &options{}
+	return &options{
+		pOpts: policy.NewOptions(),
+	}
 }
 
 func (o *options) SetTagsFilterOptions(value filters.TagsFilterOptions) Options {
@@ -85,4 +95,14 @@ func (o *options) SetIsRollupIDFn(value id.MatchIDFn) Options {
 
 func (o *options) IsRollupIDFn() id.MatchIDFn {
 	return o.isRollupIDFn
+}
+
+func (o *options) SetPolicyOptions(value policy.Options) Options {
+	opts := *o
+	opts.pOpts = value
+	return &opts
+}
+
+func (o *options) PolicyOptions() policy.Options {
+	return o.pOpts
 }

--- a/rules/ruleset.go
+++ b/rules/ruleset.go
@@ -70,7 +70,7 @@ type activeRuleSet struct {
 	tagFilterOpts   filters.TagsFilterOptions
 	newRollupIDFn   metricID.NewIDFn
 	isRollupIDFn    metricID.MatchIDFn
-	aggOpts         policy.AggregationTypesOptions
+	aggTypeOpts     policy.AggregationTypesOptions
 }
 
 func newActiveRuleSet(
@@ -108,7 +108,7 @@ func newActiveRuleSet(
 		tagFilterOpts:   tagFilterOpts,
 		newRollupIDFn:   newRollupIDFn,
 		isRollupIDFn:    isRollupIDFn,
-		aggOpts:         aggOpts,
+		aggTypeOpts:     aggOpts,
 	}
 }
 
@@ -239,7 +239,7 @@ func (as *activeRuleSet) reverseMappingsForRollupID(
 				copy(policies, target.Policies)
 				resolved := resolvePolicies(policies)
 				// Filter the each policy by the aggregation type.
-				filtered, _ := filterPoliciesWithAggregationTypes(resolved, mt, at, as.aggOpts)
+				filtered, _ := filterPoliciesWithAggregationTypes(resolved, mt, at, as.aggTypeOpts)
 				if len(filtered) == 0 {
 					return policy.DefaultStagedPolicies, false
 				}
@@ -260,7 +260,7 @@ func (as *activeRuleSet) reverseMappingsForNonRollupID(
 	policies, cutoverNanos := as.mappingsForNonRollupID(id, timeNanos)
 	// NB(cw) aggregation types filter must be applied after the policy list is resolved.
 	// Because policies like [1m:40h|P90,P99; 1m:20h|P50] will be resolved to [1m:40h|P50,P90,P99].
-	filtered, isDefault := filterPoliciesWithAggregationTypes(policies, mt, at, as.aggOpts)
+	filtered, isDefault := filterPoliciesWithAggregationTypes(policies, mt, at, as.aggTypeOpts)
 	if cutoverNanos == 0 && isDefault {
 		return policy.DefaultStagedPolicies, true
 	}

--- a/rules/ruleset_test.go
+++ b/rules/ruleset_test.go
@@ -22,17 +22,18 @@ package rules
 
 import (
 	"bytes"
+	"math"
 	"testing"
 	"time"
 
 	"github.com/m3db/m3metrics/filters"
 	"github.com/m3db/m3metrics/generated/proto/schema"
+	"github.com/m3db/m3metrics/metric"
 	"github.com/m3db/m3metrics/metric/id"
 	"github.com/m3db/m3metrics/policy"
 	xtime "github.com/m3db/m3x/time"
 
 	"github.com/stretchr/testify/require"
-	yaml "gopkg.in/yaml.v2"
 )
 
 var (
@@ -48,46 +49,12 @@ var (
 	testUser = "test_user"
 )
 
-func TestMatchModeUnmarshalYAML(t *testing.T) {
-	inputs := []struct {
-		str         string
-		expected    MatchMode
-		expectedErr bool
-	}{
-		{
-			str:      "forward",
-			expected: ForwardMatch,
-		},
-		{
-			str:      "reverse",
-			expected: ReverseMatch,
-		},
-		{
-			str:         "bad",
-			expectedErr: true,
-		},
-	}
-	for _, input := range inputs {
-		var m MatchMode
-		err := yaml.Unmarshal([]byte(input.str), &m)
-
-		if input.expectedErr {
-			require.Error(t, err)
-			continue
-		}
-
-		require.NoError(t, err)
-		require.Equal(t, input.expected, m)
-	}
-}
-
-func TestActiveRuleSetMappingPoliciesForNonRollupID(t *testing.T) {
+func TestActiveRuleSetForwardMappingPoliciesForNonRollupID(t *testing.T) {
 	inputs := []testMappingsData{
 		{
 			id:            "mtagName1=mtagValue1",
 			matchFrom:     25000,
 			matchTo:       25001,
-			matchMode:     ForwardMatch,
 			expireAtNanos: 30000,
 			result: policy.PoliciesList{
 				policy.NewStagedPolicies(
@@ -106,7 +73,6 @@ func TestActiveRuleSetMappingPoliciesForNonRollupID(t *testing.T) {
 			id:            "mtagName1=mtagValue1",
 			matchFrom:     35000,
 			matchTo:       35001,
-			matchMode:     ForwardMatch,
 			expireAtNanos: 100000,
 			result: policy.PoliciesList{
 				policy.NewStagedPolicies(
@@ -124,7 +90,6 @@ func TestActiveRuleSetMappingPoliciesForNonRollupID(t *testing.T) {
 			id:            "mtagName1=mtagValue2",
 			matchFrom:     25000,
 			matchTo:       25001,
-			matchMode:     ForwardMatch,
 			expireAtNanos: 30000,
 			result: policy.PoliciesList{
 				policy.NewStagedPolicies(
@@ -140,7 +105,6 @@ func TestActiveRuleSetMappingPoliciesForNonRollupID(t *testing.T) {
 			id:            "mtagName1=mtagValue3",
 			matchFrom:     25000,
 			matchTo:       25001,
-			matchMode:     ForwardMatch,
 			expireAtNanos: 30000,
 			result:        policy.DefaultPoliciesList,
 		},
@@ -148,7 +112,6 @@ func TestActiveRuleSetMappingPoliciesForNonRollupID(t *testing.T) {
 			id:            "mtagName1=mtagValue1",
 			matchFrom:     10000,
 			matchTo:       40000,
-			matchMode:     ForwardMatch,
 			expireAtNanos: 100000,
 			result: policy.PoliciesList{
 				policy.NewStagedPolicies(
@@ -210,7 +173,6 @@ func TestActiveRuleSetMappingPoliciesForNonRollupID(t *testing.T) {
 			id:            "mtagName1=mtagValue2",
 			matchFrom:     10000,
 			matchTo:       40000,
-			matchMode:     ForwardMatch,
 			expireAtNanos: 100000,
 			result: policy.PoliciesList{
 				policy.DefaultStagedPolicies,
@@ -233,24 +195,230 @@ func TestActiveRuleSetMappingPoliciesForNonRollupID(t *testing.T) {
 		testTagsFilterOptions(),
 		mockNewID,
 		nil,
+		policy.NewOptions(),
 	)
 	expectedCutovers := []int64{10000, 15000, 20000, 22000, 24000, 30000, 34000, 35000, 100000}
 	require.Equal(t, expectedCutovers, as.cutoverTimesAsc)
 	for _, input := range inputs {
-		res := as.MatchAll(b(input.id), input.matchFrom, input.matchTo, input.matchMode)
+		res := as.ForwardMatch(b(input.id), input.matchFrom, input.matchTo)
 		require.Equal(t, input.expireAtNanos, res.expireAtNanos)
 		require.Equal(t, input.result, res.MappingsAt(0))
 	}
 }
 
-func TestActiveRuleSetMappingPoliciesForRollupID(t *testing.T) {
+func TestActiveRuleSetReverseMappingPoliciesForNonRollupID(t *testing.T) {
 	inputs := []testMappingsData{
 		{
-			id:            "rName4|rtagName1=rtagValue2",
-			matchFrom:     25000,
-			matchTo:       25001,
-			matchMode:     ReverseMatch,
-			expireAtNanos: 30000,
+			id:              "mtagName1=mtagValue1",
+			matchFrom:       25000,
+			matchTo:         25001,
+			expireAtNanos:   30000,
+			metricType:      metric.CounterType,
+			aggregationType: policy.Sum,
+			result: policy.PoliciesList{
+				policy.NewStagedPolicies(
+					22000,
+					false,
+					[]policy.Policy{
+						policy.NewPolicy(policy.NewStoragePolicy(10*time.Second, xtime.Second, 12*time.Hour), policy.DefaultAggregationID),
+						policy.NewPolicy(policy.NewStoragePolicy(time.Minute, xtime.Minute, 24*time.Hour), policy.DefaultAggregationID),
+						policy.NewPolicy(policy.NewStoragePolicy(5*time.Minute, xtime.Minute, 48*time.Hour), policy.DefaultAggregationID),
+						policy.NewPolicy(policy.NewStoragePolicy(10*time.Minute, xtime.Minute, 48*time.Hour), policy.DefaultAggregationID),
+					},
+				),
+			},
+		},
+		{
+			id:              "mtagName1=mtagValue1",
+			matchFrom:       35000,
+			matchTo:         35001,
+			expireAtNanos:   100000,
+			metricType:      metric.CounterType,
+			aggregationType: policy.Sum,
+			result: policy.PoliciesList{
+				policy.NewStagedPolicies(
+					35000,
+					false,
+					[]policy.Policy{
+						policy.NewPolicy(policy.NewStoragePolicy(10*time.Second, xtime.Second, 2*time.Hour), policy.DefaultAggregationID),
+						policy.NewPolicy(policy.NewStoragePolicy(30*time.Second, xtime.Second, 6*time.Hour), policy.DefaultAggregationID),
+						policy.NewPolicy(policy.NewStoragePolicy(time.Minute, xtime.Minute, time.Hour), policy.DefaultAggregationID),
+					},
+				),
+			},
+		},
+		{
+			id:              "mtagName1=mtagValue2",
+			matchFrom:       25000,
+			matchTo:         25001,
+			expireAtNanos:   30000,
+			metricType:      metric.CounterType,
+			aggregationType: policy.Sum,
+			result: policy.PoliciesList{
+				policy.NewStagedPolicies(
+					24000,
+					false,
+					[]policy.Policy{
+						policy.NewPolicy(policy.NewStoragePolicy(10*time.Second, xtime.Second, 24*time.Hour), policy.DefaultAggregationID),
+					},
+				),
+			},
+		},
+		{
+			id:              "mtagName1=mtagValue3",
+			matchFrom:       25000,
+			matchTo:         25001,
+			expireAtNanos:   30000,
+			metricType:      metric.CounterType,
+			aggregationType: policy.Sum,
+			result:          policy.DefaultPoliciesList,
+		},
+		{
+			id:              "mtagName1=mtagValue3",
+			matchFrom:       25000,
+			matchTo:         25001,
+			expireAtNanos:   30000,
+			metricType:      metric.CounterType,
+			aggregationType: policy.Min,
+			result:          nil,
+		},
+		{
+			id:              "mtagName1=mtagValue1",
+			matchFrom:       10000,
+			matchTo:         12000,
+			expireAtNanos:   15000,
+			metricType:      metric.CounterType,
+			aggregationType: policy.Sum,
+			result:          nil,
+		},
+		{
+			id:              "mtagName1=mtagValue1",
+			matchFrom:       10000,
+			matchTo:         21000,
+			expireAtNanos:   22000,
+			metricType:      metric.CounterType,
+			aggregationType: policy.Sum,
+			result: policy.PoliciesList{
+				policy.NewStagedPolicies(
+					20000,
+					false,
+					[]policy.Policy{
+						policy.NewPolicy(policy.NewStoragePolicy(5*time.Minute, xtime.Minute, 48*time.Hour), policy.DefaultAggregationID),
+						policy.NewPolicy(policy.NewStoragePolicy(10*time.Minute, xtime.Minute, 48*time.Hour), policy.DefaultAggregationID),
+					},
+				),
+			},
+		},
+		{
+			id:              "mtagName1=mtagValue1",
+			matchFrom:       10000,
+			matchTo:         40000,
+			expireAtNanos:   100000,
+			metricType:      metric.TimerType,
+			aggregationType: policy.Count,
+			result: policy.PoliciesList{
+				policy.NewStagedPolicies(
+					10000,
+					false,
+					[]policy.Policy{
+						policy.NewPolicy(policy.NewStoragePolicy(10*time.Second, xtime.Second, 24*time.Hour), compressedCount),
+					},
+				),
+				policy.NewStagedPolicies(
+					15000,
+					false,
+					[]policy.Policy{
+						// different policies same resolution, merge aggregation types
+						policy.NewPolicy(policy.NewStoragePolicy(10*time.Second, xtime.Second, 24*time.Hour), compressedCountAndMean),
+					},
+				),
+				policy.NewStagedPolicies(
+					20000,
+					false,
+					[]policy.Policy{
+						policy.NewPolicy(policy.NewStoragePolicy(5*time.Minute, xtime.Minute, 48*time.Hour), policy.DefaultAggregationID),
+						policy.NewPolicy(policy.NewStoragePolicy(10*time.Minute, xtime.Minute, 48*time.Hour), policy.DefaultAggregationID),
+					},
+				),
+				policy.NewStagedPolicies(
+					22000,
+					false,
+					[]policy.Policy{
+						policy.NewPolicy(policy.NewStoragePolicy(10*time.Second, xtime.Second, 12*time.Hour), policy.DefaultAggregationID),
+						policy.NewPolicy(policy.NewStoragePolicy(time.Minute, xtime.Minute, 24*time.Hour), policy.DefaultAggregationID),
+						policy.NewPolicy(policy.NewStoragePolicy(5*time.Minute, xtime.Minute, 48*time.Hour), policy.DefaultAggregationID),
+						policy.NewPolicy(policy.NewStoragePolicy(10*time.Minute, xtime.Minute, 48*time.Hour), policy.DefaultAggregationID),
+					},
+				),
+				policy.NewStagedPolicies(
+					30000,
+					false,
+					[]policy.Policy{
+						policy.NewPolicy(policy.NewStoragePolicy(10*time.Second, xtime.Second, 12*time.Hour), policy.DefaultAggregationID),
+						policy.NewPolicy(policy.NewStoragePolicy(30*time.Second, xtime.Second, 6*time.Hour), policy.DefaultAggregationID),
+						policy.NewPolicy(policy.NewStoragePolicy(time.Minute, xtime.Minute, 24*time.Hour), policy.DefaultAggregationID),
+						policy.NewPolicy(policy.NewStoragePolicy(5*time.Minute, xtime.Minute, 48*time.Hour), policy.DefaultAggregationID),
+					},
+				),
+				policy.NewStagedPolicies(
+					34000,
+					false,
+					[]policy.Policy{
+						policy.NewPolicy(policy.NewStoragePolicy(10*time.Second, xtime.Second, 2*time.Hour), policy.DefaultAggregationID),
+						policy.NewPolicy(policy.NewStoragePolicy(30*time.Second, xtime.Second, 6*time.Hour), policy.DefaultAggregationID),
+						policy.NewPolicy(policy.NewStoragePolicy(time.Minute, xtime.Minute, time.Hour), policy.DefaultAggregationID),
+					},
+				),
+			},
+		},
+		{
+			id:              "mtagName1=mtagValue2",
+			matchFrom:       10000,
+			matchTo:         40000,
+			expireAtNanos:   100000,
+			metricType:      metric.CounterType,
+			aggregationType: policy.Sum,
+			result: policy.PoliciesList{
+				policy.DefaultStagedPolicies,
+				policy.NewStagedPolicies(
+					24000,
+					false,
+					[]policy.Policy{
+						policy.NewPolicy(policy.NewStoragePolicy(10*time.Second, xtime.Second, 24*time.Hour), policy.DefaultAggregationID),
+					},
+				),
+			},
+		},
+	}
+
+	mappingRules := testMappingRules(t)
+	as := newActiveRuleSet(
+		0,
+		mappingRules,
+		nil,
+		testTagsFilterOptions(),
+		mockNewID,
+		func([]byte, []byte) bool { return false },
+		policy.NewOptions(),
+	)
+	expectedCutovers := []int64{10000, 15000, 20000, 22000, 24000, 30000, 34000, 35000, 100000}
+	require.Equal(t, expectedCutovers, as.cutoverTimesAsc)
+	for _, input := range inputs {
+		res := as.ReverseMatch(b(input.id), input.matchFrom, input.matchTo, input.metricType, input.aggregationType)
+		require.Equal(t, input.expireAtNanos, res.expireAtNanos)
+		require.Equal(t, input.result, res.MappingsAt(0))
+	}
+}
+
+func TestActiveRuleSetReverseMappingPoliciesForRollupID(t *testing.T) {
+	inputs := []testMappingsData{
+		{
+			id:              "rName4|rtagName1=rtagValue2",
+			matchFrom:       25000,
+			matchTo:         25001,
+			expireAtNanos:   30000,
+			metricType:      metric.CounterType,
+			aggregationType: policy.Sum,
 			result: policy.PoliciesList{
 				policy.NewStagedPolicies(
 					24000,
@@ -262,28 +430,99 @@ func TestActiveRuleSetMappingPoliciesForRollupID(t *testing.T) {
 			},
 		},
 		{
-			id:            "rName4|rtagName2=rtagValue2",
-			matchFrom:     25000,
-			matchTo:       25001,
-			matchMode:     ReverseMatch,
-			expireAtNanos: 30000,
-			result:        nil,
+			id:              "rName4|rtagName1=rtagValue2",
+			matchFrom:       25000,
+			matchTo:         25001,
+			expireAtNanos:   30000,
+			metricType:      metric.CounterType,
+			aggregationType: policy.Min,
+			result:          nil,
+		},
+		{
+			id:              "rName4|rtagName1=rtagValue2",
+			matchFrom:       25000,
+			matchTo:         25001,
+			expireAtNanos:   30000,
+			metricType:      metric.UnknownType,
+			aggregationType: policy.Unknown,
+			result:          nil,
+		},
+		{
+			id:              "rName4|rtagName1=rtagValue2",
+			matchFrom:       25000,
+			matchTo:         25001,
+			expireAtNanos:   30000,
+			metricType:      metric.TimerType,
+			aggregationType: policy.P99,
+			result: policy.PoliciesList{
+				policy.NewStagedPolicies(
+					24000,
+					false,
+					[]policy.Policy{
+						policy.NewPolicy(policy.NewStoragePolicy(time.Second, xtime.Second, time.Minute), policy.DefaultAggregationID),
+					},
+				),
+			},
+		},
+		{
+			id:              "rName4|rtagName2=rtagValue2",
+			matchFrom:       25000,
+			matchTo:         25001,
+			expireAtNanos:   30000,
+			metricType:      metric.CounterType,
+			aggregationType: policy.Sum,
+			result:          nil,
 		},
 		{
 			id:            "rName4|rtagName1=rtagValue2",
 			matchFrom:     10000,
 			matchTo:       10001,
-			matchMode:     ReverseMatch,
 			expireAtNanos: 15000,
 			result:        nil,
 		},
 		{
-			id:            "rName3|rtagName1=rtagValue2",
-			matchFrom:     25000,
-			matchTo:       25001,
-			matchMode:     ReverseMatch,
-			expireAtNanos: 30000,
-			result:        nil,
+			id:              "rName5|rtagName1=rtagValue2",
+			matchFrom:       130000,
+			matchTo:         130001,
+			expireAtNanos:   math.MaxInt64,
+			metricType:      metric.TimerType,
+			aggregationType: policy.P99,
+			result: policy.PoliciesList{
+				policy.NewStagedPolicies(
+					120000,
+					false,
+					[]policy.Policy{
+						policy.NewPolicy(policy.NewStoragePolicy(time.Second, xtime.Second, time.Hour), policy.MustCompressAggregationTypes(policy.Sum, policy.P90, policy.P99)),
+						policy.NewPolicy(policy.NewStoragePolicy(time.Minute, xtime.Second, 10*time.Hour), policy.MustCompressAggregationTypes(policy.Sum, policy.P99)),
+					},
+				),
+			},
+		},
+		{
+			id:              "rName5|rtagName1=rtagValue2",
+			matchFrom:       130000,
+			matchTo:         130001,
+			expireAtNanos:   math.MaxInt64,
+			metricType:      metric.TimerType,
+			aggregationType: policy.P90,
+			result: policy.PoliciesList{
+				policy.NewStagedPolicies(
+					120000,
+					false,
+					[]policy.Policy{
+						policy.NewPolicy(policy.NewStoragePolicy(time.Second, xtime.Second, time.Hour), policy.MustCompressAggregationTypes(policy.Sum, policy.P90, policy.P99)),
+					},
+				),
+			},
+		},
+		{
+			id:              "rName5|rtagName1=rtagValue2",
+			matchFrom:       130000,
+			matchTo:         130001,
+			expireAtNanos:   math.MaxInt64,
+			metricType:      metric.GaugeType,
+			aggregationType: policy.Last,
+			result:          nil,
 		},
 	}
 
@@ -295,11 +534,12 @@ func TestActiveRuleSetMappingPoliciesForRollupID(t *testing.T) {
 		testTagsFilterOptions(),
 		mockNewID,
 		func([]byte, []byte) bool { return true },
+		policy.NewOptions(),
 	)
-	expectedCutovers := []int64{10000, 15000, 20000, 22000, 24000, 30000, 34000, 35000, 38000, 100000}
+	expectedCutovers := []int64{10000, 15000, 20000, 22000, 24000, 30000, 34000, 35000, 38000, 100000, 120000}
 	require.Equal(t, expectedCutovers, as.cutoverTimesAsc)
 	for _, input := range inputs {
-		res := as.MatchAll(b(input.id), input.matchFrom, input.matchTo, input.matchMode)
+		res := as.ReverseMatch(b(input.id), input.matchFrom, input.matchTo, input.metricType, input.aggregationType)
 		require.Equal(t, input.expireAtNanos, res.expireAtNanos)
 		require.Equal(t, input.result, res.MappingsAt(0))
 		require.Nil(t, res.rollups)
@@ -312,7 +552,6 @@ func TestActiveRuleSetRollupResults(t *testing.T) {
 			id:            "rtagName1=rtagValue1,rtagName2=rtagValue2,rtagName3=rtagValue3",
 			matchFrom:     25000,
 			matchTo:       25001,
-			matchMode:     ForwardMatch,
 			expireAtNanos: 30000,
 			result: []RollupResult{
 				{
@@ -348,7 +587,6 @@ func TestActiveRuleSetRollupResults(t *testing.T) {
 			id:            "rtagName1=rtagValue2",
 			matchFrom:     25000,
 			matchTo:       25001,
-			matchMode:     ForwardMatch,
 			expireAtNanos: 30000,
 			result: []RollupResult{
 				{
@@ -369,7 +607,6 @@ func TestActiveRuleSetRollupResults(t *testing.T) {
 			id:            "rtagName5=rtagValue5",
 			matchFrom:     25000,
 			matchTo:       25001,
-			matchMode:     ForwardMatch,
 			expireAtNanos: 30000,
 			result:        []RollupResult{},
 		},
@@ -377,7 +614,6 @@ func TestActiveRuleSetRollupResults(t *testing.T) {
 			id:            "rtagName1=rtagValue1,rtagName2=rtagValue2,rtagName3=rtagValue3",
 			matchFrom:     10000,
 			matchTo:       40000,
-			matchMode:     ForwardMatch,
 			expireAtNanos: 100000,
 			result: []RollupResult{
 				{
@@ -477,11 +713,12 @@ func TestActiveRuleSetRollupResults(t *testing.T) {
 		testTagsFilterOptions(),
 		mockNewID,
 		nil,
+		policy.NewOptions(),
 	)
-	expectedCutovers := []int64{10000, 15000, 20000, 22000, 24000, 30000, 34000, 35000, 38000, 100000}
+	expectedCutovers := []int64{10000, 15000, 20000, 22000, 24000, 30000, 34000, 35000, 38000, 100000, 120000}
 	require.Equal(t, expectedCutovers, as.cutoverTimesAsc)
 	for _, input := range inputs {
-		res := as.MatchAll(b(input.id), input.matchFrom, input.matchTo, input.matchMode)
+		res := as.ForwardMatch(b(input.id), input.matchFrom, input.matchTo)
 		require.Equal(t, input.expireAtNanos, res.expireAtNanos)
 		require.Equal(t, len(input.result), res.NumRollups())
 		for i := 0; i < len(input.result); i++ {
@@ -560,7 +797,6 @@ func TestRuleSetActiveSet(t *testing.T) {
 					id:            "mtagName1=mtagValue1",
 					matchFrom:     25000,
 					matchTo:       25001,
-					matchMode:     ForwardMatch,
 					expireAtNanos: 30000,
 					result: policy.PoliciesList{
 						policy.NewStagedPolicies(
@@ -580,7 +816,6 @@ func TestRuleSetActiveSet(t *testing.T) {
 					id:            "mtagName1=mtagValue1",
 					matchFrom:     35000,
 					matchTo:       35001,
-					matchMode:     ForwardMatch,
 					expireAtNanos: 100000,
 					result: policy.PoliciesList{
 						policy.NewStagedPolicies(
@@ -598,7 +833,6 @@ func TestRuleSetActiveSet(t *testing.T) {
 					id:            "mtagName1=mtagValue2",
 					matchFrom:     25000,
 					matchTo:       25001,
-					matchMode:     ForwardMatch,
 					expireAtNanos: 30000,
 					result: policy.PoliciesList{
 						policy.NewStagedPolicies(
@@ -614,7 +848,6 @@ func TestRuleSetActiveSet(t *testing.T) {
 					id:            "mtagName1=mtagValue3",
 					matchFrom:     25000,
 					matchTo:       25001,
-					matchMode:     ForwardMatch,
 					expireAtNanos: 30000,
 					result:        policy.DefaultPoliciesList,
 				},
@@ -624,7 +857,6 @@ func TestRuleSetActiveSet(t *testing.T) {
 					id:            "rtagName1=rtagValue1,rtagName2=rtagValue2,rtagName3=rtagValue3",
 					matchFrom:     25000,
 					matchTo:       25001,
-					matchMode:     ForwardMatch,
 					expireAtNanos: 30000,
 					result: []RollupResult{
 						{
@@ -660,7 +892,6 @@ func TestRuleSetActiveSet(t *testing.T) {
 					id:            "rtagName1=rtagValue2",
 					matchFrom:     25000,
 					matchTo:       25001,
-					matchMode:     ForwardMatch,
 					expireAtNanos: 30000,
 					result: []RollupResult{
 						{
@@ -681,7 +912,6 @@ func TestRuleSetActiveSet(t *testing.T) {
 					id:            "rtagName5=rtagValue5",
 					matchFrom:     25000,
 					matchTo:       25001,
-					matchMode:     ForwardMatch,
 					expireAtNanos: 30000,
 					result:        []RollupResult{},
 				},
@@ -694,7 +924,6 @@ func TestRuleSetActiveSet(t *testing.T) {
 					id:            "mtagName1=mtagValue1",
 					matchFrom:     35000,
 					matchTo:       35001,
-					matchMode:     ForwardMatch,
 					expireAtNanos: 100000,
 					result: policy.PoliciesList{
 						policy.NewStagedPolicies(
@@ -712,7 +941,6 @@ func TestRuleSetActiveSet(t *testing.T) {
 					id:            "mtagName1=mtagValue2",
 					matchFrom:     35000,
 					matchTo:       35001,
-					matchMode:     ForwardMatch,
 					expireAtNanos: 100000,
 					result: policy.PoliciesList{
 						policy.NewStagedPolicies(
@@ -728,7 +956,6 @@ func TestRuleSetActiveSet(t *testing.T) {
 					id:            "mtagName1=mtagValue3",
 					matchFrom:     35000,
 					matchTo:       35001,
-					matchMode:     ForwardMatch,
 					expireAtNanos: 100000,
 					result:        policy.DefaultPoliciesList,
 				},
@@ -738,7 +965,6 @@ func TestRuleSetActiveSet(t *testing.T) {
 					id:            "rtagName1=rtagValue1,rtagName2=rtagValue2,rtagName3=rtagValue3",
 					matchFrom:     35000,
 					matchTo:       35001,
-					matchMode:     ForwardMatch,
 					expireAtNanos: 100000,
 					result: []RollupResult{
 						{
@@ -761,7 +987,6 @@ func TestRuleSetActiveSet(t *testing.T) {
 					id:            "rtagName1=rtagValue2",
 					matchFrom:     35000,
 					matchTo:       35001,
-					matchMode:     ForwardMatch,
 					expireAtNanos: 100000,
 					result: []RollupResult{
 						{
@@ -782,7 +1007,6 @@ func TestRuleSetActiveSet(t *testing.T) {
 					id:            "rtagName5=rtagValue5",
 					matchFrom:     35000,
 					matchTo:       35001,
-					matchMode:     ForwardMatch,
 					expireAtNanos: 100000,
 					result:        []RollupResult{},
 				},
@@ -795,7 +1019,6 @@ func TestRuleSetActiveSet(t *testing.T) {
 					id:            "mtagName1=mtagValue1",
 					matchFrom:     250000,
 					matchTo:       250001,
-					matchMode:     ForwardMatch,
 					expireAtNanos: timeNanosMax,
 					result: policy.PoliciesList{
 						policy.NewStagedPolicies(
@@ -813,7 +1036,6 @@ func TestRuleSetActiveSet(t *testing.T) {
 					id:            "mtagName1=mtagValue2",
 					matchFrom:     250000,
 					matchTo:       250001,
-					matchMode:     ForwardMatch,
 					expireAtNanos: timeNanosMax,
 					result: policy.PoliciesList{
 						policy.NewStagedPolicies(
@@ -829,7 +1051,6 @@ func TestRuleSetActiveSet(t *testing.T) {
 					id:            "mtagName1=mtagValue3",
 					matchFrom:     250000,
 					matchTo:       250001,
-					matchMode:     ForwardMatch,
 					expireAtNanos: timeNanosMax,
 					result:        policy.DefaultPoliciesList,
 				},
@@ -839,7 +1060,6 @@ func TestRuleSetActiveSet(t *testing.T) {
 					id:            "rtagName1=rtagValue1,rtagName2=rtagValue2,rtagName3=rtagValue3",
 					matchFrom:     250000,
 					matchTo:       250001,
-					matchMode:     ForwardMatch,
 					expireAtNanos: timeNanosMax,
 					result: []RollupResult{
 						{
@@ -874,7 +1094,6 @@ func TestRuleSetActiveSet(t *testing.T) {
 					id:            "rtagName1=rtagValue2",
 					matchFrom:     250000,
 					matchTo:       250001,
-					matchMode:     ForwardMatch,
 					expireAtNanos: timeNanosMax,
 					result: []RollupResult{
 						{
@@ -895,7 +1114,6 @@ func TestRuleSetActiveSet(t *testing.T) {
 					id:            "rtagName5=rtagValue5",
 					matchFrom:     250000,
 					matchTo:       250001,
-					matchMode:     ForwardMatch,
 					expireAtNanos: timeNanosMax,
 					result:        []RollupResult{},
 				},
@@ -906,12 +1124,12 @@ func TestRuleSetActiveSet(t *testing.T) {
 	for _, inputs := range allInputs {
 		as := newRuleSet.ActiveSet(inputs.activeSetTime.UnixNano())
 		for _, input := range inputs.mappingInputs {
-			res := as.MatchAll(b(input.id), input.matchFrom, input.matchTo, input.matchMode)
+			res := as.ForwardMatch(b(input.id), input.matchFrom, input.matchTo)
 			require.Equal(t, input.expireAtNanos, res.expireAtNanos)
 			require.Equal(t, input.result, res.MappingsAt(0))
 		}
 		for _, input := range inputs.rollupInputs {
-			res := as.MatchAll(b(input.id), input.matchFrom, input.matchTo, input.matchMode)
+			res := as.ForwardMatch(b(input.id), input.matchFrom, input.matchTo)
 			require.Equal(t, input.expireAtNanos, res.expireAtNanos)
 			require.Equal(t, len(input.result), res.NumRollups())
 			for i := 0; i < len(input.result); i++ {
@@ -1308,7 +1526,31 @@ func testRollupRules(t *testing.T) []*rollupRule {
 		},
 	}
 
-	return []*rollupRule{rollupRule1, rollupRule2, rollupRule3, rollupRule4, rollupRule5, rollupRule6}
+	rollupRule7 := &rollupRule{
+		uuid: "rollupRule7",
+		snapshots: []*rollupRuleSnapshot{
+			&rollupRuleSnapshot{
+				name:               "rollupRule7.snapshot1",
+				tombstoned:         false,
+				cutoverNanos:       120000,
+				filter:             filter2,
+				lastUpdatedAtNanos: 125000,
+				lastUpdatedBy:      "test",
+				targets: []RollupTarget{
+					{
+						Name: b("rName5"),
+						Tags: [][]byte{b("rtagName1")},
+						Policies: []policy.Policy{
+							policy.NewPolicy(policy.NewStoragePolicy(time.Second, xtime.Second, time.Hour), policy.MustCompressAggregationTypes(policy.Sum, policy.P90, policy.P99)),
+							policy.NewPolicy(policy.NewStoragePolicy(time.Minute, xtime.Second, 10*time.Hour), policy.MustCompressAggregationTypes(policy.Sum, policy.P99)),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	return []*rollupRule{rollupRule1, rollupRule2, rollupRule3, rollupRule4, rollupRule5, rollupRule6, rollupRule7}
 }
 
 func testMappingRulesConfig() []*schema.MappingRule {
@@ -2497,19 +2739,19 @@ func TestRuleSetClone(t *testing.T) {
 }
 
 type testMappingsData struct {
-	id            string
-	matchFrom     int64
-	matchTo       int64
-	matchMode     MatchMode
-	expireAtNanos int64
-	result        policy.PoliciesList
+	id              string
+	matchFrom       int64
+	matchTo         int64
+	expireAtNanos   int64
+	result          policy.PoliciesList
+	metricType      metric.Type
+	aggregationType policy.AggregationType
 }
 
 type testRollupResultsData struct {
 	id            string
 	matchFrom     int64
 	matchTo       int64
-	matchMode     MatchMode
 	expireAtNanos int64
 	result        []RollupResult
 }

--- a/rules/ruleset_test.go
+++ b/rules/ruleset_test.go
@@ -195,7 +195,7 @@ func TestActiveRuleSetForwardMappingPoliciesForNonRollupID(t *testing.T) {
 		testTagsFilterOptions(),
 		mockNewID,
 		nil,
-		policy.NewOptions(),
+		policy.NewAggregationTypesOptions(),
 	)
 	expectedCutovers := []int64{10000, 15000, 20000, 22000, 24000, 30000, 34000, 35000, 100000}
 	require.Equal(t, expectedCutovers, as.cutoverTimesAsc)
@@ -399,7 +399,7 @@ func TestActiveRuleSetReverseMappingPoliciesForNonRollupID(t *testing.T) {
 		testTagsFilterOptions(),
 		mockNewID,
 		func([]byte, []byte) bool { return false },
-		policy.NewOptions(),
+		policy.NewAggregationTypesOptions(),
 	)
 	expectedCutovers := []int64{10000, 15000, 20000, 22000, 24000, 30000, 34000, 35000, 100000}
 	require.Equal(t, expectedCutovers, as.cutoverTimesAsc)
@@ -534,7 +534,7 @@ func TestActiveRuleSetReverseMappingPoliciesForRollupID(t *testing.T) {
 		testTagsFilterOptions(),
 		mockNewID,
 		func([]byte, []byte) bool { return true },
-		policy.NewOptions(),
+		policy.NewAggregationTypesOptions(),
 	)
 	expectedCutovers := []int64{10000, 15000, 20000, 22000, 24000, 30000, 34000, 35000, 38000, 100000, 120000}
 	require.Equal(t, expectedCutovers, as.cutoverTimesAsc)
@@ -713,7 +713,7 @@ func TestActiveRuleSetRollupResults(t *testing.T) {
 		testTagsFilterOptions(),
 		mockNewID,
 		nil,
-		policy.NewOptions(),
+		policy.NewAggregationTypesOptions(),
 	)
 	expectedCutovers := []int64{10000, 15000, 20000, 22000, 24000, 30000, 34000, 35000, 38000, 100000, 120000}
 	require.Equal(t, expectedCutovers, as.cutoverTimesAsc)


### PR DESCRIPTION
We need to check aggregation type specifically because we support policies with different aggregation types, so we can't simply match by id in this case.

Major changes in this diff:
* Add ForwardMatch() and ReverseMatch() methods to ruleset.Matcher and matcher.Namespace interface.
* Removed MatchMode.
* Moved config and options from aggregator repo to setup default aggregation types for different metric type.
* Logic to filter policies based on aggregation type and metric type.
* Fixed a bug in mergeMappingResults() where the initial mappingResults maybe empty.

@xichen2020 @jeromefroe 