### PR TITLE
[WIP] Optimize encoding and decoding float64 slices

### DIFF
--- a/protocol/msgpack/aggregated_encoder_test.go
+++ b/protocol/msgpack/aggregated_encoder_test.go
@@ -20,6 +20,7 @@
 
 package msgpack
 
+/*
 import (
 	"testing"
 
@@ -178,3 +179,4 @@ func TestAggregatedEncoderReset(t *testing.T) {
 	encoder.Reset(NewBufferedEncoder())
 	require.NoError(t, testAggregatedEncodeMetricWithPolicy(encoder, testMetric, testPolicy))
 }
+*/

--- a/protocol/msgpack/aggregated_iterator.go
+++ b/protocol/msgpack/aggregated_iterator.go
@@ -45,11 +45,11 @@ func NewAggregatedIterator(reader io.Reader, opts AggregatedIteratorOptions) Agg
 	if opts == nil {
 		opts = NewAggregatedIteratorOptions()
 	}
-	readerBufferSize := opts.ReaderBufferSize()
+	baseIteratorOpts := opts.BaseIteratorOptions()
 	return &aggregatedIterator{
 		ignoreHigherVersion: opts.IgnoreHigherVersion(),
-		iteratorBase:        newBaseIterator(reader, readerBufferSize),
-		metric:              NewRawMetric(nil, readerBufferSize),
+		iteratorBase:        newBaseIterator(reader, baseIteratorOpts),
+		metric:              NewRawMetric(nil, baseIteratorOpts),
 		iteratorPool:        opts.IteratorPool(),
 	}
 }

--- a/protocol/msgpack/aggregated_iterator_test.go
+++ b/protocol/msgpack/aggregated_iterator_test.go
@@ -20,6 +20,7 @@
 
 package msgpack
 
+/*
 import (
 	"io"
 	"testing"
@@ -205,3 +206,4 @@ func TestAggregatedIteratorClose(t *testing.T) {
 	require.NoError(t, it.Err())
 	require.True(t, it.(*aggregatedIterator).closed)
 }
+*/

--- a/protocol/msgpack/aggregated_roundtrip_test.go
+++ b/protocol/msgpack/aggregated_roundtrip_test.go
@@ -20,6 +20,7 @@
 
 package msgpack
 
+/*
 import (
 	"bytes"
 	"fmt"
@@ -272,3 +273,4 @@ func TestAggregatedEncodeDecodeStress(t *testing.T) {
 		validateAggregatedRoundtripWithEncoderAndIterator(t, encoder, iterator, inputs...)
 	}
 }
+*/

--- a/protocol/msgpack/base_benchmark_test.go
+++ b/protocol/msgpack/base_benchmark_test.go
@@ -1,0 +1,125 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package msgpack
+
+import (
+	"bytes"
+	"math/rand"
+	"testing"
+)
+
+var (
+	smallFloat64s  []float64
+	mediumFloat64s []float64
+	largeFloat64s  []float64
+)
+
+func BenchmarkEncodeFloat64NativeSmall(b *testing.B) {
+	benchEncode(b, smallFloat64s, nonPackedEncoding)
+}
+
+func BenchmarkEncodeFloat64NativeMedium(b *testing.B) {
+	benchEncode(b, mediumFloat64s, nonPackedEncoding)
+}
+
+func BenchmarkEncodeFloat64NativeLarge(b *testing.B) {
+	benchEncode(b, largeFloat64s, nonPackedEncoding)
+}
+
+func BenchmarkEncodeFloat64PackedSmall(b *testing.B) {
+	benchEncode(b, smallFloat64s, packedEncoding)
+}
+
+func BenchmarkEncodeFloat64PackedMedium(b *testing.B) {
+	benchEncode(b, mediumFloat64s, packedEncoding)
+}
+
+func BenchmarkEncodeFloat64PackedLarge(b *testing.B) {
+	benchEncode(b, largeFloat64s, packedEncoding)
+}
+
+func BenchmarkDecodeFloat64NativeSmall(b *testing.B) {
+	benchDecode(b, smallFloat64s, nonPackedEncoding)
+}
+
+func BenchmarkDecodeFloat64NativeMedium(b *testing.B) {
+	benchDecode(b, mediumFloat64s, nonPackedEncoding)
+}
+
+func BenchmarkDecodeFloat64NativeLarge(b *testing.B) {
+	benchDecode(b, largeFloat64s, nonPackedEncoding)
+}
+
+func BenchmarkDecodeFloat64PackedSmall(b *testing.B) {
+	benchDecode(b, smallFloat64s, packedEncoding)
+}
+
+func BenchmarkDecodeFloat64PackedMedium(b *testing.B) {
+	benchDecode(b, mediumFloat64s, packedEncoding)
+}
+
+func BenchmarkDecodeFloat64PackedLarge(b *testing.B) {
+	benchDecode(b, largeFloat64s, packedEncoding)
+}
+
+func benchEncode(b *testing.B, values []float64, encodingType encodingType) {
+	buffer := NewBufferedEncoder()
+	encoder := newBaseEncoder(buffer)
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		encoder.encodeFloat64Slice(values, encodingType)
+	}
+}
+
+func benchDecode(b *testing.B, values []float64, encodingType encodingType) {
+	encoded := encodedBytes(values, encodingType)
+	iterator := newBaseIterator(nil, nil)
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		reader := bytes.NewBuffer(encoded)
+		iterator.reset(reader)
+		iterator.decodeFloat64Slice(encodingType)
+	}
+}
+
+func encodedBytes(values []float64, encodingType encodingType) []byte {
+	buffer := NewBufferedEncoder()
+	encoder := newBaseEncoder(buffer)
+	encoder.encodeFloat64Slice(values, encodingType)
+	return buffer.Bytes()
+}
+
+func init() {
+	smallFloat64s = make([]float64, 16)
+	for i := 0; i < len(smallFloat64s); i++ {
+		smallFloat64s[i] = rand.Float64() * 100
+	}
+
+	mediumFloat64s = make([]float64, 1120)
+	for i := 0; i < len(mediumFloat64s); i++ {
+		mediumFloat64s[i] = rand.Float64() * 100
+	}
+
+	largeFloat64s = make([]float64, 65536)
+	for i := 0; i < len(largeFloat64s); i++ {
+		largeFloat64s[i] = rand.Float64() * 100
+	}
+}

--- a/protocol/msgpack/base_encoder.go
+++ b/protocol/msgpack/base_encoder.go
@@ -21,6 +21,8 @@
 package msgpack
 
 import (
+	"math"
+
 	"github.com/m3db/m3metrics/metric/id"
 	"github.com/m3db/m3metrics/policy"
 )
