### PR TITLE
Remove options validation since it's done inside m3cluster

### DIFF
--- a/matcher/config.go
+++ b/matcher/config.go
@@ -92,10 +92,6 @@ func (cfg *Configuration) NewOptions(
 		return nil, err
 	}
 
-	if err := kvOpts.Validate(); err != nil {
-		return nil, err
-	}
-
 	rulesStore, err := kvCluster.Store(kvOpts)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
cc @cw9 

This PR removes options validation since it's already done inside m3cluster.