### PR TITLE
Adds invalid char validators for rollup tags and target names

### DIFF
--- a/rules/validator.go
+++ b/rules/validator.go
@@ -162,7 +162,7 @@ func (v *validator) validateRollupRules(rrv map[string]*RollupRuleView) error {
 func (v *validator) validateFilters(f map[string]string) error {
 	invalidChars := v.opts.TagNameInvalidChars()
 	for tag, filter := range f {
-		// Validating the filter tag name does not contain invalid chars
+		// Validating the filter tag name does not contain invalid chars.
 		if err := validateChars(tag, invalidChars); err != nil {
 			return fmt.Errorf("filter tag name %s contains invalid character: %v", tag, err)
 		}

--- a/rules/validator.go
+++ b/rules/validator.go
@@ -169,8 +169,6 @@ func (v *validator) validateFilters(f map[string]string) error {
 }
 
 func (v *validator) validateRollupTags(ruleName string, tags []string) error {
-	requiredTags := v.opts.RequiredRollupTags()
-
 	// Validate that all tags have valid characters
 	invalidChars := v.opts.RollupTagInvalidChars()
 	for _, tag := range tags {
@@ -181,6 +179,7 @@ func (v *validator) validateRollupTags(ruleName string, tags []string) error {
 	}
 
 	// Validating the list of rollup tags in the rule contain all required tags.
+	requiredTags := v.opts.RequiredRollupTags()
 	rollupTags := make(map[string]struct{}, len(tags))
 	for _, tag := range tags {
 		rollupTags[tag] = struct{}{}

--- a/rules/validator.go
+++ b/rules/validator.go
@@ -126,7 +126,7 @@ func (v *validator) validateRollupRules(rrv map[string]*RollupRuleView) error {
 
 		for _, target := range view.Targets {
 			// Validate that rollup metric name is valid.
-			if err := v.validateRollupMetricName(target.Name, view.Name); err != nil {
+			if err := v.validateRollupMetricName(view.Name, target.Name); err != nil {
 				return err
 			}
 
@@ -161,7 +161,7 @@ func (v *validator) validateRollupRules(rrv map[string]*RollupRuleView) error {
 func (v *validator) validateFilters(ruleName string, f map[string]string) error {
 	for tag, filter := range f {
 		// Validating the filter tag name does not contain invalid chars.
-		if err := v.opts.ContainsInvalidCharactersForTagName(tag); err != nil {
+		if err := v.opts.CheckInvalidCharactersForTagName(tag); err != nil {
 			return fmt.Errorf("rule %s with filter tag name %s contains invalid character: %v", ruleName, tag, err)
 		}
 
@@ -176,7 +176,7 @@ func (v *validator) validateFilters(ruleName string, f map[string]string) error 
 func (v *validator) validateRollupTags(ruleName string, tags []string) error {
 	// Validating that all tag names have valid characters.
 	for _, tag := range tags {
-		if err := v.opts.ContainsInvalidCharactersForTagName(tag); err != nil {
+		if err := v.opts.CheckInvalidCharactersForTagName(tag); err != nil {
 			return fmt.Errorf("rollup rule %s has invalid rollup tag %s: %v", ruleName, tag, err)
 		}
 	}
@@ -206,7 +206,7 @@ func (v *validator) validateRollupMetricName(ruleName, metricName string) error 
 	}
 
 	// Validate that rollup metric name has valid characters.
-	if err := v.opts.ContainsInvalidCharactersForMetricName(metricName); err != nil {
+	if err := v.opts.CheckInvalidCharactersForMetricName(metricName); err != nil {
 		return fmt.Errorf("rollup rule %s has an invalid rollup metric name %s: %v", ruleName, metricName, err)
 	}
 

--- a/rules/validator.go
+++ b/rules/validator.go
@@ -160,7 +160,13 @@ func (v *validator) validateRollupRules(rrv map[string]*RollupRuleView) error {
 }
 
 func (v *validator) validateFilters(f map[string]string) error {
-	for _, filter := range f {
+	invalidChars := v.opts.TagNameInvalidChars()
+	for tag, filter := range f {
+		// Validating the filter tag name does not contain invalid chars
+		if err := validateChars(tag, invalidChars); err != nil {
+			return fmt.Errorf("filter tag name %s contains invalid character: %v", tag, err)
+		}
+
 		// Validating the filter expression by actually constructing the filter.
 		if _, err := filters.NewFilter([]byte(filter)); err != nil {
 			return err

--- a/rules/validator.go
+++ b/rules/validator.go
@@ -73,7 +73,7 @@ func (v *validator) validateMappingRules(mrv map[string]*MappingRuleView) error 
 		namesSeen[view.Name] = struct{}{}
 
 		// Validate that the filter is valid.
-		if err := v.validateFilters(view.Filters); err != nil {
+		if err := v.validateFilters(view.Name, view.Filters); err != nil {
 			return err
 		}
 
@@ -111,7 +111,7 @@ func (v *validator) validateRollupRules(rrv map[string]*RollupRuleView) error {
 		namesSeen[view.Name] = struct{}{}
 
 		// Validate that the filter is valid.
-		if err := v.validateFilters(view.Filters); err != nil {
+		if err := v.validateFilters(view.Name, view.Filters); err != nil {
 			return err
 		}
 
@@ -158,11 +158,11 @@ func (v *validator) validateRollupRules(rrv map[string]*RollupRuleView) error {
 	return nil
 }
 
-func (v *validator) validateFilters(f map[string]string) error {
+func (v *validator) validateFilters(ruleName string, f map[string]string) error {
 	for tag, filter := range f {
 		// Validating the filter tag name does not contain invalid chars.
-		if containsInvalidChar, err := v.opts.ContainsInvalidCharactersForTagName(tag); containsInvalidChar {
-			return fmt.Errorf("filter tag name %s contains invalid character: %v", tag, err)
+		if err := v.opts.ContainsInvalidCharactersForTagName(tag); err != nil {
+			return fmt.Errorf("rule %s with filter tag name %s contains invalid character: %v", ruleName, tag, err)
 		}
 
 		// Validating the filter expression by actually constructing the filter.
@@ -176,8 +176,8 @@ func (v *validator) validateFilters(f map[string]string) error {
 func (v *validator) validateRollupTags(ruleName string, tags []string) error {
 	// Validating that all tag names have valid characters.
 	for _, tag := range tags {
-		if containsInvalidChar, err := v.opts.ContainsInvalidCharactersForTagName(tag); containsInvalidChar {
-			return fmt.Errorf("rollup rule %s has invalid rolup tag %s: %v", ruleName, tag, err)
+		if err := v.opts.ContainsInvalidCharactersForTagName(tag); err != nil {
+			return fmt.Errorf("rollup rule %s has invalid rollup tag %s: %v", ruleName, tag, err)
 		}
 	}
 
@@ -199,14 +199,14 @@ func (v *validator) validateRollupTags(ruleName string, tags []string) error {
 	return nil
 }
 
-func (v *validator) validateRollupMetricName(metricName, ruleName string) error {
+func (v *validator) validateRollupMetricName(ruleName, metricName string) error {
 	// Validate that rollup metric name is not empty.
 	if metricName == "" {
 		return fmt.Errorf("rollup rule %s has an empty rollup metric name", ruleName)
 	}
 
 	// Validate that rollup metric name has valid characters.
-	if containsInvalidChar, err := v.opts.ContainsInvalidCharactersForMetricName(metricName); containsInvalidChar {
+	if err := v.opts.ContainsInvalidCharactersForMetricName(metricName); err != nil {
 		return fmt.Errorf("rollup rule %s has an invalid rollup metric name %s: %v", ruleName, metricName, err)
 	}
 

--- a/rules/validator_options.go
+++ b/rules/validator_options.go
@@ -56,17 +56,17 @@ type ValidatorOptions interface {
 	// RequiredRollupTags returns the list of required rollup tags.
 	RequiredRollupTags() []string
 
-	// SetRollupTagInvalidChars sets the list of invalid chars for a rollup metric tag.
-	SetRollupTagInvalidChars([]rune) ValidatorOptions
+	// SetTagNameInvalidChars sets the list of invalid chars for a tag name.
+	SetTagNameInvalidChars([]rune) ValidatorOptions
 
-	// RollupTagInvalidChars gets the list of invalid chars for a rollup metric tag.
-	RollupTagInvalidChars() []rune
+	// tagNameInvalidChars gets the list of invalid chars for a tag name.
+	TagNameInvalidChars() map[rune]struct{}
 
-	// SetRollupTargetNameInvalidChars sets the list of invalid chars for a rollup target name.
-	SetRollupTargetNameInvalidChars([]rune) ValidatorOptions
+	// SetMetricNameInvalidChars sets the list of invalid chars for a metric name.
+	SetMetricNameInvalidChars([]rune) ValidatorOptions
 
-	// RollupTargetNameInvalidChars gets the list of invalid chars for a rollup target name.
-	RollupTargetNameInvalidChars() []rune
+	// MetricNameInvalidChars gets the list of invalid chars for a metric name.
+	MetricNameInvalidChars() map[rune]struct{}
 
 	// IsAllowedStoragePolicyFor determines whether a given storage policy is allowed for the
 	// given metric type.
@@ -87,8 +87,8 @@ type validatorOptions struct {
 	defaultAllowedCustomAggregationTypes map[policy.AggregationType]struct{}
 	metricTypesFn                        MetricTypesFn
 	requiredRollupTags                   []string
-	rollupTargetNameInvalidChars         []rune
-	rollupTagInvalidChars                []rune
+	metricNameInvalidChars               map[rune]struct{}
+	tagNameInvalidChars                  map[rune]struct{}
 	metadatasByType                      map[metric.Type]validationMetadata
 }
 
@@ -144,28 +144,32 @@ func (o *validatorOptions) RequiredRollupTags() []string {
 	return o.requiredRollupTags
 }
 
-func (o *validatorOptions) SetRollupTagInvalidChars(value []rune) ValidatorOptions {
-	rollupTagInvalidChars := make([]rune, len(value))
-	copy(rollupTagInvalidChars, value)
+func (o *validatorOptions) SetTagNameInvalidChars(values []rune) ValidatorOptions {
+	tagNameInvalidChars := make(map[rune]struct{}, len(values))
+	for _, v := range values {
+		tagNameInvalidChars[v] = struct{}{}
+	}
 	opts := *o
-	opts.rollupTagInvalidChars = rollupTagInvalidChars
+	opts.tagNameInvalidChars = tagNameInvalidChars
 	return &opts
 }
 
-func (o *validatorOptions) RollupTagInvalidChars() []rune {
-	return o.rollupTagInvalidChars
+func (o *validatorOptions) TagNameInvalidChars() map[rune]struct{} {
+	return o.tagNameInvalidChars
 }
 
-func (o *validatorOptions) SetRollupTargetNameInvalidChars(value []rune) ValidatorOptions {
-	rollupTargetNameInvalidChars := make([]rune, len(value))
-	copy(rollupTargetNameInvalidChars, value)
+func (o *validatorOptions) SetMetricNameInvalidChars(values []rune) ValidatorOptions {
+	metricNameInvalidChars := make(map[rune]struct{}, len(values))
+	for _, v := range values {
+		metricNameInvalidChars[v] = struct{}{}
+	}
 	opts := *o
-	opts.rollupTargetNameInvalidChars = rollupTargetNameInvalidChars
+	opts.metricNameInvalidChars = metricNameInvalidChars
 	return &opts
 }
 
-func (o *validatorOptions) RollupTargetNameInvalidChars() []rune {
-	return o.rollupTargetNameInvalidChars
+func (o *validatorOptions) MetricNameInvalidChars() map[rune]struct{} {
+	return o.metricNameInvalidChars
 }
 
 func (o *validatorOptions) IsAllowedStoragePolicyFor(t metric.Type, p policy.StoragePolicy) bool {

--- a/rules/validator_options.go
+++ b/rules/validator_options.go
@@ -22,6 +22,7 @@ package rules
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/m3db/m3metrics/metric"
 	"github.com/m3db/m3metrics/policy"
@@ -228,7 +229,7 @@ func validateChars(str string, invalidChars map[rune]struct{}) error {
 	// Validate that given string doesn't contain an invalid character.
 	for _, char := range str {
 		if _, exists := invalidChars[char]; exists {
-			return fmt.Errorf("%s contains invalid character %v", str, char)
+			return fmt.Errorf("%s contains invalid character %s", str, strconv.QuoteRune(char))
 		}
 	}
 	return nil

--- a/rules/validator_options.go
+++ b/rules/validator_options.go
@@ -61,16 +61,16 @@ type ValidatorOptions interface {
 	// SetTagNameInvalidChars sets the list of invalid chars for a tag name.
 	SetTagNameInvalidChars(value []rune) ValidatorOptions
 
-	// ContainsInvalidCharactersForTagName returns whether the given tag name contains invalid characters
-	// with an error if invalid character(s) present.
-	ContainsInvalidCharactersForTagName(tagName string) error
+	// CheckInvalidCharactersForTagName checks if the given tag name contains invalid characters
+	// returning an error if invalid character(s) present.
+	CheckInvalidCharactersForTagName(tagName string) error
 
 	// SetMetricNameInvalidChars sets the list of invalid chars for a metric name.
 	SetMetricNameInvalidChars(value []rune) ValidatorOptions
 
-	// ContainsInvalidCharactersForMetricName returns whether the given metric name contains invalid characters
-	// with an error if invalid character(s) present.
-	ContainsInvalidCharactersForMetricName(metricName string) error
+	// CheckInvalidCharactersForMetricName checks if the given metric name contains invalid characters
+	// returning an error if invalid character(s) present.
+	CheckInvalidCharactersForMetricName(metricName string) error
 
 	// IsAllowedStoragePolicyFor determines whether a given storage policy is allowed for the
 	// given metric type.
@@ -158,7 +158,7 @@ func (o *validatorOptions) SetTagNameInvalidChars(values []rune) ValidatorOption
 	return &opts
 }
 
-func (o *validatorOptions) ContainsInvalidCharactersForTagName(tagName string) error {
+func (o *validatorOptions) CheckInvalidCharactersForTagName(tagName string) error {
 	return validateChars(tagName, o.tagNameInvalidChars)
 }
 
@@ -172,7 +172,7 @@ func (o *validatorOptions) SetMetricNameInvalidChars(values []rune) ValidatorOpt
 	return &opts
 }
 
-func (o *validatorOptions) ContainsInvalidCharactersForMetricName(metricName string) error {
+func (o *validatorOptions) CheckInvalidCharactersForMetricName(metricName string) error {
 	return validateChars(metricName, o.metricNameInvalidChars)
 }
 

--- a/rules/validator_options.go
+++ b/rules/validator_options.go
@@ -59,18 +59,18 @@ type ValidatorOptions interface {
 	RequiredRollupTags() []string
 
 	// SetTagNameInvalidChars sets the list of invalid chars for a tag name.
-	SetTagNameInvalidChars([]rune) ValidatorOptions
+	SetTagNameInvalidChars(value []rune) ValidatorOptions
 
 	// ContainsInvalidCharactersForTagName returns whether the given tag name contains invalid characters
 	// with an error if invalid character(s) present.
-	ContainsInvalidCharactersForTagName(tagName string) (bool, error)
+	ContainsInvalidCharactersForTagName(tagName string) error
 
 	// SetMetricNameInvalidChars sets the list of invalid chars for a metric name.
-	SetMetricNameInvalidChars([]rune) ValidatorOptions
+	SetMetricNameInvalidChars(value []rune) ValidatorOptions
 
 	// ContainsInvalidCharactersForMetricName returns whether the given metric name contains invalid characters
 	// with an error if invalid character(s) present.
-	ContainsInvalidCharactersForMetricName(metricName string) (bool, error)
+	ContainsInvalidCharactersForMetricName(metricName string) error
 
 	// IsAllowedStoragePolicyFor determines whether a given storage policy is allowed for the
 	// given metric type.
@@ -158,11 +158,8 @@ func (o *validatorOptions) SetTagNameInvalidChars(values []rune) ValidatorOption
 	return &opts
 }
 
-func (o *validatorOptions) ContainsInvalidCharactersForTagName(tagName string) (bool, error) {
-	if err := validateChars(tagName, o.tagNameInvalidChars); err != nil {
-		return true, err
-	}
-	return false, nil
+func (o *validatorOptions) ContainsInvalidCharactersForTagName(tagName string) error {
+	return validateChars(tagName, o.tagNameInvalidChars)
 }
 
 func (o *validatorOptions) SetMetricNameInvalidChars(values []rune) ValidatorOptions {
@@ -175,11 +172,8 @@ func (o *validatorOptions) SetMetricNameInvalidChars(values []rune) ValidatorOpt
 	return &opts
 }
 
-func (o *validatorOptions) ContainsInvalidCharactersForMetricName(metricName string) (bool, error) {
-	if err := validateChars(metricName, o.metricNameInvalidChars); err != nil {
-		return true, err
-	}
-	return false, nil
+func (o *validatorOptions) ContainsInvalidCharactersForMetricName(metricName string) error {
+	return validateChars(metricName, o.metricNameInvalidChars)
 }
 
 func (o *validatorOptions) IsAllowedStoragePolicyFor(t metric.Type, p policy.StoragePolicy) bool {

--- a/rules/validator_options.go
+++ b/rules/validator_options.go
@@ -56,6 +56,18 @@ type ValidatorOptions interface {
 	// RequiredRollupTags returns the list of required rollup tags.
 	RequiredRollupTags() []string
 
+	// SetRollupTagInvalidChars sets the list of invalid chars for a rollup metric tag.
+	SetRollupTagInvalidChars([]rune) ValidatorOptions
+
+	// RollupTagInvalidChars gets the list of invalid chars for a rollup metric tag.
+	RollupTagInvalidChars() []rune
+
+	// SetRollupTargetNameInvalidChars sets the list of invalid chars for a rollup target name.
+	SetRollupTargetNameInvalidChars([]rune) ValidatorOptions
+
+	// RollupTargetNameInvalidChars gets the list of invalid chars for a rollup target name.
+	RollupTargetNameInvalidChars() []rune
+
 	// IsAllowedStoragePolicyFor determines whether a given storage policy is allowed for the
 	// given metric type.
 	IsAllowedStoragePolicyFor(t metric.Type, p policy.StoragePolicy) bool
@@ -75,6 +87,8 @@ type validatorOptions struct {
 	defaultAllowedCustomAggregationTypes map[policy.AggregationType]struct{}
 	metricTypesFn                        MetricTypesFn
 	requiredRollupTags                   []string
+	rollupTargetNameInvalidChars         []rune
+	rollupTagInvalidChars                []rune
 	metadatasByType                      map[metric.Type]validationMetadata
 }
 
@@ -128,6 +142,30 @@ func (o *validatorOptions) SetRequiredRollupTags(value []string) ValidatorOption
 
 func (o *validatorOptions) RequiredRollupTags() []string {
 	return o.requiredRollupTags
+}
+
+func (o *validatorOptions) SetRollupTagInvalidChars(value []rune) ValidatorOptions {
+	rollupTagInvalidChars := make([]rune, len(value))
+	copy(rollupTagInvalidChars, value)
+	opts := *o
+	opts.rollupTagInvalidChars = rollupTagInvalidChars
+	return &opts
+}
+
+func (o *validatorOptions) RollupTagInvalidChars() []rune {
+	return o.rollupTagInvalidChars
+}
+
+func (o *validatorOptions) SetRollupTargetNameInvalidChars(value []rune) ValidatorOptions {
+	rollupTargetNameInvalidChars := make([]rune, len(value))
+	copy(rollupTargetNameInvalidChars, value)
+	opts := *o
+	opts.rollupTargetNameInvalidChars = rollupTargetNameInvalidChars
+	return &opts
+}
+
+func (o *validatorOptions) RollupTargetNameInvalidChars() []rune {
+	return o.rollupTargetNameInvalidChars
 }
 
 func (o *validatorOptions) IsAllowedStoragePolicyFor(t metric.Type, p policy.StoragePolicy) bool {

--- a/rules/validator_test.go
+++ b/rules/validator_test.go
@@ -191,6 +191,34 @@ func TestValidatorValidateRollupRuleMissingRequiredTag(t *testing.T) {
 	require.Error(t, ruleSet.Validate(validator))
 }
 
+func TestValidatorValidateRollupRuleWithInvalidRollupTargetName(t *testing.T) {
+	invalidChars := []rune{'$'}
+	ruleSet := testRuleSetWithRollupRules(t, testTargetNameRollupRulesConfig())
+	validator := NewValidator(testValidatorOptions().SetRollupTargetNameInvalidChars(invalidChars))
+	require.Error(t, ruleSet.Validate(validator))
+}
+
+func TestValidatorValidateRollupRuleWithValidRollupTargetName(t *testing.T) {
+	invalidChars := []rune{' ', '%'}
+	ruleSet := testRuleSetWithRollupRules(t, testTargetNameRollupRulesConfig())
+	validator := NewValidator(testValidatorOptions().SetRollupTargetNameInvalidChars(invalidChars))
+	require.NoError(t, ruleSet.Validate(validator))
+}
+
+func TestValidatorValidateRollupRuleWithInvalidTag(t *testing.T) {
+	invalidChars := []rune{'$'}
+	ruleSet := testRuleSetWithRollupRules(t, testTagRollupRulesConfig())
+	validator := NewValidator(testValidatorOptions().SetRollupTagInvalidChars(invalidChars))
+	require.Error(t, ruleSet.Validate(validator))
+}
+
+func TestValidatorValidateRollupRuleWithValidTag(t *testing.T) {
+	invalidChars := []rune{' ', '%'}
+	ruleSet := testRuleSetWithRollupRules(t, testTagRollupRulesConfig())
+	validator := NewValidator(testValidatorOptions().SetRollupTagInvalidChars(invalidChars))
+	require.NoError(t, ruleSet.Validate(validator))
+}
+
 func TestValidatorValidateRollupRulePolicy(t *testing.T) {
 	testStoragePolicies := []policy.StoragePolicy{
 		policy.MustParseStoragePolicy("10s:1d"),
@@ -473,6 +501,46 @@ func testMissingRequiredTagRollupRulesConfig() []*schema.RollupRule {
 					Targets: []*schema.RollupTarget{
 						&schema.RollupTarget{
 							Name: "rName1",
+							Tags: []string{"rtagName1", "rtagName2"},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func testTagRollupRulesConfig() []*schema.RollupRule {
+	return []*schema.RollupRule{
+		&schema.RollupRule{
+			Uuid: "rollupRule1",
+			Snapshots: []*schema.RollupRuleSnapshot{
+				&schema.RollupRuleSnapshot{
+					Name:       "snapshot1",
+					Tombstoned: false,
+					Targets: []*schema.RollupTarget{
+						&schema.RollupTarget{
+							Name: "rName1",
+							Tags: []string{"rtagName1", "rtagName2$", "$"},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func testTargetNameRollupRulesConfig() []*schema.RollupRule {
+	return []*schema.RollupRule{
+		&schema.RollupRule{
+			Uuid: "rollupRule1",
+			Snapshots: []*schema.RollupRuleSnapshot{
+				&schema.RollupRuleSnapshot{
+					Name:       "snapshot1",
+					Tombstoned: false,
+					Targets: []*schema.RollupTarget{
+						&schema.RollupTarget{
+							Name: "rName$1",
 							Tags: []string{"rtagName1", "rtagName2"},
 						},
 					},

--- a/rules/validator_test.go
+++ b/rules/validator_test.go
@@ -191,31 +191,46 @@ func TestValidatorValidateRollupRuleMissingRequiredTag(t *testing.T) {
 	require.Error(t, ruleSet.Validate(validator))
 }
 
-func TestValidatorValidateRollupRuleWithInvalidRollupTargetName(t *testing.T) {
+func TestValidateChars(t *testing.T) {
+	invalidChars := map[rune]struct{}{
+		'$': struct{}{},
+	}
+	require.Error(t, validateChars("test$", invalidChars))
+	require.NoError(t, validateChars("test", invalidChars))
+}
+
+func TestValidatorValidateRollupRuleWithInvalidMetricName(t *testing.T) {
 	invalidChars := []rune{'$'}
-	ruleSet := testRuleSetWithRollupRules(t, testTargetNameRollupRulesConfig())
-	validator := NewValidator(testValidatorOptions().SetRollupTargetNameInvalidChars(invalidChars))
+	ruleSet := testRuleSetWithRollupRules(t, testMetricNameRollupRulesConfig())
+	validator := NewValidator(testValidatorOptions().SetMetricNameInvalidChars(invalidChars))
 	require.Error(t, ruleSet.Validate(validator))
 }
 
-func TestValidatorValidateRollupRuleWithValidRollupTargetName(t *testing.T) {
+func TestValidatorValidateRollupRuleWithEmptyMetricName(t *testing.T) {
+	invalidChars := []rune{'$'}
+	ruleSet := testRuleSetWithRollupRules(t, testEmptyMetricNameRollupRulesConfig())
+	validator := NewValidator(testValidatorOptions().SetMetricNameInvalidChars(invalidChars))
+	require.Error(t, ruleSet.Validate(validator))
+}
+
+func TestValidatorValidateRollupRuleWithValidMetricName(t *testing.T) {
 	invalidChars := []rune{' ', '%'}
-	ruleSet := testRuleSetWithRollupRules(t, testTargetNameRollupRulesConfig())
-	validator := NewValidator(testValidatorOptions().SetRollupTargetNameInvalidChars(invalidChars))
+	ruleSet := testRuleSetWithRollupRules(t, testMetricNameRollupRulesConfig())
+	validator := NewValidator(testValidatorOptions().SetMetricNameInvalidChars(invalidChars))
 	require.NoError(t, ruleSet.Validate(validator))
 }
 
-func TestValidatorValidateRollupRuleWithInvalidTag(t *testing.T) {
+func TestValidatorValidateRollupRuleWithInvalidTagName(t *testing.T) {
 	invalidChars := []rune{'$'}
-	ruleSet := testRuleSetWithRollupRules(t, testTagRollupRulesConfig())
-	validator := NewValidator(testValidatorOptions().SetRollupTagInvalidChars(invalidChars))
+	ruleSet := testRuleSetWithRollupRules(t, testTagNameRollupRulesConfig())
+	validator := NewValidator(testValidatorOptions().SetTagNameInvalidChars(invalidChars))
 	require.Error(t, ruleSet.Validate(validator))
 }
 
-func TestValidatorValidateRollupRuleWithValidTag(t *testing.T) {
+func TestValidatorValidateRollupRuleWithValidTagName(t *testing.T) {
 	invalidChars := []rune{' ', '%'}
-	ruleSet := testRuleSetWithRollupRules(t, testTagRollupRulesConfig())
-	validator := NewValidator(testValidatorOptions().SetRollupTagInvalidChars(invalidChars))
+	ruleSet := testRuleSetWithRollupRules(t, testTagNameRollupRulesConfig())
+	validator := NewValidator(testValidatorOptions().SetTagNameInvalidChars(invalidChars))
 	require.NoError(t, ruleSet.Validate(validator))
 }
 
@@ -510,7 +525,7 @@ func testMissingRequiredTagRollupRulesConfig() []*schema.RollupRule {
 	}
 }
 
-func testTagRollupRulesConfig() []*schema.RollupRule {
+func testTagNameRollupRulesConfig() []*schema.RollupRule {
 	return []*schema.RollupRule{
 		&schema.RollupRule{
 			Uuid: "rollupRule1",
@@ -530,7 +545,7 @@ func testTagRollupRulesConfig() []*schema.RollupRule {
 	}
 }
 
-func testTargetNameRollupRulesConfig() []*schema.RollupRule {
+func testMetricNameRollupRulesConfig() []*schema.RollupRule {
 	return []*schema.RollupRule{
 		&schema.RollupRule{
 			Uuid: "rollupRule1",
@@ -541,6 +556,26 @@ func testTargetNameRollupRulesConfig() []*schema.RollupRule {
 					Targets: []*schema.RollupTarget{
 						&schema.RollupTarget{
 							Name: "rName$1",
+							Tags: []string{"rtagName1", "rtagName2"},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func testEmptyMetricNameRollupRulesConfig() []*schema.RollupRule {
+	return []*schema.RollupRule{
+		&schema.RollupRule{
+			Uuid: "rollupRule1",
+			Snapshots: []*schema.RollupRuleSnapshot{
+				&schema.RollupRuleSnapshot{
+					Name:       "snapshot1",
+					Tombstoned: false,
+					Targets: []*schema.RollupTarget{
+						&schema.RollupTarget{
+							Name: "",
 							Tags: []string{"rtagName1", "rtagName2"},
 						},
 					},

--- a/rules/validator_test.go
+++ b/rules/validator_test.go
@@ -70,6 +70,23 @@ func TestValidatorValidateMappingRuleInvalidFilter(t *testing.T) {
 	require.Error(t, rs.Validate(validator))
 }
 
+func TestValidatorValidateMappingRuleInvalidFilterTagName(t *testing.T) {
+	invalidChars := []rune{'$'}
+	invalidFilterSnapshot := &mappingRuleSnapshot{
+		rawFilters: map[string]string{
+			"random$Tag": "!=",
+		},
+	}
+	invalidFilterRule := &mappingRule{
+		snapshots: []*mappingRuleSnapshot{invalidFilterSnapshot},
+	}
+	rs := &ruleSet{
+		mappingRules: []*mappingRule{invalidFilterRule},
+	}
+	validator := NewValidator(testValidatorOptions().SetTagNameInvalidChars(invalidChars))
+	require.Error(t, rs.Validate(validator))
+}
+
 func TestValidatorValidateMappingRuleInvalidMetricType(t *testing.T) {
 	ruleSet := testRuleSetWithMappingRules(t, testInvalidMetricTypeMappingRulesConfig())
 	validator := NewValidator(testValidatorOptions())
@@ -175,6 +192,23 @@ func TestValidatorValidateRollupRuleInvalidFilter(t *testing.T) {
 		rollupRules: []*rollupRule{invalidFilterRule},
 	}
 	validator := NewValidator(testValidatorOptions())
+	require.Error(t, rs.Validate(validator))
+}
+
+func TestValidatorValidateRollupRuleInvalidFilterTagName(t *testing.T) {
+	invalidChars := []rune{'$'}
+	invalidFilterSnapshot := &mappingRuleSnapshot{
+		rawFilters: map[string]string{
+			"random$Tag": "!=",
+		},
+	}
+	invalidFilterRule := &mappingRule{
+		snapshots: []*mappingRuleSnapshot{invalidFilterSnapshot},
+	}
+	rs := &ruleSet{
+		mappingRules: []*mappingRule{invalidFilterRule},
+	}
+	validator := NewValidator(testValidatorOptions().SetTagNameInvalidChars(invalidChars))
 	require.Error(t, rs.Validate(validator))
 }
 


### PR DESCRIPTION
Adds to validator_options as well. Wasn't sure whether to call RollupTargetName or RollupMetricName