### PR TITLE
Provide options to enforce required rollup tags

### DIFF
--- a/rules/validator_options.go
+++ b/rules/validator_options.go
@@ -50,6 +50,12 @@ type ValidatorOptions interface {
 	// MetricTypesFn returns the metric types function.
 	MetricTypesFn() MetricTypesFn
 
+	// SetRequiredRollupTags sets the list of required rollup tags.
+	SetRequiredRollupTags(value []string) ValidatorOptions
+
+	// RequiredRollupTags returns the list of required rollup tags.
+	RequiredRollupTags() []string
+
 	// IsAllowedStoragePolicyFor determines whether a given storage policy is allowed for the
 	// given metric type.
 	IsAllowedStoragePolicyFor(t metric.Type, p policy.StoragePolicy) bool
@@ -68,6 +74,7 @@ type validatorOptions struct {
 	defaultAllowedStoragePolicies        map[policy.StoragePolicy]struct{}
 	defaultAllowedCustomAggregationTypes map[policy.AggregationType]struct{}
 	metricTypesFn                        MetricTypesFn
+	requiredRollupTags                   []string
 	metadatasByType                      map[metric.Type]validationMetadata
 }
 
@@ -109,6 +116,18 @@ func (o *validatorOptions) SetMetricTypesFn(value MetricTypesFn) ValidatorOption
 
 func (o *validatorOptions) MetricTypesFn() MetricTypesFn {
 	return o.metricTypesFn
+}
+
+func (o *validatorOptions) SetRequiredRollupTags(value []string) ValidatorOptions {
+	requiredRollupTags := make([]string, len(value))
+	copy(requiredRollupTags, value)
+	opts := *o
+	opts.requiredRollupTags = requiredRollupTags
+	return &opts
+}
+
+func (o *validatorOptions) RequiredRollupTags() []string {
+	return o.requiredRollupTags
 }
 
 func (o *validatorOptions) IsAllowedStoragePolicyFor(t metric.Type, p policy.StoragePolicy) bool {

--- a/rules/validator_test.go
+++ b/rules/validator_test.go
@@ -184,6 +184,13 @@ func TestValidatorValidateRollupRuleInvalidMetricType(t *testing.T) {
 	require.Error(t, ruleSet.Validate(validator))
 }
 
+func TestValidatorValidateRollupRuleMissingRequiredTag(t *testing.T) {
+	requiredRollupTags := []string{"requiredTag"}
+	ruleSet := testRuleSetWithRollupRules(t, testMissingRequiredTagRollupRulesConfig())
+	validator := NewValidator(testValidatorOptions().SetRequiredRollupTags(requiredRollupTags))
+	require.Error(t, ruleSet.Validate(validator))
+}
+
 func TestValidatorValidateRollupRulePolicy(t *testing.T) {
 	testStoragePolicies := []policy.StoragePolicy{
 		policy.MustParseStoragePolicy("10s:1d"),
@@ -448,6 +455,26 @@ func testInvalidMetricTypeRollupRulesConfig() []*schema.RollupRule {
 					Tombstoned: false,
 					TagFilters: map[string]string{
 						testTypeTag: "nonexistent",
+					},
+				},
+			},
+		},
+	}
+}
+
+func testMissingRequiredTagRollupRulesConfig() []*schema.RollupRule {
+	return []*schema.RollupRule{
+		&schema.RollupRule{
+			Uuid: "rollupRule1",
+			Snapshots: []*schema.RollupRuleSnapshot{
+				&schema.RollupRuleSnapshot{
+					Name:       "snapshot1",
+					Tombstoned: false,
+					Targets: []*schema.RollupTarget{
+						&schema.RollupTarget{
+							Name: "rName1",
+							Tags: []string{"rtagName1", "rtagName2"},
+						},
 					},
 				},
 			},


### PR DESCRIPTION
cc @cw9 @jeromefroe 

This PR adds logic to optionally enforce a list of required rollup tags during validation.