### PR TITLE
Replace suffixes with type strings

### DIFF
--- a/matcher/config.go
+++ b/matcher/config.go
@@ -114,11 +114,15 @@ func (cfg *Configuration) NewOptions(
 		return m3.IsRollupID(name, tags, sortedTagIteratorPool)
 	}
 
+	aggTypeOpts, err := cfg.AggregationTypes.NewOptions(instrumentOpts)
+	if err != nil {
+		return nil, err
+	}
 	ruleSetOpts := rules.NewOptions().
 		SetTagsFilterOptions(tagsFilterOptions).
 		SetNewRollupIDFn(m3.NewRollupID).
 		SetIsRollupIDFn(isRollupIDFn).
-		SetAggregationTypesOptions(cfg.AggregationTypes.NewOptions(instrumentOpts))
+		SetAggregationTypesOptions(aggTypeOpts)
 
 	// Configure ruleset key function.
 	ruleSetKeyFn := func(namespace []byte) string {

--- a/policy/aggregation_type_config.go
+++ b/policy/aggregation_type_config.go
@@ -158,34 +158,7 @@ var (
 		noopTransformType,
 		suffixTransformType,
 	}
-	validTypeStringTransformFnTypes = []string{
-		string(noopTransformType),
-		string(suffixTransformType),
-	}
 )
