### PR TITLE
Stricter check to compare staged policies

### DIFF
--- a/policy/staged_policy.go
+++ b/policy/staged_policy.go
@@ -63,9 +63,11 @@ func (p StagedPolicies) Policies() ([]Policy, bool) {
 	return p.policies, p.hasDefaultPolicies()
 }
 
-// SamePolicies returns whether two staged policies have the same policy list,
-// assuming the policies are sorted in the same order.
-func (p StagedPolicies) SamePolicies(other StagedPolicies) bool {
+// Equals returns whether two staged policies are equal.
+func (p StagedPolicies) Equals(other StagedPolicies) bool {
+	if p.CutoverNanos != other.CutoverNanos || p.Tombstoned != other.Tombstoned {
+		return false
+	}
 	currPolicies, currIsDefault := p.Policies()
 	otherPolicies, otherIsDefault := other.Policies()
 	if currIsDefault && otherIsDefault {

--- a/policy/staged_policy_test.go
+++ b/policy/staged_policy_test.go
@@ -48,7 +48,7 @@ func TestStagedPoliciesHasCustomPolicies(t *testing.T) {
 	require.Equal(t, policies, actual)
 }
 
-func TestStagedPoliciesSamePoliciesDefaultPolicies(t *testing.T) {
+func TestStagedPoliciesEquals(t *testing.T) {
 	inputs := []struct {
 		sp       [2]StagedPolicies
 		expected bool
@@ -56,7 +56,7 @@ func TestStagedPoliciesSamePoliciesDefaultPolicies(t *testing.T) {
 		{
 			sp: [2]StagedPolicies{
 				NewStagedPolicies(0, false, nil),
-				NewStagedPolicies(0, true, []Policy{}),
+				NewStagedPolicies(0, false, []Policy{}),
 			},
 			expected: true,
 		},
@@ -70,6 +70,33 @@ func TestStagedPoliciesSamePoliciesDefaultPolicies(t *testing.T) {
 				}),
 			},
 			expected: true,
+		},
+		{
+			sp: [2]StagedPolicies{
+				NewStagedPolicies(0, false, []Policy{
+					NewPolicy(NewStoragePolicy(10*time.Second, xtime.Second, 6*time.Hour), DefaultAggregationID),
+					NewPolicy(NewStoragePolicy(time.Minute, xtime.Minute, 12*time.Hour), DefaultAggregationID),
+				}),
+				NewStagedPolicies(0, false, []Policy{
+					NewPolicy(NewStoragePolicy(10*time.Second, xtime.Second, 6*time.Hour), DefaultAggregationID),
+					NewPolicy(NewStoragePolicy(time.Minute, xtime.Minute, 12*time.Hour), DefaultAggregationID),
+				}),
+			},
+			expected: true,
+		},
+		{
+			sp: [2]StagedPolicies{
+				NewStagedPolicies(0, false, nil),
+				NewStagedPolicies(1, false, nil),
+			},
+			expected: false,
+		},
+		{
+			sp: [2]StagedPolicies{
+				NewStagedPolicies(0, false, nil),
+				NewStagedPolicies(0, true, nil),
+			},
+			expected: false,
 		},
 		{
 			sp: [2]StagedPolicies{
@@ -96,7 +123,7 @@ func TestStagedPoliciesSamePoliciesDefaultPolicies(t *testing.T) {
 		{
 			sp: [2]StagedPolicies{
 				NewStagedPolicies(0, false, nil),
-				NewStagedPolicies(0, true, []Policy{
+				NewStagedPolicies(0, false, []Policy{
 					NewPolicy(NewStoragePolicy(10*time.Second, xtime.Second, 6*time.Hour), DefaultAggregationID),
 					NewPolicy(NewStoragePolicy(time.Minute, xtime.Minute, 12*time.Hour), DefaultAggregationID),
 				}),
@@ -109,20 +136,7 @@ func TestStagedPoliciesSamePoliciesDefaultPolicies(t *testing.T) {
 					NewPolicy(NewStoragePolicy(10*time.Second, xtime.Second, 6*time.Hour), DefaultAggregationID),
 					NewPolicy(NewStoragePolicy(time.Minute, xtime.Minute, 12*time.Hour), DefaultAggregationID),
 				}),
-				NewStagedPolicies(0, true, []Policy{
-					NewPolicy(NewStoragePolicy(10*time.Second, xtime.Second, 6*time.Hour), DefaultAggregationID),
-					NewPolicy(NewStoragePolicy(time.Minute, xtime.Minute, 12*time.Hour), DefaultAggregationID),
-				}),
-			},
-			expected: true,
-		},
-		{
-			sp: [2]StagedPolicies{
-				NewStagedPolicies(1000, false, []Policy{
-					NewPolicy(NewStoragePolicy(10*time.Second, xtime.Second, 6*time.Hour), DefaultAggregationID),
-					NewPolicy(NewStoragePolicy(time.Minute, xtime.Minute, 12*time.Hour), DefaultAggregationID),
-				}),
-				NewStagedPolicies(0, true, []Policy{
+				NewStagedPolicies(0, false, []Policy{
 					NewPolicy(NewStoragePolicy(10*time.Second, xtime.Second, 6*time.Hour), DefaultAggregationID),
 					NewPolicy(NewStoragePolicy(time.Minute, xtime.Minute, 12*time.Hour), DefaultAggregationID),
 					NewPolicy(NewStoragePolicy(10*time.Minute, xtime.Minute, 24*time.Hour), DefaultAggregationID),
@@ -132,21 +146,34 @@ func TestStagedPoliciesSamePoliciesDefaultPolicies(t *testing.T) {
 		},
 		{
 			sp: [2]StagedPolicies{
-				NewStagedPolicies(0, true, []Policy{
+				NewStagedPolicies(0, false, []Policy{
 					NewPolicy(NewStoragePolicy(10*time.Second, xtime.Second, 6*time.Hour), DefaultAggregationID),
 					NewPolicy(NewStoragePolicy(time.Minute, xtime.Minute, 12*time.Hour), DefaultAggregationID),
 					NewPolicy(NewStoragePolicy(10*time.Minute, xtime.Minute, 24*time.Hour), DefaultAggregationID),
 				}),
-				NewStagedPolicies(1000, false, []Policy{
+				NewStagedPolicies(0, false, []Policy{
 					NewPolicy(NewStoragePolicy(10*time.Second, xtime.Second, 6*time.Hour), DefaultAggregationID),
 					NewPolicy(NewStoragePolicy(time.Minute, xtime.Minute, 12*time.Hour), DefaultAggregationID),
+				}),
+			},
+			expected: false,
+		},
+		{
+			sp: [2]StagedPolicies{
+				NewStagedPolicies(0, false, []Policy{
+					NewPolicy(NewStoragePolicy(10*time.Second, xtime.Second, 6*time.Hour), DefaultAggregationID),
+					NewPolicy(NewStoragePolicy(time.Minute, xtime.Minute, 12*time.Hour), DefaultAggregationID),
+				}),
+				NewStagedPolicies(0, false, []Policy{
+					NewPolicy(NewStoragePolicy(10*time.Second, xtime.Second, 6*time.Hour), DefaultAggregationID),
+					NewPolicy(NewStoragePolicy(time.Minute, xtime.Minute, 24*time.Hour), DefaultAggregationID),
 				}),
 			},
 			expected: false,
 		},
 	}
 	for _, input := range inputs {
-		require.Equal(t, input.expected, input.sp[0].SamePolicies(input.sp[1]))
+		require.Equal(t, input.expected, input.sp[0].Equals(input.sp[1]))
 	}
 }
 

--- a/rules/ruleset.go
+++ b/rules/ruleset.go
@@ -1052,7 +1052,7 @@ func mergeMappingResults(
 		return policy.PoliciesList{nextMappingPolicies}
 	}
 	currMappingPolicies := currMappingResults[len(currMappingResults)-1]
-	if currMappingPolicies.SamePolicies(nextMappingPolicies) {
+	if currMappingPolicies.Equals(nextMappingPolicies) {
 		return currMappingResults
 	}
 	currMappingResults = append(currMappingResults, nextMappingPolicies)
@@ -1082,7 +1082,7 @@ func mergeRollupResults(
 		if compareResult == 0 {
 			currRollupPolicies := currRollupResult.PoliciesList[len(currRollupResult.PoliciesList)-1]
 			nextRollupPolicies := nextRollupResult.PoliciesList[0]
-			if !currRollupPolicies.SamePolicies(nextRollupPolicies) {
+			if !currRollupPolicies.Equals(nextRollupPolicies) {
 				currRollupResults[currRollupIdx].PoliciesList = append(currRollupResults[currRollupIdx].PoliciesList, nextRollupPolicies)
 			}
 			currRollupIdx++


### PR DESCRIPTION
cc @cw9 @jeromefroe 

This PR renames `SamePolicies` to `Equals` and perform stricter checks for equality semantics.