### PR TITLE
Add validator configuration and export `ValidateSnapshot`

### DIFF
--- a/rules/rollup_test.go
+++ b/rules/rollup_test.go
@@ -130,11 +130,27 @@ func TestRollupTargetSameTransform(t *testing.T) {
 			result: true,
 		},
 		{
-			target: RollupTarget{Name: b("baz"), Tags: bs("bar1", "bar2")},
+			target: RollupTarget{Name: b("foo"), Tags: bs("bar2", "bar1"), Policies: policies},
+			result: true,
+		},
+		{
+			target: RollupTarget{Name: b("foo"), Tags: bs("bar1")},
+			result: false,
+		},
+		{
+			target: RollupTarget{Name: b("foo"), Tags: bs("bar1", "bar2", "bar3")},
 			result: false,
 		},
 		{
 			target: RollupTarget{Name: b("foo"), Tags: bs("bar1", "bar3")},
+			result: false,
+		},
+		{
+			target: RollupTarget{Name: b("baz"), Tags: bs("bar1", "bar2")},
+			result: false,
+		},
+		{
+			target: RollupTarget{Name: b("baz"), Tags: bs("bar2", "bar1")},
 			result: false,
 		},
 	}

--- a/rules/validator_config.go
+++ b/rules/validator_config.go
@@ -9,8 +9,8 @@ import (
 // ValidationConfiguration is the configuration for rules validation.
 type ValidationConfiguration struct {
 	RequiredRollupTags     []string                           `yaml:"requiredRollupTags"`
-	MetricTypes            MetricTypesValidationConfiguration `yaml:"metricTypes"`
-	Policies               PoliciesValidationConfiguration    `yaml:"policies"`
+	MetricTypes            metricTypesValidationConfiguration `yaml:"metricTypes"`
+	Policies               policiesValidationConfiguration    `yaml:"policies"`
 	TagNameInvalidChars    string                             `yaml:"tagNameInvalidChars"`
 	MetricNameInvalidChars string                             `yaml:"metricNameInvalidChars"`
 }
@@ -32,8 +32,8 @@ func (c ValidationConfiguration) NewValidator() Validator {
 	return NewValidator(opts)
 }
 
-// MetricTypesValidationConfiguration is th configuration for metric types validation.
-type MetricTypesValidationConfiguration struct {
+// metricTypesValidationConfiguration is th configuration for metric types validation.
+type metricTypesValidationConfiguration struct {
 	// Metric type tag.
 	TypeTag string `yaml:"typeTag"`
 
@@ -42,7 +42,7 @@ type MetricTypesValidationConfiguration struct {
 }
 
 // NewMetricTypesFn creates a new metric types fn from the given configuration.
-func (c MetricTypesValidationConfiguration) NewMetricTypesFn() MetricTypesFn {
+func (c metricTypesValidationConfiguration) NewMetricTypesFn() MetricTypesFn {
 	return func(tagFilters filters.TagFilterValueMap) ([]metric.Type, error) {
 		allowed := make([]metric.Type, 0, len(c.Allowed))
 		filterValue, exists := tagFilters[c.TypeTag]
@@ -64,23 +64,23 @@ func (c MetricTypesValidationConfiguration) NewMetricTypesFn() MetricTypesFn {
 	}
 }
 
-// PoliciesValidationConfiguration is the configuration for policies validation.
-type PoliciesValidationConfiguration struct {
+// policiesValidationConfiguration is the configuration for policies validation.
+type policiesValidationConfiguration struct {
 	// DefaultAllowed defines the policies allowed by default.
-	DefaultAllowed PoliciesConfiguration `yaml:"defaultAllowed"`
+	DefaultAllowed policiesConfiguration `yaml:"defaultAllowed"`
 
 	// Overrides define the metric type specific policy overrides.
-	Overrides []PoliciesOverrideConfiguration `yaml:"overrides"`
+	Overrides []policiesOverrideConfiguration `yaml:"overrides"`
 }
 
-// PoliciesOverrideConfiguration is the configuration for metric type specific policy overrides.
-type PoliciesOverrideConfiguration struct {
+// policiesOverrideConfiguration is the configuration for metric type specific policy overrides.
+type policiesOverrideConfiguration struct {
 	Type    metric.Type           `yaml:"type"`
-	Allowed PoliciesConfiguration `yaml:"allowed"`
+	Allowed policiesConfiguration `yaml:"allowed"`
 }
 
-// PoliciesConfiguration is the configuration for storage policies and aggregation types.
-type PoliciesConfiguration struct {
+// policiesConfiguration is the configuration for storage policies and aggregation types.
+type policiesConfiguration struct {
 	StoragePolicies  []policy.StoragePolicy   `yaml:"storagePolicies"`
 	AggregationTypes []policy.AggregationType `yaml:"aggregationTypes"`
 }

--- a/rules/validator_config.go
+++ b/rules/validator_config.go
@@ -1,0 +1,94 @@
+package rules
+
+import (
+	"github.com/m3db/m3metrics/filters"
+	"github.com/m3db/m3metrics/metric"
+	"github.com/m3db/m3metrics/policy"
+)
+
+// ValidationConfiguration is the configuration for rules validation.
+type ValidationConfiguration struct {
+	RequiredRollupTags     []string                           `yaml:"requiredRollupTags"`
+	MetricTypes            MetricTypesValidationConfiguration `yaml:"metricTypes"`
+	Policies               PoliciesValidationConfiguration    `yaml:"policies"`
+	TagNameInvalidChars    string                             `yaml:"tagNameInvalidChars"`
+	MetricNameInvalidChars string                             `yaml:"metricNameInvalidChars"`
+}
+
+// NewValidator creates a new rules validator based on the given configuration.
+func (c ValidationConfiguration) NewValidator() Validator {
+	opts := NewValidatorOptions().
+		SetRequiredRollupTags(c.RequiredRollupTags).
+		SetMetricTypesFn(c.MetricTypes.NewMetricTypesFn()).
+		SetDefaultAllowedStoragePolicies(c.Policies.DefaultAllowed.StoragePolicies).
+		SetDefaultAllowedCustomAggregationTypes(c.Policies.DefaultAllowed.AggregationTypes).
+		SetTagNameInvalidChars(toRunes(c.TagNameInvalidChars)).
+		SetMetricNameInvalidChars(toRunes(c.MetricNameInvalidChars))
+	for _, override := range c.Policies.Overrides {
+		opts = opts.
+			SetAllowedStoragePoliciesFor(override.Type, override.Allowed.StoragePolicies).
+			SetAllowedCustomAggregationTypesFor(override.Type, override.Allowed.AggregationTypes)
+	}
+	return NewValidator(opts)
+}
+
+// MetricTypesValidationConfiguration is th configuration for metric types validation.
+type MetricTypesValidationConfiguration struct {
+	// Metric type tag.
+	TypeTag string `yaml:"typeTag"`
+
+	// Allowed metric types.
+	Allowed []metric.Type `yaml:"allowed"`
+}
+
+// NewMetricTypesFn creates a new metric types fn from the given configuration.
+func (c MetricTypesValidationConfiguration) NewMetricTypesFn() MetricTypesFn {
+	return func(tagFilters filters.TagFilterValueMap) ([]metric.Type, error) {
+		allowed := make([]metric.Type, 0, len(c.Allowed))
+		filterValue, exists := tagFilters[c.TypeTag]
+		if !exists {
+			// If there is not type filter provided, the filter may match any allowed type.
+			allowed = append(allowed, c.Allowed...)
+			return allowed, nil
+		}
+		f, err := filters.NewFilterFromFilterValue(filterValue)
+		if err != nil {
+			return nil, err
+		}
+		for _, t := range c.Allowed {
+			if f.Matches([]byte(t.String())) {
+				allowed = append(allowed, t)
+			}
+		}
+		return allowed, nil
+	}
+}
+
+// PoliciesValidationConfiguration is the configuration for policies validation.
+type PoliciesValidationConfiguration struct {
+	// DefaultAllowed defines the policies allowed by default.
+	DefaultAllowed PoliciesConfiguration `yaml:"defaultAllowed"`
+
+	// Overrides define the metric type specific policy overrides.
+	Overrides []PoliciesOverrideConfiguration `yaml:"overrides"`
+}
+
+// PoliciesOverrideConfiguration is the configuration for metric type specific policy overrides.
+type PoliciesOverrideConfiguration struct {
+	Type    metric.Type           `yaml:"type"`
+	Allowed PoliciesConfiguration `yaml:"allowed"`
+}
+
+// PoliciesConfiguration is the configuration for storage policies and aggregation types.
+type PoliciesConfiguration struct {
+	StoragePolicies  []policy.StoragePolicy   `yaml:"storagePolicies"`
+	AggregationTypes []policy.AggregationType `yaml:"aggregationTypes"`
+}
+
+func toRunes(s string) []rune {
+	r := make([]rune, 0, len(s))
+	for _, c := range s {
+		r = append(r, c)
+	}
+	return r
+}


### PR DESCRIPTION
cc @cw9 @jeromefroe 

This PR adds configuration for the validator to be reused by both `m3ctl` and internal tooling. It also adds a new `ValidateSnapshot` API to validate a rule snapshot and additional validation logic to detect duplicate rollup tags and policies.