-
-func (t *transformType) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	fmt.Println("called")
-	var str string
-	if err := unmarshal(&str); err != nil {
-		return err
-	}
-	if str == "" {
-		*t = noopTransformType
-		return nil
-	}
-	var validStrings []string
-	for _, validType := range validTypes {
-		validString := string(validType)
-		if validString == str {
-			*t = validType
-			return nil
-		}
-		validStrings = append(validStrings, validString)
-	}
-
-	return fmt.Errorf("invalid transform type %s, valid types are: %v", str, validStrings)
-}
 
 func (t transformType) TransformFn() (TypeStringTransformFn, error) {
 	switch t {

--- a/policy/aggregation_type_config_test.go
+++ b/policy/aggregation_type_config_test.go
@@ -33,13 +33,13 @@ func TestAggregationTypesConfiguration(t *testing.T) {
 	str := `
 defaultGaugeAggregationTypes: Max
 defaultTimerAggregationTypes: P50,P99,P9999
-typeStrings: 
+globalOverrides: 
   Mean: testMean
-gaugeTypeStringOverrides:
+gaugeOverrides:
   Last: ""
-counterTypeStringOverrides:
+counterOverrides:
   Sum: ""
-typeStringTransformerType: withDotPrefix
+transformFnType: suffix
 `
 
 	var cfg AggregationTypesConfiguration
@@ -59,11 +59,29 @@ typeStringTransformerType: withDotPrefix
 	}
 }
 
+func TestAggregationTypesConfigNoTransformFnType(t *testing.T) {
+	str := `
+defaultGaugeAggregationTypes: Max
+defaultTimerAggregationTypes: P50,P99,P9999
+globalOverrides: 
+  Mean: testMean
+gaugeOverrides:
+  Last: ""
+counterOverrides:
+  Sum: ""
+`
+
+	var cfg AggregationTypesConfiguration
+	require.NoError(t, yaml.Unmarshal([]byte(str), &cfg))
+	_, err := cfg.NewOptions(instrument.NewOptions())
+	require.NoError(t, err)
+}
+
 func TestAggregationTypesConfigurationError(t *testing.T) {
 	str := `
 defaultGaugeAggregationTypes: Max
 defaultTimerAggregationTypes: P50,P99,P9999
-typeStringTransformerType: bla
+transformFnType: bla
 `
 
 	var cfg AggregationTypesConfiguration

--- a/policy/aggregation_type_config_test.go
+++ b/policy/aggregation_type_config_test.go
@@ -21,6 +21,7 @@
 package policy
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/m3db/m3x/instrument"
@@ -32,24 +33,41 @@ func TestAggregationTypesConfiguration(t *testing.T) {
 	str := `
 defaultGaugeAggregationTypes: Max
 defaultTimerAggregationTypes: P50,P99,P9999
-meanSuffix: .testMean
-gaugeSuffixOverrides:
+typeStrings: 
+  Mean: testMean
+gaugeTypeStringOverrides:
   Last: ""
-counterSuffixOverrides:
+counterTypeStringOverrides:
   Sum: ""
+typeStringTransformerType: withDotPrefix
 `
 
 	var cfg AggregationTypesConfiguration
 	require.NoError(t, yaml.Unmarshal([]byte(str), &cfg))
-	opts := cfg.NewOptions(instrument.NewOptions())
+	opts, err := cfg.NewOptions(instrument.NewOptions())
+	require.NoError(t, err)
 	require.Equal(t, defaultDefaultCounterAggregationTypes, opts.DefaultCounterAggregationTypes())
 	require.Equal(t, AggregationTypes{Max}, opts.DefaultGaugeAggregationTypes())
 	require.Equal(t, AggregationTypes{P50, P99, P9999}, opts.DefaultTimerAggregationTypes())
-	require.Equal(t, []byte(".testMean"), opts.MeanSuffix())
-	require.Equal(t, []byte(nil), opts.SuffixForCounter(Sum))
-	require.Equal(t, []byte(nil), opts.SuffixForGauge(Last))
-	suffixes := opts.DefaultTimerAggregationSuffixes()
+	require.Equal(t, []byte(".testMean"), opts.TypeStringForCounter(Mean))
+	require.Equal(t, []byte(nil), opts.TypeStringForCounter(Sum))
+	require.Equal(t, []byte(nil), opts.TypeStringForGauge(Last))
+	typeStrings := opts.DefaultTimerAggregationTypeStrings()
 	for i, aggType := range opts.DefaultTimerAggregationTypes() {
-		require.Equal(t, suffixes[i], opts.SuffixForTimer(aggType))
+		require.Equal(t, typeStrings[i], opts.TypeStringForTimer(aggType))
+		require.True(t, strings.HasPrefix(string(typeStrings[i]), "."))
 	}
+}
+
+func TestAggregationTypesConfigurationError(t *testing.T) {
+	str := `
+defaultGaugeAggregationTypes: Max
+defaultTimerAggregationTypes: P50,P99,P9999
+typeStringTransformerType: bla
+`
+
+	var cfg AggregationTypesConfiguration
+	require.NoError(t, yaml.Unmarshal([]byte(str), &cfg))
+	_, err := cfg.NewOptions(instrument.NewOptions())
+	require.Error(t, err)
 }

--- a/policy/aggregation_type_config_test.go
+++ b/policy/aggregation_type_config_test.go
@@ -85,7 +85,5 @@ transformFnType: bla
 `
 
 	var cfg AggregationTypesConfiguration
-	require.NoError(t, yaml.Unmarshal([]byte(str), &cfg))
-	_, err := cfg.NewOptions(instrument.NewOptions())
-	require.Error(t, err)
+	require.Error(t, yaml.Unmarshal([]byte(str), &cfg))
 }

--- a/policy/aggregation_type_options.go
+++ b/policy/aggregation_type_options.go
@@ -202,16 +202,16 @@ var (
 		Last,
 	}
 
-	defaultUnknownSuffix = []byte(".unknown")
-	defaultLastSuffix    = []byte(".last")
-	defaultSumSuffix     = []byte(".sum")
-	defaultSumSqSuffix   = []byte(".sum_sq")
-	defaultMeanSuffix    = []byte(".mean")
-	defaultMinSuffix     = []byte(".lower")
-	defaultMaxSuffix     = []byte(".upper")
-	defaultCountSuffix   = []byte(".count")
-	defaultStdevSuffix   = []byte(".stdev")
-	defaultMedianSuffix  = []byte(".median")
+	defaultUnknownSuffix = []byte("unknown")
+	defaultLastSuffix    = []byte("last")
+	defaultSumSuffix     = []byte("sum")
+	defaultSumSqSuffix   = []byte("sum_sq")
+	defaultMeanSuffix    = []byte("mean")
+	defaultMinSuffix     = []byte("lower")
+	defaultMaxSuffix     = []byte("upper")
+	defaultCountSuffix   = []byte("count")
+	defaultStdevSuffix   = []byte("stdev")
+	defaultMedianSuffix  = []byte("median")
 
 	defaultCounterSuffixOverride = map[AggregationType][]byte{
 		Sum: nil,
@@ -662,12 +662,12 @@ func (o *options) computeDefaultGaugeAggregationSuffix() {
 	}
 }
 
-// By default we use e.g. ".p50", ".p95", ".p99" for the 50th/95th/99th percentile.
+// By default we use e.g. "p50", "p95", "p99" for the 50th/95th/99th percentile.
 func defaultTimerQuantileSuffixFn(quantile float64) []byte {
 	str := strconv.FormatFloat(quantile*100, 'f', -1, 64)
 	idx := strings.Index(str, ".")
 	if idx != -1 {
 		str = str[:idx] + str[idx+1:]
 	}
-	return []byte(".p" + str)
+	return []byte("p" + str)
 }

--- a/policy/aggregation_type_options.go
+++ b/policy/aggregation_type_options.go
@@ -30,8 +30,11 @@ import (
 	"github.com/m3db/m3x/pool"
 )
 
-// QuantileSuffixFn returns the byte-slice suffix for a quantile value
-type QuantileSuffixFn func(quantile float64) []byte
+// QuantileTypeStringFn returns the byte-slice type string for a quantile value
+type QuantileTypeStringFn func(quantile float64) []byte
+
+// TypeStringTransformerFn transforms the type string.
+type TypeStringTransformerFn func(typeString []byte) []byte
 
 // AggregationTypesOptions provides a set of options for aggregation types.
 type AggregationTypesOptions interface {
@@ -58,65 +61,19 @@ type AggregationTypesOptions interface {
 	// DefaultGaugeAggregationTypes returns the default aggregation types for gauges.
 	DefaultGaugeAggregationTypes() AggregationTypes
 
-	// SetLastSuffix sets the suffix for aggregation type last.
-	SetLastSuffix(value []byte) AggregationTypesOptions
+	// SetTimerQuantileTypeStringFn sets the quantile type string function for timers.
+	SetTimerQuantileTypeStringFn(value QuantileTypeStringFn) AggregationTypesOptions
 
-	// LastSuffix returns the suffix for aggregation type last.
-	LastSuffix() []byte
+	// TimerQuantileTypeStringFn returns the quantile type string function for timers.
+	TimerQuantileTypeStringFn() QuantileTypeStringFn
 
-	// SetMinSuffix sets the suffix for aggregation type min.
-	SetMinSuffix(value []byte) AggregationTypesOptions
+	// SetTypeStringTransformerFn sets the type string transformer functions.
+	// TypeStringTransformerFn will only be applied to the global type strings, it
+	// will NOT be applied to the metric type specific overrides.
+	SetTypeStringTransformerFn(value TypeStringTransformerFn) AggregationTypesOptions
 
-	// MinSuffix returns the suffix for aggregation type min.
-	MinSuffix() []byte
-
-	// SetMaxSuffix sets the suffix for aggregation type max.
-	SetMaxSuffix(value []byte) AggregationTypesOptions
-
-	// MaxSuffix returns the suffix for aggregation type max.
-	MaxSuffix() []byte
-
-	// SetMeanSuffix sets the suffix for aggregation type mean.
-	SetMeanSuffix(value []byte) AggregationTypesOptions
-
-	// MeanSuffix returns the suffix for aggregation type mean.
-	MeanSuffix() []byte
-
-	// SetMedianSuffix sets the suffix for aggregation type median.
-	SetMedianSuffix(value []byte) AggregationTypesOptions
-
-	// MedianSuffix returns the suffix for aggregation type median.
-	MedianSuffix() []byte
-
-	// SetCountSuffix sets the suffix for aggregation type count.
-	SetCountSuffix(value []byte) AggregationTypesOptions
-
-	// CountSuffix returns the suffix for aggregation type count.
-	CountSuffix() []byte
-
-	// SetSumSuffix sets the suffix for aggregation type sum.
-	SetSumSuffix(value []byte) AggregationTypesOptions
-
-	// SumSuffix returns the suffix for aggregation type sum.
-	SumSuffix() []byte
-
-	// SetSumSqSuffix sets the suffix for aggregation type sum square.
-	SetSumSqSuffix(value []byte) AggregationTypesOptions
-
-	// SumSqSuffix returns the suffix for aggregation type sum square.
-	SumSqSuffix() []byte
-
-	// SetStdevSuffix sets the suffix for aggregation type standard deviation.
-	SetStdevSuffix(value []byte) AggregationTypesOptions
-
-	// StdevSuffix returns the suffix for aggregation type standard deviation.
-	StdevSuffix() []byte
-
-	// SetTimerQuantileSuffixFn sets the quantile suffix function for timers.
-	SetTimerQuantileSuffixFn(value QuantileSuffixFn) AggregationTypesOptions
-
-	// TimerQuantileSuffixFn returns the quantile suffix function for timers.
-	TimerQuantileSuffixFn() QuantileSuffixFn
+	// TypeStringTransformerFn returns the type string transformer functions.
+	TypeStringTransformerFn() TypeStringTransformerFn
 
 	// SetAggregationTypesPool sets the aggregation types pool.
 	SetAggregationTypesPool(pool AggregationTypesPool) AggregationTypesOptions
@@ -132,45 +89,49 @@ type AggregationTypesOptions interface {
 
 	/// Write-only options.
 
-	// SetCounterSuffixOverrides sets the overrides for counter suffixes.
-	SetCounterSuffixOverrides(m map[AggregationType][]byte) AggregationTypesOptions
+	// SetTypeStrings sets the global type strings. TypeStringTransformerFn
+	// will be applied to these type strings.
+	SetTypeStrings(m map[AggregationType][]byte) AggregationTypesOptions
 
-	// SetTimerSuffixOverrides sets the overrides for timer suffixes.
-	SetTimerSuffixOverrides(m map[AggregationType][]byte) AggregationTypesOptions
+	// SetCounterTypeStringOverrides sets the overrides for counter type strings.
+	SetCounterTypeStringOverrides(m map[AggregationType][]byte) AggregationTypesOptions
 
-	// SetGaugeSuffixOverrides sets the overrides for gauge suffixes.
-	SetGaugeSuffixOverrides(m map[AggregationType][]byte) AggregationTypesOptions
+	// SetTimerTypeStringOverrides sets the overrides for timer type strings.
+	SetTimerTypeStringOverrides(m map[AggregationType][]byte) AggregationTypesOptions
+
+	// SetGaugeTypeStringOverrides sets the overrides for gauge type strings.
+	SetGaugeTypeStringOverrides(m map[AggregationType][]byte) AggregationTypesOptions
 
 	// Read only methods.
 
-	// DefaultCounterAggregationSuffixes returns the suffix for
+	// DefaultCounterAggregationTypeStrings returns the type string for
 	// default counter aggregation types.
-	DefaultCounterAggregationSuffixes() [][]byte
+	DefaultCounterAggregationTypeStrings() [][]byte
 
-	// DefaultTimerAggregationSuffixes returns the suffix for
+	// DefaultTimerAggregationTypeStrings returns the type string for
 	// default timer aggregation types.
-	DefaultTimerAggregationSuffixes() [][]byte
+	DefaultTimerAggregationTypeStrings() [][]byte
 
-	// DefaultGaugeAggregationSuffixes returns the suffix for
+	// DefaultGaugeAggregationTypeStrings returns the type string for
 	// default gauge aggregation types.
-	DefaultGaugeAggregationSuffixes() [][]byte
+	DefaultGaugeAggregationTypeStrings() [][]byte
 
-	// Suffix returns the suffix for the aggregation type for counters.
-	SuffixForCounter(value AggregationType) []byte
+	// TypeString returns the type string for the aggregation type for counters.
+	TypeStringForCounter(value AggregationType) []byte
 
-	// Suffix returns the suffix for the aggregation type for timers.
-	SuffixForTimer(value AggregationType) []byte
+	// TypeString returns the type string for the aggregation type for timers.
+	TypeStringForTimer(value AggregationType) []byte
 
-	// Suffix returns the suffix for the aggregation type for gauges.
-	SuffixForGauge(value AggregationType) []byte
+	// TypeString returns the type string for the aggregation type for gauges.
+	TypeStringForGauge(value AggregationType) []byte
 
-	// AggregationTypeForCounter returns the aggregation type with the given suffix for counters.
+	// AggregationTypeForCounter returns the aggregation type with the given type string for counters.
 	AggregationTypeForCounter(value []byte) AggregationType
 
-	// AggregationTypeForTimer returns the aggregation type with the given suffix for timers.
+	// AggregationTypeForTimer returns the aggregation type with the given type string for timers.
 	AggregationTypeForTimer(value []byte) AggregationType
 
-	// AggregationTypeForGauge returns the aggregation type with the given suffix for gauges.
+	// AggregationTypeForGauge returns the aggregation type with the given type string for gauges.
 	AggregationTypeForGauge(value []byte) AggregationType
 
 	// TimerQuantiles returns the quantiles for timers.
@@ -202,22 +163,22 @@ var (
 		Last,
 	}
 
-	defaultUnknownSuffix = []byte("unknown")
-	defaultLastSuffix    = []byte("last")
-	defaultSumSuffix     = []byte("sum")
-	defaultSumSqSuffix   = []byte("sum_sq")
-	defaultMeanSuffix    = []byte("mean")
-	defaultMinSuffix     = []byte("lower")
-	defaultMaxSuffix     = []byte("upper")
-	defaultCountSuffix   = []byte("count")
-	defaultStdevSuffix   = []byte("stdev")
-	defaultMedianSuffix  = []byte("median")
+	defaultUnknownTypeString = []byte("unknown")
+	defaultLastTypeString    = []byte("last")
+	defaultSumTypeString     = []byte("sum")
+	defaultSumSqTypeString   = []byte("sum_sq")
+	defaultMeanTypeString    = []byte("mean")
+	defaultMinTypeString     = []byte("lower")
+	defaultMaxTypeString     = []byte("upper")
+	defaultCountTypeString   = []byte("count")
+	defaultStdevTypeString   = []byte("stdev")
+	defaultMedianTypeString  = []byte("median")
 
-	defaultCounterSuffixOverride = map[AggregationType][]byte{
+	defaultCounterTypeStringOverride = map[AggregationType][]byte{
 		Sum: nil,
 	}
-	defaultTimerSuffixOverride = map[AggregationType][]byte{}
-	defaultGaugeSuffixOverride = map[AggregationType][]byte{
+	defaultTimerTypeStringOverride = map[AggregationType][]byte{}
+	defaultGaugeTypeStringOverride = map[AggregationType][]byte{
 		Last: nil,
 	}
 )
@@ -226,32 +187,25 @@ type options struct {
 	defaultCounterAggregationTypes AggregationTypes
 	defaultTimerAggregationTypes   AggregationTypes
 	defaultGaugeAggregationTypes   AggregationTypes
-	sumSuffix                      []byte
-	sumSqSuffix                    []byte
-	meanSuffix                     []byte
-	lastSuffix                     []byte
-	minSuffix                      []byte
-	maxSuffix                      []byte
-	countSuffix                    []byte
-	stdevSuffix                    []byte
-	medianSuffix                   []byte
-	timerQuantileSuffixFn          QuantileSuffixFn
+	timerQuantileTypeStringFn      QuantileTypeStringFn
+	typeStringTransformerFn        TypeStringTransformerFn
 	aggTypesPool                   AggregationTypesPool
 	quantilesPool                  pool.FloatsPool
 
-	defaultSuffixes [][]byte
-	counterSuffixes [][]byte
-	timerSuffixes   [][]byte
-	gaugeSuffixes   [][]byte
+	defaultTypeStrings [][]byte
+	counterTypeStrings [][]byte
+	timerTypeStrings   [][]byte
+	gaugeTypeStrings   [][]byte
 
-	counterSuffixOverride map[AggregationType][]byte
-	timerSuffixOverride   map[AggregationType][]byte
-	gaugeSuffixOverride   map[AggregationType][]byte
+	typeStringOverrides       map[AggregationType][]byte
+	counterTypeStringOverride map[AggregationType][]byte
+	timerTypeStringOverride   map[AggregationType][]byte
+	gaugeTypeStringOverride   map[AggregationType][]byte
 
-	defaultCounterAggregationSuffixes [][]byte
-	defaultTimerAggregationSuffixes   [][]byte
-	defaultGaugeAggregationSuffixes   [][]byte
-	timerQuantiles                    []float64
+	defaultCounterAggregationTypeStrings [][]byte
+	defaultTimerAggregationTypeStrings   [][]byte
+	defaultGaugeAggregationTypeStrings   [][]byte
+	timerQuantiles                       []float64
 }
 
 // NewAggregationTypesOptions returns a default AggregationTypesOptions.
@@ -260,19 +214,11 @@ func NewAggregationTypesOptions() AggregationTypesOptions {
 		defaultCounterAggregationTypes: defaultDefaultCounterAggregationTypes,
 		defaultGaugeAggregationTypes:   defaultDefaultGaugeAggregationTypes,
 		defaultTimerAggregationTypes:   defaultDefaultTimerAggregationTypes,
-		lastSuffix:                     defaultLastSuffix,
-		minSuffix:                      defaultMinSuffix,
-		maxSuffix:                      defaultMaxSuffix,
-		meanSuffix:                     defaultMeanSuffix,
-		medianSuffix:                   defaultMedianSuffix,
-		countSuffix:                    defaultCountSuffix,
-		sumSuffix:                      defaultSumSuffix,
-		sumSqSuffix:                    defaultSumSqSuffix,
-		stdevSuffix:                    defaultStdevSuffix,
-		timerQuantileSuffixFn:          defaultTimerQuantileSuffixFn,
-		counterSuffixOverride:          defaultCounterSuffixOverride,
-		timerSuffixOverride:            defaultTimerSuffixOverride,
-		gaugeSuffixOverride:            defaultGaugeSuffixOverride,
+		timerQuantileTypeStringFn:      defaultTimerQuantileTypeStringFn,
+		typeStringTransformerFn:        defaultTypeStringTransformerFn,
+		counterTypeStringOverride:      defaultCounterTypeStringOverride,
+		timerTypeStringOverride:        defaultTimerTypeStringOverride,
+		gaugeTypeStringOverride:        defaultGaugeTypeStringOverride,
 	}
 	o.initPools()
 	o.computeAllDerived()
@@ -290,21 +236,21 @@ func (o *options) initPools() {
 }
 
 func (o *options) Validate() error {
-	if err := o.ensureUniqueSuffix(o.counterSuffixes, metric.CounterType); err != nil {
+	if err := o.ensureUniqueTypeString(o.counterTypeStrings, metric.CounterType); err != nil {
 		return err
 	}
-	if err := o.ensureUniqueSuffix(o.timerSuffixes, metric.TimerType); err != nil {
+	if err := o.ensureUniqueTypeString(o.timerTypeStrings, metric.TimerType); err != nil {
 		return err
 	}
-	return o.ensureUniqueSuffix(o.gaugeSuffixes, metric.GaugeType)
+	return o.ensureUniqueTypeString(o.gaugeTypeStrings, metric.GaugeType)
 }
 
-func (o *options) ensureUniqueSuffix(suffixes [][]byte, t metric.Type) error {
-	m := make(map[string]int, len(suffixes))
-	for aggType, suffix := range suffixes {
-		s := string(suffix)
+func (o *options) ensureUniqueTypeString(typeStrings [][]byte, t metric.Type) error {
+	m := make(map[string]int, len(typeStrings))
+	for aggType, typeString := range typeStrings {
+		s := string(typeString)
 		if existAggType, ok := m[s]; ok {
-			return fmt.Errorf("invalid options, found duplicated suffix: '%s' for aggregation type %v and %v for metric type: %s",
+			return fmt.Errorf("invalid options, found duplicated type string: '%s' for aggregation type %v and %v for metric type: %s",
 				s, AggregationType(aggType), AggregationType(existAggType), t.String())
 		}
 		m[s] = aggType
@@ -315,7 +261,7 @@ func (o *options) ensureUniqueSuffix(suffixes [][]byte, t metric.Type) error {
 func (o *options) SetDefaultCounterAggregationTypes(aggTypes AggregationTypes) AggregationTypesOptions {
 	opts := *o
 	opts.defaultCounterAggregationTypes = aggTypes
-	opts.computeSuffixes()
+	opts.computeTypeStrings()
 	return &opts
 }
 
@@ -327,7 +273,7 @@ func (o *options) SetDefaultTimerAggregationTypes(aggTypes AggregationTypes) Agg
 	opts := *o
 	opts.defaultTimerAggregationTypes = aggTypes
 	opts.computeQuantiles()
-	opts.computeSuffixes()
+	opts.computeTypeStrings()
 	return &opts
 }
 
@@ -338,7 +284,7 @@ func (o *options) DefaultTimerAggregationTypes() AggregationTypes {
 func (o *options) SetDefaultGaugeAggregationTypes(aggTypes AggregationTypes) AggregationTypesOptions {
 	opts := *o
 	opts.defaultGaugeAggregationTypes = aggTypes
-	opts.computeSuffixes()
+	opts.computeTypeStrings()
 	return &opts
 }
 
@@ -346,114 +292,26 @@ func (o *options) DefaultGaugeAggregationTypes() AggregationTypes {
 	return o.defaultGaugeAggregationTypes
 }
 
-func (o *options) SetLastSuffix(value []byte) AggregationTypesOptions {
+func (o *options) SetTimerQuantileTypeStringFn(value QuantileTypeStringFn) AggregationTypesOptions {
 	opts := *o
-	opts.lastSuffix = value
-	opts.computeSuffixes()
+	opts.timerQuantileTypeStringFn = value
+	opts.computeTypeStrings()
 	return &opts
 }
 
-func (o *options) LastSuffix() []byte {
-	return o.lastSuffix
+func (o *options) TimerQuantileTypeStringFn() QuantileTypeStringFn {
+	return o.timerQuantileTypeStringFn
 }
 
-func (o *options) SetMinSuffix(value []byte) AggregationTypesOptions {
+func (o *options) SetTypeStringTransformerFn(value TypeStringTransformerFn) AggregationTypesOptions {
 	opts := *o
-	opts.minSuffix = value
-	opts.computeSuffixes()
+	opts.typeStringTransformerFn = value
+	opts.computeTypeStrings()
 	return &opts
 }
 
-func (o *options) MinSuffix() []byte {
-	return o.minSuffix
-}
-
-func (o *options) SetMaxSuffix(value []byte) AggregationTypesOptions {
-	opts := *o
-	opts.maxSuffix = value
-	opts.computeSuffixes()
-	return &opts
-}
-
-func (o *options) MaxSuffix() []byte {
-	return o.maxSuffix
-}
-
-func (o *options) SetMeanSuffix(value []byte) AggregationTypesOptions {
-	opts := *o
-	opts.meanSuffix = value
-	opts.computeSuffixes()
-	return &opts
-}
-
-func (o *options) MeanSuffix() []byte {
-	return o.meanSuffix
-}
-
-func (o *options) SetMedianSuffix(value []byte) AggregationTypesOptions {
-	opts := *o
-	opts.medianSuffix = value
-	opts.computeSuffixes()
-	return &opts
-}
-
-func (o *options) MedianSuffix() []byte {
-	return o.medianSuffix
-}
-
-func (o *options) SetCountSuffix(value []byte) AggregationTypesOptions {
-	opts := *o
-	opts.countSuffix = value
-	opts.computeSuffixes()
-	return &opts
-}
-
-func (o *options) CountSuffix() []byte {
-	return o.countSuffix
-}
-
-func (o *options) SetSumSuffix(value []byte) AggregationTypesOptions {
-	opts := *o
-	opts.sumSuffix = value
-	opts.computeSuffixes()
-	return &opts
-}
-
-func (o *options) SumSuffix() []byte {
-	return o.sumSuffix
-}
-
-func (o *options) SetSumSqSuffix(value []byte) AggregationTypesOptions {
-	opts := *o
-	opts.sumSqSuffix = value
-	opts.computeSuffixes()
-	return &opts
-}
-
-func (o *options) SumSqSuffix() []byte {
-	return o.sumSqSuffix
-}
-
-func (o *options) SetStdevSuffix(value []byte) AggregationTypesOptions {
-	opts := *o
-	opts.stdevSuffix = value
-	opts.computeSuffixes()
-	return &opts
-}
-
-func (o *options) StdevSuffix() []byte {
-	return o.stdevSuffix
-}
-
-func (o *options) SetTimerQuantileSuffixFn(value QuantileSuffixFn) AggregationTypesOptions {
-	opts := *o
-	opts.timerQuantileSuffixFn = value
-	opts.computeSuffixes()
-	return &opts
-}
-
-func (o *options) TimerQuantileSuffixFn() QuantileSuffixFn {
-	return o.timerQuantileSuffixFn
+func (o *options) TypeStringTransformerFn() TypeStringTransformerFn {
+	return o.typeStringTransformerFn
 }
 
 func (o *options) SetAggregationTypesPool(pool AggregationTypesPool) AggregationTypesOptions {
@@ -476,61 +334,68 @@ func (o *options) QuantilesPool() pool.FloatsPool {
 	return o.quantilesPool
 }
 
-func (o *options) SetCounterSuffixOverrides(m map[AggregationType][]byte) AggregationTypesOptions {
+func (o *options) SetTypeStrings(m map[AggregationType][]byte) AggregationTypesOptions {
 	opts := *o
-	opts.counterSuffixOverride = m
-	opts.computeSuffixes()
+	opts.typeStringOverrides = m
+	opts.computeTypeStrings()
 	return &opts
 }
 
-func (o *options) SetTimerSuffixOverrides(m map[AggregationType][]byte) AggregationTypesOptions {
+func (o *options) SetCounterTypeStringOverrides(m map[AggregationType][]byte) AggregationTypesOptions {
 	opts := *o
-	opts.timerSuffixOverride = m
-	opts.computeSuffixes()
+	opts.counterTypeStringOverride = m
+	opts.computeTypeStrings()
 	return &opts
 }
 
-func (o *options) SetGaugeSuffixOverrides(m map[AggregationType][]byte) AggregationTypesOptions {
+func (o *options) SetTimerTypeStringOverrides(m map[AggregationType][]byte) AggregationTypesOptions {
 	opts := *o
-	opts.gaugeSuffixOverride = m
-	opts.computeSuffixes()
+	opts.timerTypeStringOverride = m
+	opts.computeTypeStrings()
 	return &opts
 }
 
-func (o *options) DefaultCounterAggregationSuffixes() [][]byte {
-	return o.defaultCounterAggregationSuffixes
+func (o *options) SetGaugeTypeStringOverrides(m map[AggregationType][]byte) AggregationTypesOptions {
+	opts := *o
+	opts.gaugeTypeStringOverride = m
+	opts.computeTypeStrings()
+	return &opts
 }
 
-func (o *options) DefaultTimerAggregationSuffixes() [][]byte {
-	return o.defaultTimerAggregationSuffixes
+func (o *options) DefaultCounterAggregationTypeStrings() [][]byte {
+	return o.defaultCounterAggregationTypeStrings
 }
 
-func (o *options) DefaultGaugeAggregationSuffixes() [][]byte {
-	return o.defaultGaugeAggregationSuffixes
+func (o *options) DefaultTimerAggregationTypeStrings() [][]byte {
+	return o.defaultTimerAggregationTypeStrings
 }
 
-func (o *options) SuffixForCounter(aggType AggregationType) []byte {
-	return o.counterSuffixes[aggType.ID()]
+func (o *options) DefaultGaugeAggregationTypeStrings() [][]byte {
+	return o.defaultGaugeAggregationTypeStrings
 }
 
-func (o *options) SuffixForTimer(aggType AggregationType) []byte {
-	return o.timerSuffixes[aggType.ID()]
+func (o *options) TypeStringForCounter(aggType AggregationType) []byte {
+	return o.counterTypeStrings[aggType.ID()]
 }
 
-func (o *options) SuffixForGauge(aggType AggregationType) []byte {
-	return o.gaugeSuffixes[aggType.ID()]
+func (o *options) TypeStringForTimer(aggType AggregationType) []byte {
+	return o.timerTypeStrings[aggType.ID()]
+}
+
+func (o *options) TypeStringForGauge(aggType AggregationType) []byte {
+	return o.gaugeTypeStrings[aggType.ID()]
 }
 
 func (o *options) AggregationTypeForCounter(value []byte) AggregationType {
-	return aggregationTypeWithSuffix(value, o.counterSuffixes)
+	return aggregationTypeWithTypeString(value, o.counterTypeStrings)
 }
 
 func (o *options) AggregationTypeForTimer(value []byte) AggregationType {
-	return aggregationTypeWithSuffix(value, o.timerSuffixes)
+	return aggregationTypeWithTypeString(value, o.timerTypeStrings)
 }
 
 func (o *options) AggregationTypeForGauge(value []byte) AggregationType {
-	return aggregationTypeWithSuffix(value, o.gaugeSuffixes)
+	return aggregationTypeWithTypeString(value, o.gaugeTypeStrings)
 }
 
 func (o *options) TimerQuantiles() []float64 {
@@ -551,8 +416,8 @@ func (o *options) IsContainedInDefaultAggregationTypes(at AggregationType, mt me
 	return aggTypes.Contains(at)
 }
 
-func aggregationTypeWithSuffix(value []byte, suffixes [][]byte) AggregationType {
-	for aggType, b := range suffixes {
+func aggregationTypeWithTypeString(value []byte, typeStrings [][]byte) AggregationType {
+	for aggType, b := range typeStrings {
 		if aggType == UnknownAggregationType.ID() {
 			continue
 		}
@@ -565,109 +430,122 @@ func aggregationTypeWithSuffix(value []byte, suffixes [][]byte) AggregationType 
 
 func (o *options) computeAllDerived() {
 	o.computeQuantiles()
-	o.computeSuffixes()
+	o.computeTypeStrings()
 }
 
 func (o *options) computeQuantiles() {
 	o.timerQuantiles, _ = o.DefaultTimerAggregationTypes().PooledQuantiles(o.QuantilesPool())
 }
 
-func (o *options) computeSuffixes() {
+func (o *options) computeTypeStrings() {
 	// NB(cw) The order matters.
-	o.computeDefaultSuffixes()
-	o.computeCounterSuffixes()
-	o.computeTimerSuffixes()
-	o.computeGaugeSuffixes()
-	o.computeDefaultCounterAggregationSuffix()
-	o.computeDefaultTimerAggregationSuffix()
-	o.computeDefaultGaugeAggregationSuffix()
+	o.computeDefaultTypeStrings()
+	o.computeCounterTypeStrings()
+	o.computeTimerTypeStrings()
+	o.computeGaugeTypeStrings()
+	o.computeDefaultCounterAggregationTypeString()
+	o.computeDefaultTimerAggregationTypeString()
+	o.computeDefaultGaugeAggregationTypeString()
 }
 
-func (o *options) computeDefaultSuffixes() {
-	o.defaultSuffixes = make([][]byte, MaxAggregationTypeID+1)
-	o.defaultSuffixes[UnknownAggregationType.ID()] = defaultUnknownSuffix
+func (o *options) computeDefaultTypeStrings() {
+	o.defaultTypeStrings = make([][]byte, MaxAggregationTypeID+1)
+	o.defaultTypeStrings[UnknownAggregationType.ID()] = defaultUnknownTypeString
+	transformerFn := o.TypeStringTransformerFn()
 	for aggType := range ValidAggregationTypes {
-		var suffix []byte
+		var typeString []byte
 		switch aggType {
 		case Last:
-			suffix = o.LastSuffix()
+			typeString = defaultLastTypeString
 		case Min:
-			suffix = o.MinSuffix()
+			typeString = defaultMinTypeString
 		case Max:
-			suffix = o.MaxSuffix()
+			typeString = defaultMaxTypeString
 		case Mean:
-			suffix = o.MeanSuffix()
+			typeString = defaultMeanTypeString
 		case Median:
-			suffix = o.MedianSuffix()
+			typeString = defaultMedianTypeString
 		case Count:
-			suffix = o.CountSuffix()
+			typeString = defaultCountTypeString
 		case Sum:
-			suffix = o.SumSuffix()
+			typeString = defaultSumTypeString
 		case SumSq:
-			suffix = o.SumSqSuffix()
+			typeString = defaultSumSqTypeString
 		case Stdev:
-			suffix = o.StdevSuffix()
+			typeString = defaultStdevTypeString
 		default:
 			q, ok := aggType.Quantile()
 			if ok {
-				suffix = o.timerQuantileSuffixFn(q)
+				typeString = o.timerQuantileTypeStringFn(q)
 			}
 		}
-		o.defaultSuffixes[aggType.ID()] = suffix
+		override, ok := o.typeStringOverrides[aggType]
+		if ok {
+			typeString = override
+		}
+		o.defaultTypeStrings[aggType.ID()] = transformerFn(typeString)
 	}
 }
 
-func (o *options) computeCounterSuffixes() {
-	o.counterSuffixes = o.computeOverrideSuffixes(o.counterSuffixOverride)
+func (o *options) computeCounterTypeStrings() {
+	o.counterTypeStrings = o.computeOverrideTypeStrings(o.counterTypeStringOverride)
 }
 
-func (o *options) computeTimerSuffixes() {
-	o.timerSuffixes = o.computeOverrideSuffixes(o.timerSuffixOverride)
+func (o *options) computeTimerTypeStrings() {
+	o.timerTypeStrings = o.computeOverrideTypeStrings(o.timerTypeStringOverride)
 }
 
-func (o *options) computeGaugeSuffixes() {
-	o.gaugeSuffixes = o.computeOverrideSuffixes(o.gaugeSuffixOverride)
+func (o *options) computeGaugeTypeStrings() {
+	o.gaugeTypeStrings = o.computeOverrideTypeStrings(o.gaugeTypeStringOverride)
 }
 
-func (o options) computeOverrideSuffixes(m map[AggregationType][]byte) [][]byte {
-	res := make([][]byte, len(o.defaultSuffixes))
-	for aggType, defaultSuffix := range o.defaultSuffixes {
-		if overrideSuffix, ok := m[AggregationType(aggType)]; ok {
-			res[aggType] = overrideSuffix
+func (o options) computeOverrideTypeStrings(m map[AggregationType][]byte) [][]byte {
+	res := make([][]byte, len(o.defaultTypeStrings))
+	for aggType, defaultTypeString := range o.defaultTypeStrings {
+		if overrideTypeString, ok := m[AggregationType(aggType)]; ok {
+			res[aggType] = overrideTypeString
 			continue
 		}
-		res[aggType] = defaultSuffix
+		res[aggType] = defaultTypeString
 	}
 	return res
 }
 
-func (o *options) computeDefaultCounterAggregationSuffix() {
-	o.defaultCounterAggregationSuffixes = make([][]byte, len(o.DefaultCounterAggregationTypes()))
+func (o *options) computeDefaultCounterAggregationTypeString() {
+	o.defaultCounterAggregationTypeStrings = make([][]byte, len(o.DefaultCounterAggregationTypes()))
 	for i, aggType := range o.DefaultCounterAggregationTypes() {
-		o.defaultCounterAggregationSuffixes[i] = o.SuffixForCounter(aggType)
+		o.defaultCounterAggregationTypeStrings[i] = o.TypeStringForCounter(aggType)
 	}
 }
 
-func (o *options) computeDefaultTimerAggregationSuffix() {
-	o.defaultTimerAggregationSuffixes = make([][]byte, len(o.DefaultTimerAggregationTypes()))
+func (o *options) computeDefaultTimerAggregationTypeString() {
+	o.defaultTimerAggregationTypeStrings = make([][]byte, len(o.DefaultTimerAggregationTypes()))
 	for i, aggType := range o.DefaultTimerAggregationTypes() {
-		o.defaultTimerAggregationSuffixes[i] = o.SuffixForTimer(aggType)
+		o.defaultTimerAggregationTypeStrings[i] = o.TypeStringForTimer(aggType)
 	}
 }
 
-func (o *options) computeDefaultGaugeAggregationSuffix() {
-	o.defaultGaugeAggregationSuffixes = make([][]byte, len(o.DefaultGaugeAggregationTypes()))
+func (o *options) computeDefaultGaugeAggregationTypeString() {
+	o.defaultGaugeAggregationTypeStrings = make([][]byte, len(o.DefaultGaugeAggregationTypes()))
 	for i, aggType := range o.DefaultGaugeAggregationTypes() {
-		o.defaultGaugeAggregationSuffixes[i] = o.SuffixForGauge(aggType)
+		o.defaultGaugeAggregationTypeStrings[i] = o.TypeStringForGauge(aggType)
 	}
 }
 
 // By default we use e.g. "p50", "p95", "p99" for the 50th/95th/99th percentile.
-func defaultTimerQuantileSuffixFn(quantile float64) []byte {
+func defaultTimerQuantileTypeStringFn(quantile float64) []byte {
 	str := strconv.FormatFloat(quantile*100, 'f', -1, 64)
 	idx := strings.Index(str, ".")
 	if idx != -1 {
 		str = str[:idx] + str[idx+1:]
 	}
 	return []byte("p" + str)
+}
+
+func defaultTypeStringTransformerFn(b []byte) []byte {
+	return b
+}
+
+func withDotPrefixTypeStringTransformerFn(b []byte) []byte {
+	return append([]byte("."), b...)
 }

--- a/policy/aggregation_type_options_test.go
+++ b/policy/aggregation_type_options_test.go
@@ -48,8 +48,8 @@ func TestAggregationTypesOptionsValidateDefault(t *testing.T) {
 	// Validate derived options
 	validateQuantiles(t, o)
 	require.Equal(t, [][]byte{nil}, o.DefaultCounterAggregationSuffixes())
-	require.Equal(t, [][]byte{[]byte(".sum"), []byte(".sum_sq"), []byte(".mean"), []byte(".lower"), []byte(".upper"), []byte(".count"),
-		[]byte(".stdev"), []byte(".median"), []byte(".p50"), []byte(".p95"), []byte(".p99")}, o.DefaultTimerAggregationSuffixes())
+	require.Equal(t, [][]byte{[]byte("sum"), []byte("sum_sq"), []byte("mean"), []byte("lower"), []byte("upper"), []byte("count"),
+		[]byte("stdev"), []byte("median"), []byte("p50"), []byte("p95"), []byte("p99")}, o.DefaultTimerAggregationSuffixes())
 	require.Equal(t, [][]byte{nil}, o.DefaultGaugeAggregationSuffixes())
 }
 
@@ -71,7 +71,7 @@ func TestOptionsSetDefaultCounterAggregationTypes(t *testing.T) {
 	aggTypes := AggregationTypes{Mean, SumSq}
 	o := NewAggregationTypesOptions().SetDefaultCounterAggregationTypes(aggTypes)
 	require.Equal(t, aggTypes, o.DefaultCounterAggregationTypes())
-	require.Equal(t, [][]byte{[]byte(".mean"), []byte(".sum_sq")}, o.DefaultCounterAggregationSuffixes())
+	require.Equal(t, [][]byte{[]byte("mean"), []byte("sum_sq")}, o.DefaultCounterAggregationSuffixes())
 }
 
 func TestOptionsSetDefaultTimerAggregationTypes(t *testing.T) {
@@ -79,14 +79,14 @@ func TestOptionsSetDefaultTimerAggregationTypes(t *testing.T) {
 	o := NewAggregationTypesOptions().SetDefaultTimerAggregationTypes(aggTypes)
 	require.Equal(t, aggTypes, o.DefaultTimerAggregationTypes())
 	require.Equal(t, []float64{0.99, 0.9999}, o.TimerQuantiles())
-	require.Equal(t, [][]byte{[]byte(".mean"), []byte(".sum_sq"), []byte(".p99"), []byte(".p9999")}, o.DefaultTimerAggregationSuffixes())
+	require.Equal(t, [][]byte{[]byte("mean"), []byte("sum_sq"), []byte("p99"), []byte("p9999")}, o.DefaultTimerAggregationSuffixes())
 }
 
 func TestOptionsSetDefaultGaugeAggregationTypes(t *testing.T) {
 	aggTypes := AggregationTypes{Mean, SumSq}
 	o := NewAggregationTypesOptions().SetDefaultGaugeAggregationTypes(aggTypes)
 	require.Equal(t, aggTypes, o.DefaultGaugeAggregationTypes())
-	require.Equal(t, [][]byte{[]byte(".mean"), []byte(".sum_sq")}, o.DefaultGaugeAggregationSuffixes())
+	require.Equal(t, [][]byte{[]byte("mean"), []byte("sum_sq")}, o.DefaultGaugeAggregationSuffixes())
 }
 
 func TestOptionsSetTimerSumSqSuffix(t *testing.T) {
@@ -238,41 +238,41 @@ func TestOptionsSetTimerQuantileSuffixFn(t *testing.T) {
 
 func TestOptionsCounterSuffix(t *testing.T) {
 	o := NewAggregationTypesOptions()
-	require.Equal(t, []byte(".last"), o.SuffixForCounter(Last))
-	require.Equal(t, []byte(".lower"), o.SuffixForCounter(Min))
-	require.Equal(t, []byte(".upper"), o.SuffixForCounter(Max))
-	require.Equal(t, []byte(".mean"), o.SuffixForCounter(Mean))
-	require.Equal(t, []byte(".median"), o.SuffixForCounter(Median))
-	require.Equal(t, []byte(".count"), o.SuffixForCounter(Count))
+	require.Equal(t, []byte("last"), o.SuffixForCounter(Last))
+	require.Equal(t, []byte("lower"), o.SuffixForCounter(Min))
+	require.Equal(t, []byte("upper"), o.SuffixForCounter(Max))
+	require.Equal(t, []byte("mean"), o.SuffixForCounter(Mean))
+	require.Equal(t, []byte("median"), o.SuffixForCounter(Median))
+	require.Equal(t, []byte("count"), o.SuffixForCounter(Count))
 	require.Equal(t, []byte(nil), o.SuffixForCounter(Sum))
-	require.Equal(t, []byte(".sum_sq"), o.SuffixForCounter(SumSq))
-	require.Equal(t, []byte(".stdev"), o.SuffixForCounter(Stdev))
+	require.Equal(t, []byte("sum_sq"), o.SuffixForCounter(SumSq))
+	require.Equal(t, []byte("stdev"), o.SuffixForCounter(Stdev))
 }
 
 func TestOptionsTimerSuffix(t *testing.T) {
 	o := NewAggregationTypesOptions()
-	require.Equal(t, []byte(".last"), o.SuffixForTimer(Last))
-	require.Equal(t, []byte(".lower"), o.SuffixForTimer(Min))
-	require.Equal(t, []byte(".upper"), o.SuffixForTimer(Max))
-	require.Equal(t, []byte(".mean"), o.SuffixForTimer(Mean))
-	require.Equal(t, []byte(".median"), o.SuffixForTimer(Median))
-	require.Equal(t, []byte(".count"), o.SuffixForTimer(Count))
-	require.Equal(t, []byte(".sum"), o.SuffixForTimer(Sum))
-	require.Equal(t, []byte(".sum_sq"), o.SuffixForTimer(SumSq))
-	require.Equal(t, []byte(".stdev"), o.SuffixForTimer(Stdev))
+	require.Equal(t, []byte("last"), o.SuffixForTimer(Last))
+	require.Equal(t, []byte("lower"), o.SuffixForTimer(Min))
+	require.Equal(t, []byte("upper"), o.SuffixForTimer(Max))
+	require.Equal(t, []byte("mean"), o.SuffixForTimer(Mean))
+	require.Equal(t, []byte("median"), o.SuffixForTimer(Median))
+	require.Equal(t, []byte("count"), o.SuffixForTimer(Count))
+	require.Equal(t, []byte("sum"), o.SuffixForTimer(Sum))
+	require.Equal(t, []byte("sum_sq"), o.SuffixForTimer(SumSq))
+	require.Equal(t, []byte("stdev"), o.SuffixForTimer(Stdev))
 }
 
 func TestOptionsGaugeSuffix(t *testing.T) {
 	o := NewAggregationTypesOptions()
 	require.Equal(t, []byte(nil), o.SuffixForGauge(Last))
-	require.Equal(t, []byte(".lower"), o.SuffixForGauge(Min))
-	require.Equal(t, []byte(".upper"), o.SuffixForGauge(Max))
-	require.Equal(t, []byte(".mean"), o.SuffixForGauge(Mean))
-	require.Equal(t, []byte(".median"), o.SuffixForGauge(Median))
-	require.Equal(t, []byte(".count"), o.SuffixForGauge(Count))
-	require.Equal(t, []byte(".sum"), o.SuffixForGauge(Sum))
-	require.Equal(t, []byte(".sum_sq"), o.SuffixForGauge(SumSq))
-	require.Equal(t, []byte(".stdev"), o.SuffixForGauge(Stdev))
+	require.Equal(t, []byte("lower"), o.SuffixForGauge(Min))
+	require.Equal(t, []byte("upper"), o.SuffixForGauge(Max))
+	require.Equal(t, []byte("mean"), o.SuffixForGauge(Mean))
+	require.Equal(t, []byte("median"), o.SuffixForGauge(Median))
+	require.Equal(t, []byte("count"), o.SuffixForGauge(Count))
+	require.Equal(t, []byte("sum"), o.SuffixForGauge(Sum))
+	require.Equal(t, []byte("sum_sq"), o.SuffixForGauge(SumSq))
+	require.Equal(t, []byte("stdev"), o.SuffixForGauge(Stdev))
 }
 
 func TestOptionTimerQuantileSuffix(t *testing.T) {
@@ -283,51 +283,51 @@ func TestOptionTimerQuantileSuffix(t *testing.T) {
 	}{
 		{
 			quantile: 0.01,
-			b:        []byte(".p1"),
+			b:        []byte("p1"),
 		},
 		{
 			quantile: 0.1,
-			b:        []byte(".p10"),
+			b:        []byte("p10"),
 		},
 		{
 			quantile: 0.5,
-			b:        []byte(".p50"),
+			b:        []byte("p50"),
 		},
 		{
 			quantile: 0.9,
-			b:        []byte(".p90"),
+			b:        []byte("p90"),
 		},
 		{
 			quantile: 0.90,
-			b:        []byte(".p90"),
+			b:        []byte("p90"),
 		},
 		{
 			quantile: 0.90,
-			b:        []byte(".p90"),
+			b:        []byte("p90"),
 		},
 		{
 			quantile: 0.909,
-			b:        []byte(".p909"),
+			b:        []byte("p909"),
 		},
 		{
 			quantile: 0.999,
-			b:        []byte(".p999"),
+			b:        []byte("p999"),
 		},
 		{
 			quantile: 0.9990,
-			b:        []byte(".p999"),
+			b:        []byte("p999"),
 		},
 		{
 			quantile: 0.9999,
-			b:        []byte(".p9999"),
+			b:        []byte("p9999"),
 		},
 		{
 			quantile: 0.99995,
-			b:        []byte(".p99995"),
+			b:        []byte("p99995"),
 		},
 		{
 			quantile: 0.123,
-			b:        []byte(".p123"),
+			b:        []byte("p123"),
 		},
 	}
 
@@ -351,7 +351,7 @@ func TestSetCounterSuffixOverride(t *testing.T) {
 	o := NewAggregationTypesOptions().SetCounterSuffixOverrides(m)
 	require.Equal(t, [][]byte{nil}, o.DefaultCounterAggregationSuffixes())
 	require.Equal(t, []byte("test"), o.SuffixForCounter(Mean))
-	require.Equal(t, []byte(".count"), o.SuffixForCounter(Count))
+	require.Equal(t, []byte("count"), o.SuffixForCounter(Count))
 	require.NoError(t, o.Validate())
 }
 
@@ -370,23 +370,23 @@ func TestSetCounterSuffixOverrideDuplicate(t *testing.T) {
 
 func TestSetTimerSuffixOverride(t *testing.T) {
 	m := map[AggregationType][]byte{
-		Min:  []byte(".lower"),
-		Max:  []byte(".upper"),
+		Min:  []byte("lower"),
+		Max:  []byte("upper"),
 		Mean: []byte("test"),
 	}
 
 	o := NewAggregationTypesOptions().SetTimerSuffixOverrides(m)
 	require.Equal(t, []byte("test"), o.SuffixForTimer(Mean))
-	require.Equal(t, []byte(".count"), o.SuffixForTimer(Count))
-	require.Equal(t, []byte(".lower"), o.SuffixForTimer(Min))
-	require.Equal(t, []byte(".upper"), o.SuffixForTimer(Max))
+	require.Equal(t, []byte("count"), o.SuffixForTimer(Count))
+	require.Equal(t, []byte("lower"), o.SuffixForTimer(Min))
+	require.Equal(t, []byte("upper"), o.SuffixForTimer(Max))
 	require.NoError(t, o.Validate())
 }
 
 func TestSetTimerSuffixOverrideDuplicate(t *testing.T) {
 	m := map[AggregationType][]byte{
-		Min:  []byte(".lower"),
-		Max:  []byte(".upper"),
+		Min:  []byte("lower"),
+		Max:  []byte("upper"),
 		Mean: []byte("test"),
 		Sum:  []byte("test"),
 	}
@@ -407,7 +407,7 @@ func TestSetGaugeSuffixOverride(t *testing.T) {
 	require.Equal(t, [][]byte{nil}, o.DefaultGaugeAggregationSuffixes())
 	require.Equal(t, []byte("test"), o.SuffixForGauge(Mean))
 	require.Equal(t, []byte(nil), o.SuffixForGauge(Last))
-	require.Equal(t, []byte(".count"), o.SuffixForGauge(Count))
+	require.Equal(t, []byte("count"), o.SuffixForGauge(Count))
 	require.NoError(t, o.Validate())
 }
 

--- a/policy/aggregation_type_options_test.go
+++ b/policy/aggregation_type_options_test.go
@@ -22,6 +22,7 @@ package policy
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/m3db/m3x/pool"
@@ -35,26 +36,30 @@ func TestAggregationTypesOptionsValidateDefault(t *testing.T) {
 	require.Equal(t, defaultDefaultCounterAggregationTypes, o.DefaultCounterAggregationTypes())
 	require.Equal(t, defaultDefaultTimerAggregationTypes, o.DefaultTimerAggregationTypes())
 	require.Equal(t, defaultDefaultGaugeAggregationTypes, o.DefaultGaugeAggregationTypes())
-	require.Equal(t, defaultSumSuffix, o.SumSuffix())
-	require.Equal(t, defaultSumSqSuffix, o.SumSqSuffix())
-	require.Equal(t, defaultMeanSuffix, o.MeanSuffix())
-	require.Equal(t, defaultMinSuffix, o.MinSuffix())
-	require.Equal(t, defaultMaxSuffix, o.MaxSuffix())
-	require.Equal(t, defaultCountSuffix, o.CountSuffix())
-	require.Equal(t, defaultStdevSuffix, o.StdevSuffix())
-	require.Equal(t, defaultMedianSuffix, o.MedianSuffix())
-	require.NotNil(t, o.TimerQuantileSuffixFn())
+	require.NotNil(t, o.TimerQuantileTypeStringFn())
+	require.NotNil(t, o.TypeStringTransformerFn())
 
 	// Validate derived options
 	validateQuantiles(t, o)
-	require.Equal(t, [][]byte{nil}, o.DefaultCounterAggregationSuffixes())
-	require.Equal(t, [][]byte{[]byte("sum"), []byte("sum_sq"), []byte("mean"), []byte("lower"), []byte("upper"), []byte("count"),
-		[]byte("stdev"), []byte("median"), []byte("p50"), []byte("p95"), []byte("p99")}, o.DefaultTimerAggregationSuffixes())
-	require.Equal(t, [][]byte{nil}, o.DefaultGaugeAggregationSuffixes())
+	require.Equal(t, [][]byte{nil}, o.DefaultCounterAggregationTypeStrings())
+	require.Equal(t, [][]byte{
+		[]byte(defaultSumTypeString),
+		[]byte(defaultSumSqTypeString),
+		[]byte(defaultMeanTypeString),
+		[]byte(defaultMinTypeString),
+		[]byte(defaultMaxTypeString),
+		[]byte(defaultCountTypeString),
+		[]byte(defaultStdevTypeString),
+		[]byte(defaultMedianTypeString),
+		[]byte("p50"),
+		[]byte("p95"),
+		[]byte("p99"),
+	}, o.DefaultTimerAggregationTypeStrings())
+	require.Equal(t, [][]byte{nil}, o.DefaultGaugeAggregationTypeStrings())
 }
 
 func validateQuantiles(t *testing.T, o AggregationTypesOptions) {
-	suffixFn := o.TimerQuantileSuffixFn()
+	typeStringFn := o.TimerQuantileTypeStringFn()
 	quantiles, _ := o.DefaultTimerAggregationTypes().PooledQuantiles(nil)
 	require.Equal(t, o.TimerQuantiles(), quantiles)
 
@@ -63,7 +68,7 @@ func validateQuantiles(t *testing.T, o AggregationTypesOptions) {
 		if !ok || aggType == Median {
 			continue
 		}
-		require.Equal(t, suffixFn(q), o.SuffixForTimer(aggType))
+		require.Equal(t, typeStringFn(q), o.TypeStringForTimer(aggType))
 	}
 }
 
@@ -71,7 +76,7 @@ func TestOptionsSetDefaultCounterAggregationTypes(t *testing.T) {
 	aggTypes := AggregationTypes{Mean, SumSq}
 	o := NewAggregationTypesOptions().SetDefaultCounterAggregationTypes(aggTypes)
 	require.Equal(t, aggTypes, o.DefaultCounterAggregationTypes())
-	require.Equal(t, [][]byte{[]byte("mean"), []byte("sum_sq")}, o.DefaultCounterAggregationSuffixes())
+	require.Equal(t, [][]byte{[]byte(defaultMeanTypeString), []byte(defaultSumSqTypeString)}, o.DefaultCounterAggregationTypeStrings())
 }
 
 func TestOptionsSetDefaultTimerAggregationTypes(t *testing.T) {
@@ -79,203 +84,211 @@ func TestOptionsSetDefaultTimerAggregationTypes(t *testing.T) {
 	o := NewAggregationTypesOptions().SetDefaultTimerAggregationTypes(aggTypes)
 	require.Equal(t, aggTypes, o.DefaultTimerAggregationTypes())
 	require.Equal(t, []float64{0.99, 0.9999}, o.TimerQuantiles())
-	require.Equal(t, [][]byte{[]byte("mean"), []byte("sum_sq"), []byte("p99"), []byte("p9999")}, o.DefaultTimerAggregationSuffixes())
+	require.Equal(t, [][]byte{[]byte(defaultMeanTypeString), []byte(defaultSumSqTypeString), []byte("p99"), []byte("p9999")}, o.DefaultTimerAggregationTypeStrings())
 }
 
 func TestOptionsSetDefaultGaugeAggregationTypes(t *testing.T) {
 	aggTypes := AggregationTypes{Mean, SumSq}
 	o := NewAggregationTypesOptions().SetDefaultGaugeAggregationTypes(aggTypes)
 	require.Equal(t, aggTypes, o.DefaultGaugeAggregationTypes())
-	require.Equal(t, [][]byte{[]byte("mean"), []byte("sum_sq")}, o.DefaultGaugeAggregationSuffixes())
+	require.Equal(t, [][]byte{[]byte(defaultMeanTypeString), []byte(defaultSumSqTypeString)}, o.DefaultGaugeAggregationTypeStrings())
 }
 
-func TestOptionsSetTimerSumSqSuffix(t *testing.T) {
-	newSumSqSuffix := []byte("testTimerSumSqSuffix")
+func TestOptionsSetTimerSumSqTypeString(t *testing.T) {
+	newSumSqTypeString := []byte("testTimerSumSqTypeString")
 	o := NewAggregationTypesOptions().
 		SetDefaultCounterAggregationTypes(AggregationTypes{SumSq}).
 		SetDefaultTimerAggregationTypes(AggregationTypes{SumSq}).
 		SetDefaultGaugeAggregationTypes(AggregationTypes{SumSq}).
-		SetSumSqSuffix(newSumSqSuffix)
-	require.Equal(t, newSumSqSuffix, o.SumSqSuffix())
-	require.Equal(t, newSumSqSuffix, o.SuffixForCounter(SumSq))
-	require.Equal(t, newSumSqSuffix, o.SuffixForTimer(SumSq))
-	require.Equal(t, newSumSqSuffix, o.SuffixForGauge(SumSq))
-	require.Equal(t, [][]byte{[]byte(newSumSqSuffix)}, o.DefaultCounterAggregationSuffixes())
-	require.Equal(t, [][]byte{[]byte(newSumSqSuffix)}, o.DefaultTimerAggregationSuffixes())
-	require.Equal(t, [][]byte{[]byte(newSumSqSuffix)}, o.DefaultGaugeAggregationSuffixes())
-	require.Equal(t, SumSq, o.AggregationTypeForCounter([]byte("testTimerSumSqSuffix")))
-	require.Equal(t, SumSq, o.AggregationTypeForTimer([]byte("testTimerSumSqSuffix")))
-	require.Equal(t, SumSq, o.AggregationTypeForGauge([]byte("testTimerSumSqSuffix")))
+		SetTypeStrings(map[AggregationType][]byte{SumSq: newSumSqTypeString})
+	require.Equal(t, newSumSqTypeString, o.TypeStringForCounter(SumSq))
+	require.Equal(t, newSumSqTypeString, o.TypeStringForTimer(SumSq))
+	require.Equal(t, newSumSqTypeString, o.TypeStringForGauge(SumSq))
+	require.Equal(t, [][]byte{[]byte(newSumSqTypeString)}, o.DefaultCounterAggregationTypeStrings())
+	require.Equal(t, [][]byte{[]byte(newSumSqTypeString)}, o.DefaultTimerAggregationTypeStrings())
+	require.Equal(t, [][]byte{[]byte(newSumSqTypeString)}, o.DefaultGaugeAggregationTypeStrings())
+	require.Equal(t, SumSq, o.AggregationTypeForCounter([]byte("testTimerSumSqTypeString")))
+	require.Equal(t, SumSq, o.AggregationTypeForTimer([]byte("testTimerSumSqTypeString")))
+	require.Equal(t, SumSq, o.AggregationTypeForGauge([]byte("testTimerSumSqTypeString")))
 	require.NoError(t, o.Validate())
 }
 
-func TestOptionsSetTimerMeanSuffix(t *testing.T) {
-	newMeanSuffix := []byte("testTimerMeanSuffix")
+func TestOptionsSetTimerMeanTypeString(t *testing.T) {
+	newMeanTypeString := []byte("testTimerMeanTypeString")
 	o := NewAggregationTypesOptions().
 		SetDefaultCounterAggregationTypes(AggregationTypes{Mean}).
 		SetDefaultTimerAggregationTypes(AggregationTypes{Mean}).
 		SetDefaultGaugeAggregationTypes(AggregationTypes{Mean}).
-		SetMeanSuffix(newMeanSuffix)
-	require.Equal(t, newMeanSuffix, o.MeanSuffix())
-	require.Equal(t, newMeanSuffix, o.SuffixForCounter(Mean))
-	require.Equal(t, newMeanSuffix, o.SuffixForTimer(Mean))
-	require.Equal(t, newMeanSuffix, o.SuffixForGauge(Mean))
-	require.Equal(t, [][]byte{[]byte(newMeanSuffix)}, o.DefaultCounterAggregationSuffixes())
-	require.Equal(t, [][]byte{[]byte(newMeanSuffix)}, o.DefaultTimerAggregationSuffixes())
-	require.Equal(t, [][]byte{[]byte(newMeanSuffix)}, o.DefaultGaugeAggregationSuffixes())
-	require.Equal(t, Mean, o.AggregationTypeForCounter([]byte("testTimerMeanSuffix")))
-	require.Equal(t, Mean, o.AggregationTypeForTimer([]byte("testTimerMeanSuffix")))
-	require.Equal(t, Mean, o.AggregationTypeForGauge([]byte("testTimerMeanSuffix")))
+		SetTypeStrings(map[AggregationType][]byte{Mean: newMeanTypeString})
+	require.Equal(t, newMeanTypeString, o.TypeStringForCounter(Mean))
+	require.Equal(t, newMeanTypeString, o.TypeStringForTimer(Mean))
+	require.Equal(t, newMeanTypeString, o.TypeStringForGauge(Mean))
+	require.Equal(t, [][]byte{[]byte(newMeanTypeString)}, o.DefaultCounterAggregationTypeStrings())
+	require.Equal(t, [][]byte{[]byte(newMeanTypeString)}, o.DefaultTimerAggregationTypeStrings())
+	require.Equal(t, [][]byte{[]byte(newMeanTypeString)}, o.DefaultGaugeAggregationTypeStrings())
+	require.Equal(t, Mean, o.AggregationTypeForCounter([]byte("testTimerMeanTypeString")))
+	require.Equal(t, Mean, o.AggregationTypeForTimer([]byte("testTimerMeanTypeString")))
+	require.Equal(t, Mean, o.AggregationTypeForGauge([]byte("testTimerMeanTypeString")))
 	require.NoError(t, o.Validate())
 }
 
-func TestOptionsSetCounterSumSuffix(t *testing.T) {
-	newSumSuffix := []byte("testSumSuffix")
+func TestOptionsSetCounterSumTypeString(t *testing.T) {
+	newSumTypeString := []byte("testSumTypeString")
 	o := NewAggregationTypesOptions().
 		SetDefaultCounterAggregationTypes(AggregationTypes{Sum}).
 		SetDefaultTimerAggregationTypes(AggregationTypes{Sum}).
 		SetDefaultGaugeAggregationTypes(AggregationTypes{Sum}).
-		SetSumSuffix(newSumSuffix)
-	require.Equal(t, newSumSuffix, o.SumSuffix())
-	require.Equal(t, []byte(nil), o.SuffixForCounter(Sum))
-	require.Equal(t, newSumSuffix, o.SuffixForTimer(Sum))
-	require.Equal(t, newSumSuffix, o.SuffixForGauge(Sum))
-	require.Equal(t, [][]byte{[]byte(nil)}, o.DefaultCounterAggregationSuffixes())
-	require.Equal(t, [][]byte{[]byte(newSumSuffix)}, o.DefaultTimerAggregationSuffixes())
-	require.Equal(t, [][]byte{[]byte(newSumSuffix)}, o.DefaultGaugeAggregationSuffixes())
+		SetTypeStrings(map[AggregationType][]byte{Sum: newSumTypeString})
+	require.Equal(t, []byte(nil), o.TypeStringForCounter(Sum))
+	require.Equal(t, newSumTypeString, o.TypeStringForTimer(Sum))
+	require.Equal(t, newSumTypeString, o.TypeStringForGauge(Sum))
+	require.Equal(t, [][]byte{[]byte(nil)}, o.DefaultCounterAggregationTypeStrings())
+	require.Equal(t, [][]byte{[]byte(newSumTypeString)}, o.DefaultTimerAggregationTypeStrings())
+	require.Equal(t, [][]byte{[]byte(newSumTypeString)}, o.DefaultGaugeAggregationTypeStrings())
 	require.Equal(t, Sum, o.AggregationTypeForCounter([]byte(nil)))
-	require.Equal(t, Sum, o.AggregationTypeForTimer([]byte("testSumSuffix")))
-	require.Equal(t, Sum, o.AggregationTypeForGauge([]byte("testSumSuffix")))
+	require.Equal(t, Sum, o.AggregationTypeForTimer([]byte("testSumTypeString")))
+	require.Equal(t, Sum, o.AggregationTypeForGauge([]byte("testSumTypeString")))
 	require.NoError(t, o.Validate())
 }
 
-func TestOptionsSetGaugeLastSuffix(t *testing.T) {
-	newLastSuffix := []byte("testLastSuffix")
+func TestOptionsSetGaugeLastTypeString(t *testing.T) {
+	newLastTypeString := []byte("testLastTypeString")
 	o := NewAggregationTypesOptions().
 		SetDefaultCounterAggregationTypes(AggregationTypes{Last}).
 		SetDefaultTimerAggregationTypes(AggregationTypes{Last}).
 		SetDefaultGaugeAggregationTypes(AggregationTypes{Last}).
-		SetLastSuffix(newLastSuffix)
-	require.Equal(t, newLastSuffix, o.LastSuffix())
-	require.Equal(t, newLastSuffix, o.SuffixForCounter(Last))
-	require.Equal(t, newLastSuffix, o.SuffixForTimer(Last))
-	require.Equal(t, []byte(nil), o.SuffixForGauge(Last))
-	require.Equal(t, [][]byte{[]byte(newLastSuffix)}, o.DefaultCounterAggregationSuffixes())
-	require.Equal(t, [][]byte{[]byte(newLastSuffix)}, o.DefaultTimerAggregationSuffixes())
-	require.Equal(t, [][]byte{[]byte(nil)}, o.DefaultGaugeAggregationSuffixes())
-	require.Equal(t, Last, o.AggregationTypeForCounter([]byte("testLastSuffix")))
-	require.Equal(t, Last, o.AggregationTypeForTimer([]byte("testLastSuffix")))
+		SetTypeStrings(map[AggregationType][]byte{Last: newLastTypeString})
+	require.Equal(t, newLastTypeString, o.TypeStringForCounter(Last))
+	require.Equal(t, newLastTypeString, o.TypeStringForTimer(Last))
+	require.Equal(t, []byte(nil), o.TypeStringForGauge(Last))
+	require.Equal(t, [][]byte{[]byte(newLastTypeString)}, o.DefaultCounterAggregationTypeStrings())
+	require.Equal(t, [][]byte{[]byte(newLastTypeString)}, o.DefaultTimerAggregationTypeStrings())
+	require.Equal(t, [][]byte{[]byte(nil)}, o.DefaultGaugeAggregationTypeStrings())
+	require.Equal(t, Last, o.AggregationTypeForCounter([]byte("testLastTypeString")))
+	require.Equal(t, Last, o.AggregationTypeForTimer([]byte("testLastTypeString")))
 	require.Equal(t, Last, o.AggregationTypeForGauge([]byte(nil)))
 	require.NoError(t, o.Validate())
 }
 
-func TestOptionsSetTimerCountSuffix(t *testing.T) {
-	newCountSuffix := []byte("testTimerCountSuffix")
+func TestOptionsSetTimerCountTypeString(t *testing.T) {
+	newCountTypeString := []byte("testTimerCountTypeString")
 	o := NewAggregationTypesOptions().
 		SetDefaultCounterAggregationTypes(AggregationTypes{Count}).
 		SetDefaultTimerAggregationTypes(AggregationTypes{Count}).
 		SetDefaultGaugeAggregationTypes(AggregationTypes{Count}).
-		SetCountSuffix(newCountSuffix)
-	require.Equal(t, newCountSuffix, o.CountSuffix())
-	require.Equal(t, newCountSuffix, o.SuffixForCounter(Count))
-	require.Equal(t, newCountSuffix, o.SuffixForTimer(Count))
-	require.Equal(t, newCountSuffix, o.SuffixForGauge(Count))
-	require.Equal(t, [][]byte{[]byte(newCountSuffix)}, o.DefaultCounterAggregationSuffixes())
-	require.Equal(t, [][]byte{[]byte(newCountSuffix)}, o.DefaultTimerAggregationSuffixes())
-	require.Equal(t, [][]byte{[]byte(newCountSuffix)}, o.DefaultGaugeAggregationSuffixes())
-	require.Equal(t, Count, o.AggregationTypeForCounter([]byte("testTimerCountSuffix")))
-	require.Equal(t, Count, o.AggregationTypeForTimer([]byte("testTimerCountSuffix")))
-	require.Equal(t, Count, o.AggregationTypeForGauge([]byte("testTimerCountSuffix")))
+		SetTypeStrings(map[AggregationType][]byte{Count: newCountTypeString})
+	require.Equal(t, newCountTypeString, o.TypeStringForCounter(Count))
+	require.Equal(t, newCountTypeString, o.TypeStringForTimer(Count))
+	require.Equal(t, newCountTypeString, o.TypeStringForGauge(Count))
+	require.Equal(t, [][]byte{[]byte(newCountTypeString)}, o.DefaultCounterAggregationTypeStrings())
+	require.Equal(t, [][]byte{[]byte(newCountTypeString)}, o.DefaultTimerAggregationTypeStrings())
+	require.Equal(t, [][]byte{[]byte(newCountTypeString)}, o.DefaultGaugeAggregationTypeStrings())
+	require.Equal(t, Count, o.AggregationTypeForCounter([]byte("testTimerCountTypeString")))
+	require.Equal(t, Count, o.AggregationTypeForTimer([]byte("testTimerCountTypeString")))
+	require.Equal(t, Count, o.AggregationTypeForGauge([]byte("testTimerCountTypeString")))
 	require.NoError(t, o.Validate())
 }
 
-func TestOptionsSetTimerStdevSuffix(t *testing.T) {
-	newStdevSuffix := []byte("testTimerStdevSuffix")
+func TestOptionsSetTimerStdevTypeString(t *testing.T) {
+	newStdevTypeString := []byte("testTimerStdevTypeString")
 	o := NewAggregationTypesOptions().
 		SetDefaultCounterAggregationTypes(AggregationTypes{Stdev}).
 		SetDefaultTimerAggregationTypes(AggregationTypes{Stdev}).
 		SetDefaultGaugeAggregationTypes(AggregationTypes{Stdev}).
-		SetStdevSuffix(newStdevSuffix)
-	require.Equal(t, newStdevSuffix, o.StdevSuffix())
-	require.Equal(t, newStdevSuffix, o.SuffixForCounter(Stdev))
-	require.Equal(t, newStdevSuffix, o.SuffixForTimer(Stdev))
-	require.Equal(t, newStdevSuffix, o.SuffixForGauge(Stdev))
-	require.Equal(t, [][]byte{[]byte(newStdevSuffix)}, o.DefaultCounterAggregationSuffixes())
-	require.Equal(t, [][]byte{[]byte(newStdevSuffix)}, o.DefaultTimerAggregationSuffixes())
-	require.Equal(t, [][]byte{[]byte(newStdevSuffix)}, o.DefaultGaugeAggregationSuffixes())
-	require.Equal(t, Stdev, o.AggregationTypeForCounter([]byte("testTimerStdevSuffix")))
-	require.Equal(t, Stdev, o.AggregationTypeForTimer([]byte("testTimerStdevSuffix")))
-	require.Equal(t, Stdev, o.AggregationTypeForGauge([]byte("testTimerStdevSuffix")))
+		SetTypeStrings(map[AggregationType][]byte{Stdev: newStdevTypeString})
+	require.Equal(t, newStdevTypeString, o.TypeStringForCounter(Stdev))
+	require.Equal(t, newStdevTypeString, o.TypeStringForTimer(Stdev))
+	require.Equal(t, newStdevTypeString, o.TypeStringForGauge(Stdev))
+	require.Equal(t, [][]byte{[]byte(newStdevTypeString)}, o.DefaultCounterAggregationTypeStrings())
+	require.Equal(t, [][]byte{[]byte(newStdevTypeString)}, o.DefaultTimerAggregationTypeStrings())
+	require.Equal(t, [][]byte{[]byte(newStdevTypeString)}, o.DefaultGaugeAggregationTypeStrings())
+	require.Equal(t, Stdev, o.AggregationTypeForCounter([]byte("testTimerStdevTypeString")))
+	require.Equal(t, Stdev, o.AggregationTypeForTimer([]byte("testTimerStdevTypeString")))
+	require.Equal(t, Stdev, o.AggregationTypeForGauge([]byte("testTimerStdevTypeString")))
 	require.NoError(t, o.Validate())
 }
 
-func TestOptionsSetTimerMedianSuffix(t *testing.T) {
-	newMedianSuffix := []byte("testTimerMedianSuffix")
+func TestOptionsSetTimerMedianTypeString(t *testing.T) {
+	newMedianTypeString := []byte("testTimerMedianTypeString")
 	o := NewAggregationTypesOptions().
 		SetDefaultCounterAggregationTypes(AggregationTypes{Median}).
 		SetDefaultTimerAggregationTypes(AggregationTypes{Median}).
 		SetDefaultGaugeAggregationTypes(AggregationTypes{Median}).
-		SetMedianSuffix(newMedianSuffix)
-	require.Equal(t, newMedianSuffix, o.MedianSuffix())
-	require.Equal(t, newMedianSuffix, o.SuffixForCounter(Median))
-	require.Equal(t, newMedianSuffix, o.SuffixForTimer(Median))
-	require.Equal(t, newMedianSuffix, o.SuffixForGauge(Median))
-	require.Equal(t, [][]byte{[]byte(newMedianSuffix)}, o.DefaultCounterAggregationSuffixes())
-	require.Equal(t, [][]byte{[]byte(newMedianSuffix)}, o.DefaultTimerAggregationSuffixes())
-	require.Equal(t, [][]byte{[]byte(newMedianSuffix)}, o.DefaultGaugeAggregationSuffixes())
-	require.Equal(t, Median, o.AggregationTypeForCounter([]byte("testTimerMedianSuffix")))
-	require.Equal(t, Median, o.AggregationTypeForTimer([]byte("testTimerMedianSuffix")))
-	require.Equal(t, Median, o.AggregationTypeForGauge([]byte("testTimerMedianSuffix")))
+		SetTypeStrings(map[AggregationType][]byte{Median: newMedianTypeString})
+	require.Equal(t, newMedianTypeString, o.TypeStringForCounter(Median))
+	require.Equal(t, newMedianTypeString, o.TypeStringForTimer(Median))
+	require.Equal(t, newMedianTypeString, o.TypeStringForGauge(Median))
+	require.Equal(t, [][]byte{[]byte(newMedianTypeString)}, o.DefaultCounterAggregationTypeStrings())
+	require.Equal(t, [][]byte{[]byte(newMedianTypeString)}, o.DefaultTimerAggregationTypeStrings())
+	require.Equal(t, [][]byte{[]byte(newMedianTypeString)}, o.DefaultGaugeAggregationTypeStrings())
+	require.Equal(t, Median, o.AggregationTypeForCounter([]byte("testTimerMedianTypeString")))
+	require.Equal(t, Median, o.AggregationTypeForTimer([]byte("testTimerMedianTypeString")))
+	require.Equal(t, Median, o.AggregationTypeForGauge([]byte("testTimerMedianTypeString")))
 	require.NoError(t, o.Validate())
 }
 
-func TestOptionsSetTimerQuantileSuffixFn(t *testing.T) {
+func TestOptionsSetTimerQuantileTypeStringFn(t *testing.T) {
 	fn := func(q float64) []byte { return []byte(fmt.Sprintf("%1.2f", q)) }
-	o := NewAggregationTypesOptions().SetTimerQuantileSuffixFn(fn)
-	require.Equal(t, []byte("0.96"), o.TimerQuantileSuffixFn()(0.9582))
+	o := NewAggregationTypesOptions().SetTimerQuantileTypeStringFn(fn)
+	require.Equal(t, []byte("0.96"), o.TimerQuantileTypeStringFn()(0.9582))
 	validateQuantiles(t, o)
 }
 
-func TestOptionsCounterSuffix(t *testing.T) {
+func TestOptionsCounterTypeString(t *testing.T) {
 	o := NewAggregationTypesOptions()
-	require.Equal(t, []byte("last"), o.SuffixForCounter(Last))
-	require.Equal(t, []byte("lower"), o.SuffixForCounter(Min))
-	require.Equal(t, []byte("upper"), o.SuffixForCounter(Max))
-	require.Equal(t, []byte("mean"), o.SuffixForCounter(Mean))
-	require.Equal(t, []byte("median"), o.SuffixForCounter(Median))
-	require.Equal(t, []byte("count"), o.SuffixForCounter(Count))
-	require.Equal(t, []byte(nil), o.SuffixForCounter(Sum))
-	require.Equal(t, []byte("sum_sq"), o.SuffixForCounter(SumSq))
-	require.Equal(t, []byte("stdev"), o.SuffixForCounter(Stdev))
+	require.Equal(t, []byte(defaultLastTypeString), o.TypeStringForCounter(Last))
+	require.Equal(t, []byte(defaultMinTypeString), o.TypeStringForCounter(Min))
+	require.Equal(t, []byte(defaultMaxTypeString), o.TypeStringForCounter(Max))
+	require.Equal(t, []byte(defaultMeanTypeString), o.TypeStringForCounter(Mean))
+	require.Equal(t, []byte(defaultMedianTypeString), o.TypeStringForCounter(Median))
+	require.Equal(t, []byte(defaultCountTypeString), o.TypeStringForCounter(Count))
+	require.Equal(t, []byte(nil), o.TypeStringForCounter(Sum))
+	require.Equal(t, []byte(defaultSumSqTypeString), o.TypeStringForCounter(SumSq))
+	require.Equal(t, []byte(defaultStdevTypeString), o.TypeStringForCounter(Stdev))
 }
 
-func TestOptionsTimerSuffix(t *testing.T) {
+func TestOptionsTimerTypeString(t *testing.T) {
 	o := NewAggregationTypesOptions()
-	require.Equal(t, []byte("last"), o.SuffixForTimer(Last))
-	require.Equal(t, []byte("lower"), o.SuffixForTimer(Min))
-	require.Equal(t, []byte("upper"), o.SuffixForTimer(Max))
-	require.Equal(t, []byte("mean"), o.SuffixForTimer(Mean))
-	require.Equal(t, []byte("median"), o.SuffixForTimer(Median))
-	require.Equal(t, []byte("count"), o.SuffixForTimer(Count))
-	require.Equal(t, []byte("sum"), o.SuffixForTimer(Sum))
-	require.Equal(t, []byte("sum_sq"), o.SuffixForTimer(SumSq))
-	require.Equal(t, []byte("stdev"), o.SuffixForTimer(Stdev))
+	require.Equal(t, []byte(defaultLastTypeString), o.TypeStringForTimer(Last))
+	require.Equal(t, []byte(defaultMinTypeString), o.TypeStringForTimer(Min))
+	require.Equal(t, []byte(defaultMaxTypeString), o.TypeStringForTimer(Max))
+	require.Equal(t, []byte(defaultMeanTypeString), o.TypeStringForTimer(Mean))
+	require.Equal(t, []byte(defaultMedianTypeString), o.TypeStringForTimer(Median))
+	require.Equal(t, []byte(defaultCountTypeString), o.TypeStringForTimer(Count))
+	require.Equal(t, []byte(defaultSumTypeString), o.TypeStringForTimer(Sum))
+	require.Equal(t, []byte(defaultSumSqTypeString), o.TypeStringForTimer(SumSq))
+	require.Equal(t, []byte(defaultStdevTypeString), o.TypeStringForTimer(Stdev))
 }
 
-func TestOptionsGaugeSuffix(t *testing.T) {
+func TestOptionsGaugeTypeString(t *testing.T) {
 	o := NewAggregationTypesOptions()
-	require.Equal(t, []byte(nil), o.SuffixForGauge(Last))
-	require.Equal(t, []byte("lower"), o.SuffixForGauge(Min))
-	require.Equal(t, []byte("upper"), o.SuffixForGauge(Max))
-	require.Equal(t, []byte("mean"), o.SuffixForGauge(Mean))
-	require.Equal(t, []byte("median"), o.SuffixForGauge(Median))
-	require.Equal(t, []byte("count"), o.SuffixForGauge(Count))
-	require.Equal(t, []byte("sum"), o.SuffixForGauge(Sum))
-	require.Equal(t, []byte("sum_sq"), o.SuffixForGauge(SumSq))
-	require.Equal(t, []byte("stdev"), o.SuffixForGauge(Stdev))
+	require.Equal(t, []byte(nil), o.TypeStringForGauge(Last))
+	require.Equal(t, []byte(defaultMinTypeString), o.TypeStringForGauge(Min))
+	require.Equal(t, []byte(defaultMaxTypeString), o.TypeStringForGauge(Max))
+	require.Equal(t, []byte(defaultMeanTypeString), o.TypeStringForGauge(Mean))
+	require.Equal(t, []byte(defaultMedianTypeString), o.TypeStringForGauge(Median))
+	require.Equal(t, []byte(defaultCountTypeString), o.TypeStringForGauge(Count))
+	require.Equal(t, []byte(defaultSumTypeString), o.TypeStringForGauge(Sum))
+	require.Equal(t, []byte(defaultSumSqTypeString), o.TypeStringForGauge(SumSq))
+	require.Equal(t, []byte(defaultStdevTypeString), o.TypeStringForGauge(Stdev))
 }
 
-func TestOptionTimerQuantileSuffix(t *testing.T) {
+func TestOptionsTypeStringTransformer(t *testing.T) {
+	o := NewAggregationTypesOptions()
+	for _, aggType := range o.DefaultTimerAggregationTypes() {
+		require.False(t, strings.HasPrefix(string(o.TypeStringForTimer(aggType)), "."))
+	}
+
+	o = o.SetTypeStringTransformerFn(withDotPrefixTypeStringTransformerFn)
+	for _, aggType := range o.DefaultTimerAggregationTypes() {
+		require.True(t, strings.HasPrefix(string(o.TypeStringForTimer(aggType)), "."))
+	}
+
+	o = o.SetTimerTypeStringOverrides(map[AggregationType][]byte{P95: []byte("no_dot")})
+	require.Equal(t, []byte("no_dot"), o.TypeStringForTimer(P95))
+}
+
+func TestOptionTimerQuantileTypeString(t *testing.T) {
 	o := NewAggregationTypesOptions()
 	cases := []struct {
 		quantile float64
@@ -332,7 +345,7 @@ func TestOptionTimerQuantileSuffix(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		require.Equal(t, c.b, o.TimerQuantileSuffixFn()(c.quantile))
+		require.Equal(t, c.b, o.TimerQuantileTypeStringFn()(c.quantile))
 	}
 }
 
@@ -342,84 +355,84 @@ func TestSetQuantilesPool(t *testing.T) {
 	require.Equal(t, p, o.QuantilesPool())
 }
 
-func TestSetCounterSuffixOverride(t *testing.T) {
+func TestSetCounterTypeStringOverride(t *testing.T) {
 	m := map[AggregationType][]byte{
 		Sum:  nil,
 		Mean: []byte("test"),
 	}
 
-	o := NewAggregationTypesOptions().SetCounterSuffixOverrides(m)
-	require.Equal(t, [][]byte{nil}, o.DefaultCounterAggregationSuffixes())
-	require.Equal(t, []byte("test"), o.SuffixForCounter(Mean))
-	require.Equal(t, []byte("count"), o.SuffixForCounter(Count))
+	o := NewAggregationTypesOptions().SetCounterTypeStringOverrides(m)
+	require.Equal(t, [][]byte{nil}, o.DefaultCounterAggregationTypeStrings())
+	require.Equal(t, []byte("test"), o.TypeStringForCounter(Mean))
+	require.Equal(t, []byte(defaultCountTypeString), o.TypeStringForCounter(Count))
 	require.NoError(t, o.Validate())
 }
 
-func TestSetCounterSuffixOverrideDuplicate(t *testing.T) {
+func TestSetCounterTypeStringOverrideDuplicate(t *testing.T) {
 	m := map[AggregationType][]byte{
 		Sum:  nil,
 		Mean: []byte("test"),
 		Max:  nil,
 	}
 
-	o := NewAggregationTypesOptions().SetCounterSuffixOverrides(m)
-	require.Equal(t, []byte(nil), o.SuffixForCounter(Sum))
-	require.Equal(t, []byte(nil), o.SuffixForCounter(Max))
+	o := NewAggregationTypesOptions().SetCounterTypeStringOverrides(m)
+	require.Equal(t, []byte(nil), o.TypeStringForCounter(Sum))
+	require.Equal(t, []byte(nil), o.TypeStringForCounter(Max))
 	require.Error(t, o.Validate())
 }
 
-func TestSetTimerSuffixOverride(t *testing.T) {
+func TestSetTimerTypeStringOverride(t *testing.T) {
 	m := map[AggregationType][]byte{
-		Min:  []byte("lower"),
-		Max:  []byte("upper"),
+		Min:  []byte(defaultMinTypeString),
+		Max:  []byte(defaultMaxTypeString),
 		Mean: []byte("test"),
 	}
 
-	o := NewAggregationTypesOptions().SetTimerSuffixOverrides(m)
-	require.Equal(t, []byte("test"), o.SuffixForTimer(Mean))
-	require.Equal(t, []byte("count"), o.SuffixForTimer(Count))
-	require.Equal(t, []byte("lower"), o.SuffixForTimer(Min))
-	require.Equal(t, []byte("upper"), o.SuffixForTimer(Max))
+	o := NewAggregationTypesOptions().SetTimerTypeStringOverrides(m)
+	require.Equal(t, []byte("test"), o.TypeStringForTimer(Mean))
+	require.Equal(t, []byte(defaultCountTypeString), o.TypeStringForTimer(Count))
+	require.Equal(t, []byte(defaultMinTypeString), o.TypeStringForTimer(Min))
+	require.Equal(t, []byte(defaultMaxTypeString), o.TypeStringForTimer(Max))
 	require.NoError(t, o.Validate())
 }
 
-func TestSetTimerSuffixOverrideDuplicate(t *testing.T) {
+func TestSetTimerTypeStringOverrideDuplicate(t *testing.T) {
 	m := map[AggregationType][]byte{
-		Min:  []byte("lower"),
-		Max:  []byte("upper"),
+		Min:  []byte(defaultMinTypeString),
+		Max:  []byte(defaultMaxTypeString),
 		Mean: []byte("test"),
 		Sum:  []byte("test"),
 	}
 
-	o := NewAggregationTypesOptions().SetTimerSuffixOverrides(m)
-	require.Equal(t, []byte("test"), o.SuffixForTimer(Mean))
-	require.Equal(t, []byte("test"), o.SuffixForTimer(Sum))
+	o := NewAggregationTypesOptions().SetTimerTypeStringOverrides(m)
+	require.Equal(t, []byte("test"), o.TypeStringForTimer(Mean))
+	require.Equal(t, []byte("test"), o.TypeStringForTimer(Sum))
 	require.Error(t, o.Validate())
 }
 
-func TestSetGaugeSuffixOverride(t *testing.T) {
+func TestSetGaugeTypeStringOverride(t *testing.T) {
 	m := map[AggregationType][]byte{
 		Last: nil,
 		Mean: []byte("test"),
 	}
 
-	o := NewAggregationTypesOptions().SetGaugeSuffixOverrides(m)
-	require.Equal(t, [][]byte{nil}, o.DefaultGaugeAggregationSuffixes())
-	require.Equal(t, []byte("test"), o.SuffixForGauge(Mean))
-	require.Equal(t, []byte(nil), o.SuffixForGauge(Last))
-	require.Equal(t, []byte("count"), o.SuffixForGauge(Count))
+	o := NewAggregationTypesOptions().SetGaugeTypeStringOverrides(m)
+	require.Equal(t, [][]byte{nil}, o.DefaultGaugeAggregationTypeStrings())
+	require.Equal(t, []byte("test"), o.TypeStringForGauge(Mean))
+	require.Equal(t, []byte(nil), o.TypeStringForGauge(Last))
+	require.Equal(t, []byte(defaultCountTypeString), o.TypeStringForGauge(Count))
 	require.NoError(t, o.Validate())
 }
 
-func TestSetGaugeSuffixOverrideDuplicate(t *testing.T) {
+func TestSetGaugeTypeStringOverrideDuplicate(t *testing.T) {
 	m := map[AggregationType][]byte{
 		Last: nil,
 		Mean: []byte("test"),
 		Max:  []byte("test"),
 	}
 
-	o := NewAggregationTypesOptions().SetGaugeSuffixOverrides(m)
-	require.Equal(t, []byte("test"), o.SuffixForGauge(Mean))
-	require.Equal(t, []byte("test"), o.SuffixForGauge(Max))
+	o := NewAggregationTypesOptions().SetGaugeTypeStringOverrides(m)
+	require.Equal(t, []byte("test"), o.TypeStringForGauge(Mean))
+	require.Equal(t, []byte("test"), o.TypeStringForGauge(Max))
 	require.Error(t, o.Validate())
 }


### PR DESCRIPTION
So that we only need to override the config in m3aggregator and directly use defaults in query and indexer

@xichen2020 