### PR TITLE
Validate metric types

### DIFF
--- a/metric/types.go
+++ b/metric/types.go
@@ -36,8 +36,8 @@ const (
 	GaugeType
 )
 
-// ValidTypes is a list of valid types.
-var ValidTypes = []Type{
+// validTypes is a list of valid types.
+var validTypes = []Type{
 	CounterType,
 	TimerType,
 	GaugeType,
@@ -62,14 +62,14 @@ func (t *Type) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	if err := unmarshal(&str); err != nil {
 		return err
 	}
-	validTypes := make([]string, 0, len(ValidTypes))
-	for _, valid := range ValidTypes {
+	validTypeStrs := make([]string, 0, len(validTypes))
+	for _, valid := range validTypes {
 		if str == string(valid) {
 			*t = valid
 			return nil
 		}
-		validTypes = append(validTypes, string(valid))
+		validTypeStrs = append(validTypeStrs, string(valid))
 	}
 	return fmt.Errorf("invalid metric type '%s' valid types are: %s",
-		str, strings.Join(validTypes, ", "))
+		str, strings.Join(validTypeStrs, ", "))
 }

--- a/rules/store_test.go
+++ b/rules/store_test.go
@@ -360,12 +360,6 @@ var (
 	}
 )
 
-func testStore() Store {
-	opts := NewStoreOptions(testNamespaceKey, testRuleSetKeyFmt)
-	kvStore := mem.NewStore()
-	return NewStore(kvStore, opts)
-}
-
 func TestRuleSetKey(t *testing.T) {
 	s := testStore()
 	key := s.(store).ruleSetKey(testNamespace)
@@ -373,7 +367,7 @@ func TestRuleSetKey(t *testing.T) {
 }
 
 func TestNewStore(t *testing.T) {
-	opts := NewStoreOptions(testNamespaceKey, testRuleSetKeyFmt)
+	opts := NewStoreOptions(testNamespaceKey, testRuleSetKeyFmt, nil)
 	kvStore := mem.NewStore()
 	s := NewStore(kvStore, opts).(store)
 
@@ -556,4 +550,10 @@ func TestWriteNoNamespace(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, nss.Version(), 1)
 	require.Equal(t, rs.Version(), 2)
+}
+
+func testStore() Store {
+	opts := NewStoreOptions(testNamespaceKey, testRuleSetKeyFmt, nil)
+	kvStore := mem.NewStore()
+	return NewStore(kvStore, opts)
 }

--- a/rules/validator.go
+++ b/rules/validator.go
@@ -77,8 +77,16 @@ func (v *validator) validateMappingRules(mrv map[string]*MappingRuleView) error 
 			return err
 		}
 
+		// Validate the metric types.
+		types, err := v.opts.MetricTypesFn()(view.Filters)
+		if err != nil {
+			return err
+		}
+		if len(types) == 0 {
+			return fmt.Errorf("mapping rule %s does not match any allowed metric types", view.Name)
+		}
+
 		// Validate that the policies are valid.
-		types := v.opts.MetricTypesFn()(view.Filters)
 		for _, t := range types {
 			for _, p := range view.Policies {
 				if err := v.validatePolicy(t, p); err != nil {
@@ -107,8 +115,16 @@ func (v *validator) validateRollupRules(rrv map[string]*RollupRuleView) error {
 			return err
 		}
 
+		// Validate the metric types.
+		types, err := v.opts.MetricTypesFn()(view.Filters)
+		if err != nil {
+			return err
+		}
+		if len(types) == 0 {
+			return fmt.Errorf("rollup rule %s does not match any allowed metric types", view.Name)
+		}
+
 		// Validate that the policies are valid.
-		types := v.opts.MetricTypesFn()(view.Filters)
 		for _, t := range types {
 			for _, target := range view.Targets {
 				for _, p := range target.Policies {

--- a/rules/validator.go
+++ b/rules/validator.go
@@ -83,7 +83,7 @@ func (v *validator) validateMappingRules(mrv map[string]*MappingRuleView) error 
 			return err
 		}
 		if len(types) == 0 {
-			return fmt.Errorf("mapping rule %s does not match any allowed metric types", view.Name)
+			return fmt.Errorf("mapping rule %s does not match any allowed metric types, filter=%v", view.Name, view.Filters)
 		}
 
 		// Validate that the policies are valid.
@@ -121,7 +121,7 @@ func (v *validator) validateRollupRules(rrv map[string]*RollupRuleView) error {
 			return err
 		}
 		if len(types) == 0 {
-			return fmt.Errorf("rollup rule %s does not match any allowed metric types", view.Name)
+			return fmt.Errorf("rollup rule %s does not match any allowed metric types, filter=%v", view.Name, view.Filters)
 		}
 
 		// Validate that the policies are valid.

--- a/rules/validator_options.go
+++ b/rules/validator_options.go
@@ -26,7 +26,7 @@ import (
 )
 
 // MetricTypesFn determines the possible metric types based on a set of tag based filters.
-type MetricTypesFn func(tagFilters map[string]string) []metric.Type
+type MetricTypesFn func(tagFilters map[string]string) ([]metric.Type, error)
 
 // ValidatorOptions provide a set of options for the validator.
 type ValidatorOptions interface {


### PR DESCRIPTION
cc @dgromov @cw9 @jeromefroe 

This PR changes the `MetricTypeFn` to return an error and validates the metric types to bail early if no metric type can be matched by the rule.