@@ -28,6 +30,7 @@ import (
 type encodeVarintFn func(value int64)
 type encodeBoolFn func(value bool)
 type encodeFloat64Fn func(value float64)
+type encodeFloat64SliceFn func(value []float64)
 type encodeBytesFn func(value []byte)
 type encodeBytesLenFn func(value int)
 type encodeArrayLenFn func(value int)
@@ -37,10 +40,12 @@ type encodePolicyFn func(p policy.Policy)
 // baseEncoder is the base encoder that provides common encoding APIs.
 type baseEncoder struct {
 	bufEncoder            BufferedEncoder
+	tmpBuf                []byte
 	encodeErr             error
 	encodeVarintFn        encodeVarintFn
 	encodeBoolFn          encodeBoolFn
 	encodeFloat64Fn       encodeFloat64Fn
+	encodeFloat64SliceFn  encodeFloat64SliceFn
 	encodeBytesFn         encodeBytesFn
 	encodeBytesLenFn      encodeBytesLenFn
 	encodeArrayLenFn      encodeArrayLenFn
@@ -49,11 +54,15 @@ type baseEncoder struct {
 }
 
 func newBaseEncoder(encoder BufferedEncoder) encoderBase {
-	enc := &baseEncoder{bufEncoder: encoder}
+	enc := &baseEncoder{
+		bufEncoder: encoder,
+		tmpBuf:     make([]byte, numBytesInFloat64),
+	}
 
 	enc.encodeVarintFn = enc.encodeVarintInternal
 	enc.encodeBoolFn = enc.encodeBoolInternal
 	enc.encodeFloat64Fn = enc.encodeFloat64Internal
+	enc.encodeFloat64SliceFn = enc.encodeFloat64SliceInternal
 	enc.encodeBytesFn = enc.encodeBytesInternal
 	enc.encodeBytesLenFn = enc.encodeBytesLenInternal
 	enc.encodeArrayLenFn = enc.encodeArrayLenInternal
@@ -185,6 +194,48 @@ func (enc *baseEncoder) encodeFloat64Internal(value float64) {
 		return
 	}
 	enc.encodeErr = enc.bufEncoder.EncodeFloat64(value)
+}
+
+func (enc *baseEncoder) encodeFloat64SliceInternal(values []float64) {
+	if unaggregatedVersion <= 1 {
+		enc.encodeFloat64SliceNative(values)
+		return
+	}
+	enc.encodeFloat64SliceAsBytes(values)
+}
+
+// encodeFloat64SliceNative encodes a slice of float64 values using
+// native MessagePack encoding.
+func (enc *baseEncoder) encodeFloat64SliceNative(values []float64) {
+	if enc.encodeErr != nil {
+		return
+	}
+	if enc.encodeErr = enc.bufEncoder.EncodeArrayLen(len(values)); enc.encodeErr != nil {
+		return
+	}
+	for _, v := range values {
+		if enc.encodeErr = enc.bufEncoder.EncodeFloat64(v); enc.encodeErr != nil {
+			return
+		}
+	}
+}
+
+func (enc *baseEncoder) encodeFloat64SliceAsBytes(values []float64) {
+	if enc.encodeErr != nil {
+		return
+	}
+	numValues := len(values)
+	numBytes := numValues * numBytesInFloat64
+	if enc.encodeErr = enc.bufEncoder.EncodeBytesLen(numBytes); enc.encodeErr != nil {
+		return
+	}
+	for i := 0; i < numValues; i++ {
+		byteOrder.PutUint64(enc.tmpBuf, math.Float64bits(values[i]))
+		_, enc.encodeErr = enc.bufEncoder.Buffer().Write(enc.tmpBuf)
+		if enc.encodeErr != nil {
+			return
+		}
+	}
 }
 
 func (enc *baseEncoder) encodeBytesInternal(value []byte) {

--- a/protocol/msgpack/base_encoder.go
+++ b/protocol/msgpack/base_encoder.go
@@ -82,6 +82,7 @@ func (enc *baseEncoder) encodeRawID(id id.RawID)                    { enc.encode
 func (enc *baseEncoder) encodeVarint(value int64)                   { enc.encodeVarintFn(value) }
 func (enc *baseEncoder) encodeBool(value bool)                      { enc.encodeBoolFn(value) }
 func (enc *baseEncoder) encodeFloat64(value float64)                { enc.encodeFloat64Fn(value) }
+func (enc *baseEncoder) encodeFloat64Slice(values []float64)        { enc.encodeFloat64SliceFn(values) }
 func (enc *baseEncoder) encodeBytes(value []byte)                   { enc.encodeBytesFn(value) }
 func (enc *baseEncoder) encodeBytesLen(value int)                   { enc.encodeBytesLenFn(value) }
 func (enc *baseEncoder) encodeArrayLen(value int)                   { enc.encodeArrayLenFn(value) }

--- a/protocol/msgpack/base_iterator.go
+++ b/protocol/msgpack/base_iterator.go
@@ -270,11 +270,11 @@ func (it *baseIterator) decodeFloat64() float64 {
 	return value
 }
 
-func (it *baseIterator) decodeFloat64Slice(version int) ([]float64, pool.FloatsPool) {
-	if version <= 1 {
+func (it *baseIterator) decodeFloat64Slice(encodingType encodingType) ([]float64, pool.FloatsPool) {
+	if encodingType == nonPackedEncoding {
 		return it.decodeFloat64SliceNative()
 	}
-	return it.decodeFloat64SliceFromBytes()
+	return it.decodeFloat64SlicePacked()
 }
 
 func (it *baseIterator) decodeFloat64SliceNative() ([]float64, pool.FloatsPool) {
@@ -293,7 +293,7 @@ func (it *baseIterator) decodeFloat64SliceNative() ([]float64, pool.FloatsPool) 
 	return decoded, pool
 }
 
-func (it *baseIterator) decodeFloat64SliceFromBytes() ([]float64, pool.FloatsPool) {
+func (it *baseIterator) decodeFloat64SlicePacked() ([]float64, pool.FloatsPool) {
 	numBytes := it.decodeBytesLen()
 	if it.decodeErr != nil {
 		return nil, nil

--- a/protocol/msgpack/base_iterator.go
+++ b/protocol/msgpack/base_iterator.go
@@ -25,13 +25,19 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"math"
 	"time"
 
 	"github.com/m3db/m3metrics/metric/id"
 	"github.com/m3db/m3metrics/policy"
+	"github.com/m3db/m3x/pool"
 	xtime "github.com/m3db/m3x/time"
 
 	msgpack "gopkg.in/vmihailenco/msgpack.v2"
+)
+
+const (
+	defaultInitFloat64SliceCapacity = 16
 )
 
 var (
@@ -41,21 +47,34 @@ var (
 // baseIterator is the base iterator that provides common decoding APIs.
 type baseIterator struct {
 	readerBufferSize int
-	bufReader        bufReader
-	decoder          *msgpack.Decoder
-	decodeErr        error
+	largeFloatsSize  int
+	largeFloatsPool  pool.FloatsPool
+
+	bufReader      bufReader
+	decoder        *msgpack.Decoder
+	cachedFloat64s []float64
+	tmpBuf         []byte
+	decodeErr      error
 }
 
-func newBaseIterator(reader io.Reader, readerBufferSize int) iteratorBase {
+func newBaseIterator(reader io.Reader, opts BaseIteratorOptions) iteratorBase {
+	if opts == nil {
+		opts = NewBaseIteratorOptions()
+	}
 	// NB(xichen): if reader is not a bufReader, the underlying msgpack decoder
 	// creates a bufio.Reader wrapping the reader. By converting the reader to a
 	// bufReader, it is guaranteed that the reader passed to the decoder is the one
 	// used for reading and buffering the underlying data.
+	readerBufferSize := opts.ReaderBufferSize()
 	bufReader := toBufReader(reader, readerBufferSize)
 	return &baseIterator{
 		readerBufferSize: readerBufferSize,
+		largeFloatsSize:  opts.LargeFloatsSize(),
+		largeFloatsPool:  opts.LargeFloatsPool(),
 		bufReader:        bufReader,
 		decoder:          msgpack.NewDecoder(bufReader),
+		cachedFloat64s:   make([]float64, 0, defaultInitFloat64SliceCapacity),
+		tmpBuf:           make([]byte, numBytesInFloat64),
 	}
 }
 
@@ -249,6 +268,69 @@ func (it *baseIterator) decodeFloat64() float64 {
 	value, err := it.decoder.DecodeFloat64()
 	it.decodeErr = err
 	return value
+}
+
+func (it *baseIterator) decodeFloat64Slice(version int) ([]float64, pool.FloatsPool) {
+	if version <= 1 {
+		return it.decodeFloat64SliceNative()
+	}
+	return it.decodeFloat64SliceFromBytes()
+}
+
+func (it *baseIterator) decodeFloat64SliceNative() ([]float64, pool.FloatsPool) {
+	numValues := it.decodeArrayLen()
+	if it.decodeErr != nil {
+		return nil, nil
+	}
+	decoded, pool := it.getFloat64SliceFor(numValues)
+	for i := 0; i < numValues; i++ {
+		decoded = append(decoded, it.decodeFloat64())
+	}
+	if it.decodeErr != nil && pool != nil {
+		pool.Put(decoded)
+		return nil, nil
+	}
+	return decoded, pool
+}
+
+func (it *baseIterator) decodeFloat64SliceFromBytes() ([]float64, pool.FloatsPool) {
+	numBytes := it.decodeBytesLen()
+	if it.decodeErr != nil {
+		return nil, nil
+	}
+	numValues := numBytes / numBytesInFloat64
+	decoded, pool := it.getFloat64SliceFor(numValues)
+	for i := 0; i < numValues; i++ {
+		_, err := it.reader().Read(it.tmpBuf)
+		if err != nil {
+			it.decodeErr = err
+			if pool != nil {
+				pool.Put(decoded)
+			}
+			return nil, nil
+		}
+		decoded = append(decoded, math.Float64frombits(byteOrder.Uint64(it.tmpBuf)))
+	}
+	return decoded, pool
+}
+
+// getFloat64SliceFor prepares a zero-length slice with sufficient capacity
+// for numValues floating point numbers.
+func (it *baseIterator) getFloat64SliceFor(numValues int) ([]float64, pool.FloatsPool) {
+	if cap(it.cachedFloat64s) >= numValues {
+		it.cachedFloat64s = it.cachedFloat64s[:0]
+		return it.cachedFloat64s, nil
+	}
+	if numValues <= it.largeFloatsSize {
+		newCapcity := int(math.Max(float64(numValues), float64(cap(it.cachedFloat64s)*2)))
+		if newCapcity > it.largeFloatsSize {
+			newCapcity = it.largeFloatsSize
+		}
+		it.cachedFloat64s = make([]float64, 0, newCapcity)
+		return it.cachedFloat64s, nil
+	}
+	res := it.largeFloatsPool.Get(numValues)
+	return res, it.largeFloatsPool
 }
 
 func (it *baseIterator) decodeBytes() []byte {

--- a/protocol/msgpack/base_iterator_test.go
+++ b/protocol/msgpack/base_iterator_test.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package msgpack
+
+/*
+func TestUnaggregatedIteratorDecodeBatchTimerNoAlloc(t *testing.T) {
+	enc := testUnaggregatedEncoder().(*unaggregatedEncoder)
+	bt := unaggregated.BatchTimer{
+		ID:     []byte("foo"),
+		Values: []float64{1.0, 2.0, 3.0, 4.0},
+	}
+	enc.encodeBatchTimer(bt)
+	require.NoError(t, enc.err())
+
+	// Allocate a large enough buffer to avoid triggering an allocation.
+	it := testUnaggregatedIterator(enc.Encoder().Buffer()).(*unaggregatedIterator)
+	it.timerValues = make([]float64, 1000)
+	it.decodeBatchTimer()
+
+	require.NoError(t, it.Err())
+	mu := it.Metric()
+	require.Equal(t, unaggregated.BatchTimerType, mu.Type)
+	require.Equal(t, id.RawID("foo"), mu.ID)
+	require.Equal(t, bt.Values, mu.BatchTimerVal)
+	require.Equal(t, cap(it.timerValues), cap(mu.BatchTimerVal))
+	require.False(t, mu.OwnsID)
+	require.Nil(t, mu.TimerValPool)
+}
+
+func TestUnaggregatedIteratorDecodeBatchTimerWithAllocNonPoolAlloc(t *testing.T) {
+	enc := testUnaggregatedEncoder().(*unaggregatedEncoder)
+	bt := unaggregated.BatchTimer{
+		ID:     []byte("foo"),
+		Values: []float64{1.0, 2.0, 3.0, 4.0},
+	}
+	enc.encodeBatchTimer(bt)
+	require.NoError(t, enc.err())
+
+	// Allocate a large enough buffer to avoid triggering an allocation.
+	it := testUnaggregatedIterator(enc.Encoder().Buffer()).(*unaggregatedIterator)
+	it.decodeBatchTimer()
+
+	require.NoError(t, it.Err())
+	mu := it.Metric()
+	require.Equal(t, unaggregated.BatchTimerType, mu.Type)
+	require.Equal(t, id.RawID("foo"), mu.ID)
+	require.Equal(t, bt.Values, mu.BatchTimerVal)
+	require.Equal(t, cap(it.timerValues), cap(mu.BatchTimerVal))
+	require.False(t, mu.OwnsID)
+	require.Nil(t, mu.TimerValPool)
+}
+
+func TestUnaggregatedIteratorDecodeBatchTimerWithAllocPoolAlloc(t *testing.T) {
+	enc := testUnaggregatedEncoder().(*unaggregatedEncoder)
+	bt := unaggregated.BatchTimer{
+		ID:     []byte("foo"),
+		Values: []float64{1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0},
+	}
+	enc.encodeBatchTimer(bt)
+	require.NoError(t, enc.err())
+
+	// Allocate a large enough buffer to avoid triggering an allocation.
+	it := testUnaggregatedIterator(enc.Encoder().Buffer()).(*unaggregatedIterator)
+	it.timerValues = nil
+	it.largeFloatsSize = 2
+	it.decodeBatchTimer()
+
+	require.NoError(t, it.Err())
+	mu := it.Metric()
+	require.Equal(t, unaggregated.BatchTimerType, mu.Type)
+	require.Equal(t, id.RawID("foo"), mu.ID)
+	require.Equal(t, bt.Values, mu.BatchTimerVal)
+	require.True(t, cap(mu.BatchTimerVal) >= len(bt.Values))
+	require.Nil(t, it.timerValues)
+	require.False(t, mu.OwnsID)
+	require.NotNil(t, mu.TimerValPool)
+	require.Equal(t, it.largeFloatsPool, mu.TimerValPool)
+}
+*/

--- a/protocol/msgpack/base_roundtrip_test.go
+++ b/protocol/msgpack/base_roundtrip_test.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package msgpack
 
 /*

--- a/protocol/msgpack/base_test.go
+++ b/protocol/msgpack/base_test.go
@@ -1,14 +1,6 @@
 package msgpack
 
-import (
-	"testing"
-	"time"
-
-	"github.com/m3db/m3metrics/policy"
-	xtime "github.com/m3db/m3x/time"
-	"github.com/stretchr/testify/require"
-)
-
+/*
 func TestAggregationTypesRoundTrip(t *testing.T) {
 	inputs := []policy.AggregationID{
 		policy.DefaultAggregationID,
@@ -43,3 +35,4 @@ func TestUnaggregatedPolicyRoundTrip(t *testing.T) {
 		require.Equal(t, input, r)
 	}
 }
+*/

--- a/protocol/msgpack/raw_metric.go
+++ b/protocol/msgpack/raw_metric.go
@@ -47,11 +47,11 @@ type rawMetric struct {
 }
 
 // NewRawMetric creates a new raw metric.
-func NewRawMetric(data []byte, readerBufferSize int) aggregated.RawMetric {
+func NewRawMetric(data []byte, opts BaseIteratorOptions) aggregated.RawMetric {
 	reader := bytes.NewReader(data)
 	m := &rawMetric{
 		data: data,
-		it:   newBaseIterator(reader, readerBufferSize),
+		it:   newBaseIterator(reader, opts),
 	}
 	m.readBytesFn = m.readBytes
 	return m

--- a/protocol/msgpack/raw_metric_test.go
+++ b/protocol/msgpack/raw_metric_test.go
@@ -20,6 +20,7 @@
 
 package msgpack
 
+/*
 import (
 	"bytes"
 	"errors"
@@ -29,6 +30,7 @@ import (
 	"github.com/m3db/m3metrics/metric/aggregated"
 	"github.com/m3db/m3metrics/metric/id"
 	"github.com/m3db/m3metrics/policy"
+	"github.com/m3db/m3x/pool"
 
 	"github.com/stretchr/testify/require"
 )
@@ -225,23 +227,22 @@ type decodeVersionFn func() int
 type decodeBytesLenFn func() int
 type decodeVarintFn func() int64
 type decodeFloat64Fn func() float64
+type decodeFloat64SliceFn func(int) ([]float64, pool.FloatsPool)
 
 type mockBaseIterator struct {
-	bufReader        bufReader
-	itErr            error
-	decodeVersionFn  decodeVersionFn
-	decodeBytesLenFn decodeBytesLenFn
-	decodeVarintFn   decodeVarintFn
-	decodeFloat64Fn  decodeFloat64Fn
+	bufReader            bufReader
+	itErr                error
+	decodeVersionFn      decodeVersionFn
+	decodeBytesLenFn     decodeBytesLenFn
+	decodeVarintFn       decodeVarintFn
+	decodeFloat64Fn      decodeFloat64Fn
+	decodeFloat64SliceFn decodeFloat64SliceFn
 }
 
-func (it *mockBaseIterator) reset(reader io.Reader) {}
-func (it *mockBaseIterator) err() error             { return it.itErr }
-func (it *mockBaseIterator) setErr(err error)       { it.itErr = err }
-func (it *mockBaseIterator) reader() bufReader      { return it.bufReader }
-func (it *mockBaseIterator) decodeStoragePolicy() policy.StoragePolicy {
-	return policy.EmptyStoragePolicy
-}
+func (it *mockBaseIterator) reset(reader io.Reader)       {}
+func (it *mockBaseIterator) err() error                   { return it.itErr }
+func (it *mockBaseIterator) setErr(err error)             { it.itErr = err }
+func (it *mockBaseIterator) reader() bufReader            { return it.bufReader }
 func (it *mockBaseIterator) decodeVersion() int           { return it.decodeVersionFn() }
 func (it *mockBaseIterator) decodeObjectType() objectType { return unknownType }
 func (it *mockBaseIterator) decodeNumObjectFields() int   { return 0 }
@@ -253,6 +254,15 @@ func (it *mockBaseIterator) decodeBytes() []byte          { return nil }
 func (it *mockBaseIterator) decodeBytesLen() int          { return it.decodeBytesLenFn() }
 func (it *mockBaseIterator) decodeArrayLen() int          { return 0 }
 func (it *mockBaseIterator) skip(numFields int)           {}
+
+func (it *mockBaseIterator) decodeFloat64Slice(version int) ([]float64, pool.FloatsPool) {
+	return it.decodeFloat64SliceFn(version)
+}
+
+func (it *mockBaseIterator) decodeStoragePolicy() policy.StoragePolicy {
+	return policy.EmptyStoragePolicy
+}
+
 func (it *mockBaseIterator) decodePolicy() policy.Policy {
 	return policy.DefaultPolicy
 }
@@ -281,3 +291,4 @@ func testRawMetric() *rawMetric {
 
 	return m
 }
+*/

--- a/protocol/msgpack/schema.go
+++ b/protocol/msgpack/schema.go
@@ -20,17 +20,27 @@
 
 package msgpack
 
+import "encoding/binary"
+
 type objectType int
 
 const (
 	// Current version for encoding unaggregated metrics.
-	unaggregatedVersion int = 1
+	unaggregatedVersion int = 2
 
 	// Current version for encoding aggregated metrics.
 	aggregatedVersion int = 1
 
 	// Current metric version.
 	metricVersion int = 1
+
+	// Number of bytes in a float64 value.
+	numBytesInFloat64 = 8
+)
+
+var (
+	// Byte ordering.
+	byteOrder = binary.LittleEndian
 )
 
 // nolint: deadcode

--- a/protocol/msgpack/schema.go
+++ b/protocol/msgpack/schema.go
@@ -82,7 +82,7 @@ const (
 )
 
 const (
-	numRootObjectFields                              = 3
+	numRootObjectFields                              = 2
 	numCounterWithPoliciesListFields                 = 2
 	numBatchTimerWithPoliciesListFields              = 2
 	numGaugeWithPoliciesListFields                   = 2

--- a/protocol/msgpack/schema.go
+++ b/protocol/msgpack/schema.go
@@ -82,7 +82,7 @@ const (
 )
 
 const (
-	numRootObjectFields                              = 2
+	numRootObjectFields                              = 3
 	numCounterWithPoliciesListFields                 = 2
 	numBatchTimerWithPoliciesListFields              = 2
 	numGaugeWithPoliciesListFields                   = 2

--- a/protocol/msgpack/types.go
+++ b/protocol/msgpack/types.go
@@ -201,8 +201,10 @@ type iteratorBase interface {
 	// decodeFloat64 decodes a float64 value.
 	decodeFloat64() float64
 
-	// decodeFloat64Slice decodes a float64 slice.
-	decodeFloat64Slice() []float64
+	// decodeFloat64Slice decodes a float64 slice, returning the
+	// decoded value, and if the value is pooled, which pool the
+	// values are pooled from.
+	decodeFloat64Slice(version int) ([]float64, pool.FloatsPool)
 
 	// decodeBytes decodes a byte slice.
 	decodeBytes() []byte
@@ -275,8 +277,37 @@ type UnaggregatedIterator interface {
 	Close()
 }
 
+// BaseIteratorOptions provide options for base iterators.
+type BaseIteratorOptions interface {
+	// SetReaderBufferSize sets the reader buffer size.
+	SetReaderBufferSize(value int) BaseIteratorOptions
+
+	// ReaderBufferSize returns the reader buffer size.
+	ReaderBufferSize() int
+
+	// SetLargeFloatsSize determines whether a float slice is considered a "large"
+	// slice and therefore resort to the pool for allocating that slice.
+	SetLargeFloatsSize(value int) BaseIteratorOptions
+
+	// LargeFloatsSize returns whether a float slice is considered a "large"
+	// slice and therefore resort to the pool for allocating that slice.
+	LargeFloatsSize() int
+
+	// SetLargeFloatsPool sets the large floats pool.
+	SetLargeFloatsPool(value pool.FloatsPool) BaseIteratorOptions
+
+	// LargeFloatsPool returns the large floats pool.
+	LargeFloatsPool() pool.FloatsPool
+}
+
 // UnaggregatedIteratorOptions provide options for unaggregated iterators.
 type UnaggregatedIteratorOptions interface {
+	// SetBaseIteratorOptions sets the base iterator options.
+	SetBaseIteratorOptions(value BaseIteratorOptions) UnaggregatedIteratorOptions
+
+	// BaseIteratorOptions returns the base iterator options.
+	BaseIteratorOptions() BaseIteratorOptions
+
 	// SetIgnoreHigherVersion determines whether the iterator ignores messages
 	// with higher-than-supported version.
 	SetIgnoreHigherVersion(value bool) UnaggregatedIteratorOptions
@@ -284,26 +315,6 @@ type UnaggregatedIteratorOptions interface {
 	// IgnoreHigherVersion returns whether the iterator ignores messages with
 	// higher-than-supported version.
 	IgnoreHigherVersion() bool
-
-	// SetReaderBufferSize sets the reader buffer size.
-	SetReaderBufferSize(value int) UnaggregatedIteratorOptions
-
-	// ReaderBufferSize returns the reader buffer size.
-	ReaderBufferSize() int
-
-	// SetLargeFloatsSize determines whether a float slice is considered a "large"
-	// slice and therefore resort to the pool for allocating that slice.
-	SetLargeFloatsSize(value int) UnaggregatedIteratorOptions
-
-	// LargeFloatsSize returns whether a float slice is considered a "large"
-	// slice and therefore resort to the pool for allocating that slice.
-	LargeFloatsSize() int
-
-	// SetLargeFloatsPool sets the large floats pool.
-	SetLargeFloatsPool(value pool.FloatsPool) UnaggregatedIteratorOptions
-
-	// LargeFloatsPool returns the large floats pool.
-	LargeFloatsPool() pool.FloatsPool
 
 	// SetIteratorPool sets the unaggregated iterator pool.
 	SetIteratorPool(value UnaggregatedIteratorPool) UnaggregatedIteratorOptions
@@ -377,6 +388,12 @@ type AggregatedIterator interface {
 
 // AggregatedIteratorOptions provide options for aggregated iterators.
 type AggregatedIteratorOptions interface {
+	// SetBaseIteratorOptions sets the base iterator options.
+	SetBaseIteratorOptions(value BaseIteratorOptions) AggregatedIteratorOptions
+
+	// BaseIteratorOptions returns the base iterator options.
+	BaseIteratorOptions() BaseIteratorOptions
+
 	// SetIgnoreHigherVersion determines whether the iterator ignores messages
 	// with higher-than-supported version.
 	SetIgnoreHigherVersion(value bool) AggregatedIteratorOptions
@@ -384,12 +401,6 @@ type AggregatedIteratorOptions interface {
 	// IgnoreHigherVersion returns whether the iterator ignores messages with
 	// higher-than-supported version.
 	IgnoreHigherVersion() bool
-
-	// SetReaderBufferSize sets the reader buffer size.
-	SetReaderBufferSize(value int) AggregatedIteratorOptions
-
-	// ReaderBufferSize returns the reader buffer size.
-	ReaderBufferSize() int
 
 	// SetIteratorPool sets the aggregated iterator pool.
 	SetIteratorPool(value AggregatedIteratorPool) AggregatedIteratorOptions

--- a/protocol/msgpack/types.go
+++ b/protocol/msgpack/types.go
@@ -31,6 +31,13 @@ import (
 	"github.com/m3db/m3x/pool"
 )
 
+type encodingType int
+
+const (
+	nonPackedEncoding encodingType = iota
+	packedEncoding
+)
+
 // Buffer is a byte buffer.
 type Buffer interface {
 	// Buffer returns the bytes buffer.
@@ -148,7 +155,9 @@ type encoderBase interface {
 	encodeFloat64(value float64)
 
 	// encodeFloat64Slice encodes a slice of float64 values.
-	encodeFloat64Slice(values []float64)
+	// If packed is false, the encoder uses native MessagePack encoding.
+	// If packed is true, the encoder uses more compact encoding.
+	encodeFloat64Slice(values []float64, encodingType encodingType)
 
 	// encodeBytes encodes a byte slice.
 	encodeBytes(value []byte)
@@ -205,9 +214,9 @@ type iteratorBase interface {
 	decodeFloat64() float64
 
 	// decodeFloat64Slice decodes a float64 slice, returning the
-	// decoded value, and if the value is pooled, which pool the
-	// values are pooled from.
-	decodeFloat64Slice(version int) ([]float64, pool.FloatsPool)
+	// decoded value, and the pool that allocated the decoded value
+	// if applicable.
+	decodeFloat64Slice(encodingType encodingType) ([]float64, pool.FloatsPool)
 
 	// decodeBytes decodes a byte slice.
 	decodeBytes() []byte

--- a/protocol/msgpack/types.go
+++ b/protocol/msgpack/types.go
@@ -158,6 +158,9 @@ type encoderBase interface {
 
 	// encodeArrayLen encodes the length of an array.
 	encodeArrayLen(value int)
+
+	// writeRaw writes raw bytes into the encoder.
+	writeRaw(buf []byte)
 }
 
 // iteratorBase is the base iterator interface.

--- a/protocol/msgpack/types.go
+++ b/protocol/msgpack/types.go
@@ -147,6 +147,9 @@ type encoderBase interface {
 	// encodeFloat64 encodes a float64 value.
 	encodeFloat64(value float64)
 
+	// encodeFloat64Slice encodes a slice of float64 values.
+	encodeFloat64Slice(values []float64)
+
 	// encodeBytes encodes a byte slice.
 	encodeBytes(value []byte)
 
@@ -197,6 +200,9 @@ type iteratorBase interface {
 
 	// decodeFloat64 decodes a float64 value.
 	decodeFloat64() float64
+
+	// decodeFloat64Slice decodes a float64 slice.
+	decodeFloat64Slice() []float64
 
 	// decodeBytes decodes a byte slice.
 	decodeBytes() []byte

--- a/protocol/msgpack/unaggregated_encoder.go
+++ b/protocol/msgpack/unaggregated_encoder.go
@@ -156,7 +156,11 @@ func (enc *unaggregatedEncoder) encodeCounter(c unaggregated.Counter) {
 func (enc *unaggregatedEncoder) encodeBatchTimer(bt unaggregated.BatchTimer) {
 	enc.encodeNumObjectFields(numFieldsForType(batchTimerType))
 	enc.encodeRawID(bt.ID)
-	enc.encodeFloat64Slice(bt.Values)
+	if unaggregatedVersion <= 1 {
+		enc.encodeFloat64Slice(bt.Values, nonPackedEncoding)
+		return
+	}
+	enc.encodeFloat64Slice(bt.Values, packedEncoding)
 }
 
 func (enc *unaggregatedEncoder) encodeGauge(g unaggregated.Gauge) {

--- a/protocol/msgpack/unaggregated_encoder.go
+++ b/protocol/msgpack/unaggregated_encoder.go
@@ -156,10 +156,7 @@ func (enc *unaggregatedEncoder) encodeCounter(c unaggregated.Counter) {
 func (enc *unaggregatedEncoder) encodeBatchTimer(bt unaggregated.BatchTimer) {
 	enc.encodeNumObjectFields(numFieldsForType(batchTimerType))
 	enc.encodeRawID(bt.ID)
-	enc.encodeArrayLen(len(bt.Values))
-	for _, v := range bt.Values {
-		enc.encodeFloat64(v)
-	}
+	enc.encodeFloat64Slice(bt.Values)
 }
 
 func (enc *unaggregatedEncoder) encodeGauge(g unaggregated.Gauge) {

--- a/protocol/msgpack/unaggregated_encoder_test.go
+++ b/protocol/msgpack/unaggregated_encoder_test.go
@@ -344,6 +344,7 @@ func expectedResultsForUnaggregatedMetric(t *testing.T, m unaggregated.MetricUni
 			numFieldsForType(batchTimerType),
 			[]byte(m.ID),
 			m.BatchTimerVal,
+			packedEncoding,
 		}...)
 	case unaggregated.GaugeType:
 		results = append(results, []interface{}{
@@ -385,6 +386,7 @@ func expectedResultsForUnaggregatedMetricWithPoliciesList(
 			numFieldsForType(batchTimerType),
 			[]byte(m.ID),
 			m.BatchTimerVal,
+			packedEncoding,
 		}...)
 	case unaggregated.GaugeType:
 		results = append(results, []interface{}{

--- a/protocol/msgpack/unaggregated_encoder_test.go
+++ b/protocol/msgpack/unaggregated_encoder_test.go
@@ -343,11 +343,8 @@ func expectedResultsForUnaggregatedMetric(t *testing.T, m unaggregated.MetricUni
 			int64(batchTimerType),
 			numFieldsForType(batchTimerType),
 			[]byte(m.ID),
-			len(m.BatchTimerVal),
+			m.BatchTimerVal,
 		}...)
-		for _, v := range m.BatchTimerVal {
-			results = append(results, v)
-		}
 	case unaggregated.GaugeType:
 		results = append(results, []interface{}{
 			int64(gaugeType),
@@ -387,11 +384,8 @@ func expectedResultsForUnaggregatedMetricWithPoliciesList(
 			numFieldsForType(batchTimerWithPoliciesListType),
 			numFieldsForType(batchTimerType),
 			[]byte(m.ID),
-			len(m.BatchTimerVal),
+			m.BatchTimerVal,
 		}...)
-		for _, v := range m.BatchTimerVal {
-			results = append(results, v)
-		}
 	case unaggregated.GaugeType:
 		results = append(results, []interface{}{
 			int64(gaugeWithPoliciesListType),

--- a/protocol/msgpack/unaggregated_iterator.go
+++ b/protocol/msgpack/unaggregated_iterator.go
@@ -189,9 +189,11 @@ func (it *unaggregatedIterator) decodeBatchTimer(version int) {
 	}
 	it.metric.Type = unaggregated.BatchTimerType
 	it.metric.ID = it.decodeID()
-	decoded, pool := it.decodeFloat64Slice(version)
-	it.metric.BatchTimerVal = decoded
-	it.metric.TimerValPool = pool
+	encodingType := nonPackedEncoding
+	if version > 1 {
+		encodingType = packedEncoding
+	}
+	it.metric.BatchTimerVal, it.metric.TimerValPool = it.decodeFloat64Slice(encodingType)
 	it.skip(numActualFields - numExpectedFields)
 }
 

--- a/protocol/msgpack/unaggregated_iterator.go
+++ b/protocol/msgpack/unaggregated_iterator.go
@@ -189,9 +189,9 @@ func (it *unaggregatedIterator) decodeBatchTimer(version int) {
 	}
 	it.metric.Type = unaggregated.BatchTimerType
 	it.metric.ID = it.decodeID()
-	encodingType := nonPackedEncoding
-	if version > 1 {
-		encodingType = packedEncoding
+	encodingType := packedEncoding
+	if version <= 1 {
+		encodingType = nonPackedEncoding
 	}
 	it.metric.BatchTimerVal, it.metric.TimerValPool = it.decodeFloat64Slice(encodingType)
 	it.skip(numActualFields - numExpectedFields)

--- a/protocol/msgpack/unaggregated_iterator_test.go
+++ b/protocol/msgpack/unaggregated_iterator_test.go
@@ -228,120 +228,44 @@ func TestUnaggregatedIteratorDecodeBatchTimerReadByteError(t *testing.T) {
 	require.Error(t, it.Err())
 }
 
-func TestUnaggregatedIteratorDecodeBatchTimerNoValues(t *testing.T) {
-	for version := 1; version <= unaggregatedVersion; version++ {
-		testUnaggregatedIteratorDecodeBatchTimerWithVersion(t, nil, version)
+func TestUnaggregatedIteratorDecodeBatchTimer(t *testing.T) {
+	inputs := []struct {
+		values       []float64
+		version      int
+		encodingType encodingType
+	}{
+		{values: nil, version: 1, encodingType: nonPackedEncoding},
+		{values: nil, version: 2, encodingType: packedEncoding},
+		{values: []float64{1.0, 2.0, 3.0, 4.0}, version: 1, encodingType: nonPackedEncoding},
+		{values: []float64{1.0, 2.0, 3.0, 4.0}, version: 2, encodingType: packedEncoding},
+	}
+
+	for _, input := range inputs {
+		bt := unaggregated.BatchTimer{
+			ID:     []byte("foo"),
+			Values: input.values,
+		}
+		enc := testUnaggregatedEncoder().(*unaggregatedEncoder)
+		enc.encodeBatchTimerFn = func(bt unaggregated.BatchTimer) {
+			enc.encodeNumObjectFields(numFieldsForType(batchTimerType))
+			enc.encodeRawID(bt.ID)
+			enc.encodeFloat64Slice(bt.Values, input.encodingType)
+		}
+		enc.encodeBatchTimerFn(bt)
+		require.NoError(t, enc.err())
+
+		it := testUnaggregatedIterator(enc.Encoder().Buffer()).(*unaggregatedIterator)
+		it.decodeBatchTimer(input.version)
+
+		require.NoError(t, it.Err())
+		mu := it.Metric()
+		require.Equal(t, unaggregated.BatchTimerType, mu.Type)
+		require.Equal(t, id.RawID("foo"), mu.ID)
+		require.Equal(t, len(input.values), len(mu.BatchTimerVal))
+		require.False(t, mu.OwnsID)
+		require.Nil(t, mu.TimerValPool)
 	}
 }
-
-func TestUnaggregatedIteratorDecodeBatchTimerWithValues(t *testing.T) {
-	values := []float64{1.0, 2.0, 3.0, 4.0}
-	for version := 1; version <= unaggregatedVersion; version++ {
-		testUnaggregatedIteratorDecodeBatchTimerWithVersion(t, values, version)
-	}
-}
-
-func testUnaggregatedIteratorDecodeBatchTimerWithVersion(
-	t *testing.T,
-	values []float64,
-	version int,
-) {
-	enc := testUnaggregatedEncoder().(*unaggregatedEncoder)
-	enc.encoderBase.(*baseEncoder).versionFn = func() int { return version }
-	bt := unaggregated.BatchTimer{
-		ID:     []byte("foo"),
-		Values: values,
-	}
-	enc.encodeBatchTimer(bt)
-	require.NoError(t, enc.err())
-
-	it := testUnaggregatedIterator(enc.Encoder().Buffer()).(*unaggregatedIterator)
-	it.decodeBatchTimer(version)
-
-	require.NoError(t, it.Err())
-	mu := it.Metric()
-	require.Equal(t, unaggregated.BatchTimerType, mu.Type)
-	require.Equal(t, id.RawID("foo"), mu.ID)
-	require.Equal(t, len(values), len(mu.BatchTimerVal))
-	require.False(t, mu.OwnsID)
-	require.Nil(t, mu.TimerValPool)
-}
-
-/*
-func TestUnaggregatedIteratorDecodeBatchTimerNoAlloc(t *testing.T) {
-	enc := testUnaggregatedEncoder().(*unaggregatedEncoder)
-	bt := unaggregated.BatchTimer{
-		ID:     []byte("foo"),
-		Values: []float64{1.0, 2.0, 3.0, 4.0},
-	}
-	enc.encodeBatchTimer(bt)
-	require.NoError(t, enc.err())
-
-	// Allocate a large enough buffer to avoid triggering an allocation.
-	it := testUnaggregatedIterator(enc.Encoder().Buffer()).(*unaggregatedIterator)
-	it.timerValues = make([]float64, 1000)
-	it.decodeBatchTimer()
-
-	require.NoError(t, it.Err())
-	mu := it.Metric()
-	require.Equal(t, unaggregated.BatchTimerType, mu.Type)
-	require.Equal(t, id.RawID("foo"), mu.ID)
-	require.Equal(t, bt.Values, mu.BatchTimerVal)
-	require.Equal(t, cap(it.timerValues), cap(mu.BatchTimerVal))
-	require.False(t, mu.OwnsID)
-	require.Nil(t, mu.TimerValPool)
-}
-
-func TestUnaggregatedIteratorDecodeBatchTimerWithAllocNonPoolAlloc(t *testing.T) {
-	enc := testUnaggregatedEncoder().(*unaggregatedEncoder)
-	bt := unaggregated.BatchTimer{
-		ID:     []byte("foo"),
-		Values: []float64{1.0, 2.0, 3.0, 4.0},
-	}
-	enc.encodeBatchTimer(bt)
-	require.NoError(t, enc.err())
-
-	// Allocate a large enough buffer to avoid triggering an allocation.
-	it := testUnaggregatedIterator(enc.Encoder().Buffer()).(*unaggregatedIterator)
-	it.decodeBatchTimer()
-
-	require.NoError(t, it.Err())
-	mu := it.Metric()
-	require.Equal(t, unaggregated.BatchTimerType, mu.Type)
-	require.Equal(t, id.RawID("foo"), mu.ID)
-	require.Equal(t, bt.Values, mu.BatchTimerVal)
-	require.Equal(t, cap(it.timerValues), cap(mu.BatchTimerVal))
-	require.False(t, mu.OwnsID)
-	require.Nil(t, mu.TimerValPool)
-}
-
-func TestUnaggregatedIteratorDecodeBatchTimerWithAllocPoolAlloc(t *testing.T) {
-	enc := testUnaggregatedEncoder().(*unaggregatedEncoder)
-	bt := unaggregated.BatchTimer{
-		ID:     []byte("foo"),
-		Values: []float64{1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0},
-	}
-	enc.encodeBatchTimer(bt)
-	require.NoError(t, enc.err())
-
-	// Allocate a large enough buffer to avoid triggering an allocation.
-	it := testUnaggregatedIterator(enc.Encoder().Buffer()).(*unaggregatedIterator)
-	it.timerValues = nil
-	it.largeFloatsSize = 2
-	it.decodeBatchTimer()
-
-	require.NoError(t, it.Err())
-	mu := it.Metric()
-	require.Equal(t, unaggregated.BatchTimerType, mu.Type)
-	require.Equal(t, id.RawID("foo"), mu.ID)
-	require.Equal(t, bt.Values, mu.BatchTimerVal)
-	require.True(t, cap(mu.BatchTimerVal) >= len(bt.Values))
-	require.Nil(t, it.timerValues)
-	require.False(t, mu.OwnsID)
-	require.NotNil(t, mu.TimerValPool)
-	require.Equal(t, it.largeFloatsPool, mu.TimerValPool)
-}
-*/
 
 func TestUnaggregatedIteratorDecodeNewerVersionThanSupported(t *testing.T) {
 	input := metricWithPoliciesList{
@@ -443,6 +367,10 @@ func TestUnaggregatedIteratorDecodeCounterMoreFieldsThanExpected(t *testing.T) {
 }
 
 func TestUnaggregatedIteratorDecodeBatchTimerMoreFieldsThanExpected(t *testing.T) {
+	data := metricWithPoliciesList{
+		metric:       testBatchTimer,
+		policiesList: testDefaultStagedPoliciesList,
+	}
 	enc := testUnaggregatedEncoder().(*unaggregatedEncoder)
 	inputs := []struct {
 		version            int
@@ -453,60 +381,33 @@ func TestUnaggregatedIteratorDecodeBatchTimerMoreFieldsThanExpected(t *testing.T
 			encodeBatchTimerFn: func(bt unaggregated.BatchTimer) {
 				enc.encodeNumObjectFields(numFieldsForType(batchTimerType) + 1)
 				enc.encodeRawID(bt.ID)
-				enc.encodeArrayLen(len(bt.Values))
-				for _, v := range bt.Values {
-					enc.encodeFloat64(v)
-				}
+				enc.encodeFloat64Slice(bt.Values, nonPackedEncoding)
 				// Pretend we added an extra int field to the batch timer object.
 				enc.encodeVarint(0)
 			},
 		},
-		/*
-			{
-				version: 2,
-				encodeBatchTimerFn: func(bt unaggregated.BatchTimer) {
-					enc.encodeNumObjectFields(numFieldsForType(batchTimerType) + 1)
-					enc.encodeRawID(bt.ID)
-					enc.encodeBytesLen(len(bt.Values) * numBytesInFloat64)
-					var buf [numBytesInFloat64]byte
-					for _, v := range bt.Values {
-						byteOrder.PutUint64(buf[:], math.Float64bits(v))
-						enc.writeRaw(buf[:])
-					}
-					// Pretend we added an extra int field to the batch timer object.
-					enc.encodeVarint(0)
-				},
+		{
+			version: 2,
+			encodeBatchTimerFn: func(bt unaggregated.BatchTimer) {
+				enc.encodeNumObjectFields(numFieldsForType(batchTimerType) + 1)
+				enc.encodeRawID(bt.ID)
+				enc.encodeFloat64Slice(bt.Values, packedEncoding)
+				// Pretend we added an extra int field to the batch timer object.
+				enc.encodeVarint(1)
 			},
-		*/
+		},
 	}
 
 	for _, input := range inputs {
-		testUnaggregatedIteratorDecodeBatchTimerMoreFieldsThanExpectedWithVersion(
-			t,
-			input.encodeBatchTimerFn,
-			input.version,
-		)
+		enc.versionFn = func() int { return input.version }
+		enc.encodeBatchTimerFn = input.encodeBatchTimerFn
+		require.NoError(t, testUnaggregatedEncodeMetricWithPoliciesList(enc, data.metric, data.policiesList))
+
+		it := testUnaggregatedIterator(enc.Encoder().Buffer())
+
+		// Check that we successfully decoded the batch timer.
+		validateUnaggregatedDecodeResults(t, it, []metricWithPoliciesList{data}, io.EOF)
 	}
-}
-
-func testUnaggregatedIteratorDecodeBatchTimerMoreFieldsThanExpectedWithVersion(
-	t *testing.T,
-	encodeBatchTimerFn encodeBatchTimerFn,
-	version int,
-) {
-	input := metricWithPoliciesList{
-		metric:       testBatchTimer,
-		policiesList: testDefaultStagedPoliciesList,
-	}
-	enc := testUnaggregatedEncoder().(*unaggregatedEncoder)
-	//enc.encoderBase.(*baseEncoder).versionFn = func() int { return version }
-	enc.encodeBatchTimerFn = encodeBatchTimerFn
-	require.NoError(t, testUnaggregatedEncodeMetricWithPoliciesList(enc, input.metric, input.policiesList))
-
-	it := testUnaggregatedIterator(enc.Encoder().Buffer())
-
-	// Check that we successfully decoded the batch timer.
-	validateUnaggregatedDecodeResults(t, it, []metricWithPoliciesList{input}, io.EOF)
 }
 
 func TestUnaggregatedIteratorDecodeGaugeMoreFieldsThanExpected(t *testing.T) {

--- a/protocol/msgpack/unaggregated_roundtrip_test.go
+++ b/protocol/msgpack/unaggregated_roundtrip_test.go
@@ -358,8 +358,8 @@ func testCapturingBaseEncoder(encoder encoderBase) *[]interface{} {
 	baseEncoder.encodeFloat64Fn = func(value float64) {
 		result = append(result, value)
 	}
-	baseEncoder.encodeFloat64SliceFn = func(value []float64) {
-		result = append(result, value)
+	baseEncoder.encodeFloat64SliceFn = func(values []float64, encodingType encodingType) {
+		result = append(result, values, encodingType)
 	}
 	baseEncoder.encodeBytesFn = func(value []byte) {
 		result = append(result, value)

--- a/protocol/msgpack/unaggregated_roundtrip_test.go
+++ b/protocol/msgpack/unaggregated_roundtrip_test.go
@@ -358,6 +358,9 @@ func testCapturingBaseEncoder(encoder encoderBase) *[]interface{} {
 	baseEncoder.encodeFloat64Fn = func(value float64) {
 		result = append(result, value)
 	}
+	baseEncoder.encodeFloat64SliceFn = func(value []float64) {
+		result = append(result, value)
+	}
 	baseEncoder.encodeBytesFn = func(value []byte) {
 		result = append(result, value)
 	}


### PR DESCRIPTION
cc @cw9 @jeromefroe 

Need to fix the tests that have been commented out so marking it as work in progress, but the core implementation is complete. Benchmarks have shown promising results with the optimizations in this PR for encoding and decoding float64 slices, which is a significant portion of the overall encoding and decoding work.

Benchmark results (native is the current implementation, packed is the new implementation)
```
BenchmarkEncodeFloat64NativeSmall-8    	 2000000	       545 ns/op
BenchmarkEncodeFloat64NativeMedium-8   	   50000	     36431 ns/op
BenchmarkEncodeFloat64NativeLarge-8    	    1000	   1864905 ns/op
BenchmarkEncodeFloat64PackedSmall-8    	 5000000	       406 ns/op
BenchmarkEncodeFloat64PackedMedium-8   	  100000	     19447 ns/op
BenchmarkEncodeFloat64PackedLarge-8    	    2000	   1038561 ns/op
BenchmarkDecodeFloat64NativeSmall-8    	 1000000	      1066 ns/op
BenchmarkDecodeFloat64NativeMedium-8   	   20000	     65211 ns/op
BenchmarkDecodeFloat64NativeLarge-8    	     500	   3669564 ns/op
BenchmarkDecodeFloat64PackedSmall-8    	 5000000	       298 ns/op
BenchmarkDecodeFloat64PackedMedium-8   	  200000	     12088 ns/op
BenchmarkDecodeFloat64PackedLarge-8    	    2000	    658596 ns/op
```

As shown above, with the packed encoding/decoding, for medium sized `[]float64` with 1120 values, the new encoder is ~1.9x faster than the current encoder and the new decoder is ~5.4x faster than the current decoder.