### PR TITLE
Add namespace validation logic

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: b4d3704dbb2dd49cfa1deedd38443ade08525476bef00b3bcbdaa4d5fadfcdfb
-updated: 2017-12-13T14:55:13.315541113-05:00
+updated: 2017-12-28T22:05:13.649936023-05:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
@@ -24,10 +24,12 @@ imports:
   version: 4b25af16e37d029b79bae754d35655e6be382f94
   subpackages:
   - client
+  - generated/proto/commonpb
   - generated/proto/metadatapb
   - generated/proto/placementpb
   - kv
   - kv/mem
+  - kv/util
   - kv/util/runtime
   - placement
   - services
@@ -78,6 +80,8 @@ imports:
   - m3/thriftudp
 - name: github.com/willf/bitset
   version: 988f4f24992fc745de53c42df0da6581e42a6686
+- name: go.uber.org/atomic
+  version: 8474b86a5a6f79c443ce4b2992817ff32cf208b8
 - name: golang.org/x/net
   version: f2499483f923065a842d38eb4c7f1927e6fc6e6d
   subpackages:
@@ -104,8 +108,12 @@ testImports:
   version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
   subpackages:
   - spew
+- name: github.com/fortytw2/leaktest
+  version: 7dad53304f9614c1c365755c1176a8e876fee3e8
 - name: github.com/stretchr/testify
   version: d77da356e56a7428ad25149ca77381849a6a5232
   subpackages:
   - assert
   - require
+- name: gopkg.in/validator.v2
+  version: 3e4f037f12a1221a0864cf0dd2e81c452ab22448

--- a/rules/store.go
+++ b/rules/store.go
@@ -22,15 +22,18 @@ package rules
 
 // Store performs read/write operations for rules and namespaces.
 type Store interface {
+	// ReadNamespaces returns the persisted namespaces in kv store.
+	ReadNamespaces() (*Namespaces, error)
+
+	// ReadRuleSet returns the persisted ruleset in kv store.
+	ReadRuleSet(nsName string) (RuleSet, error)
+
 	// WriteRuleSet saves the given ruleset to the backing store.
 	WriteRuleSet(rs MutableRuleSet) error
 
 	// WriteAll saves both the given ruleset and namespace to the backing store.
 	WriteAll(nss *Namespaces, rs MutableRuleSet) error
 
-	// ReadNamespaces returns the persisted namespaces in kv store.
-	ReadNamespaces() (*Namespaces, error)
-
-	// ReadRuleSet returns the persisted ruleset in kv store.
-	ReadRuleSet(nsName string) (RuleSet, error)
+	// Close closes the store.
+	Close()
 }

--- a/rules/store/kv/store.go
+++ b/rules/store/kv/store.go
@@ -127,6 +127,13 @@ func (s *store) WriteAll(nss *rules.Namespaces, rs rules.MutableRuleSet) error {
 	return err
 }
 
+func (s *store) Close() {
+	if s.opts.Validator == nil {
+		return
+	}
+	s.opts.Validator.Close()
+}
+
 func (s *store) ruleSetKey(ns string) string {
 	return fmt.Sprintf(s.opts.RuleSetKeyFmt, ns)
 }

--- a/rules/validator/namespace/kv/config.go
+++ b/rules/validator/namespace/kv/config.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package kv
+
+import (
+	"time"
+
+	"github.com/m3db/m3cluster/client"
+	"github.com/m3db/m3cluster/kv"
+	"github.com/m3db/m3metrics/rules/validator/namespace"
+)
+
+// NamespaceValidatorConfiguration configures a KV-backed namespace validator.
+type NamespaceValidatorConfiguration struct {
+	KVConfig               kv.Configuration `yaml:"kvConfig"`
+	InitWatchTimeout       *time.Duration   `yaml:"initWatchTimeout"`
+	ValidNamespacesKey     string           `yaml:"validNamespacesKey" validate:"nonzero"`
+	DefaultValidNamespaces *[]string        `yaml:"defaultValidNamespaces"`
+}
+
+// NewNamespaceValidator creates a new namespace validator.
+func (c *NamespaceValidatorConfiguration) NewNamespaceValidator(
+	kvClient client.Client,
+) (namespace.Validator, error) {
+	kvOpts, err := c.KVConfig.NewOptions()
+	if err != nil {
+		return nil, err
+	}
+	kvStore, err := kvClient.Store(kvOpts)
+	if err != nil {
+		return nil, err
+	}
+	opts := NewNamespaceValidatorOptions().
+		SetKVStore(kvStore).
+		SetValidNamespacesKey(c.ValidNamespacesKey)
+	if c.InitWatchTimeout != nil {
+		opts = opts.SetInitWatchTimeout(*c.InitWatchTimeout)
+	}
+	if c.DefaultValidNamespaces != nil {
+		opts = opts.SetDefaultValidNamespaces(*c.DefaultValidNamespaces)
+	}
+	return NewNamespaceValidator(opts)
+}

--- a/rules/validator/namespace/kv/config_test.go
+++ b/rules/validator/namespace/kv/config_test.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package kv
+
+import (
+	"testing"
+
+	"github.com/m3db/m3cluster/client"
+	"github.com/m3db/m3cluster/generated/proto/commonpb"
+	"github.com/m3db/m3cluster/kv"
+	"github.com/m3db/m3cluster/kv/mem"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+	gvalidator "gopkg.in/validator.v2"
+	yaml "gopkg.in/yaml.v2"
+)
+
+func TestNamespaceValidatorConfiguration(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	cfgStr := `
+kvConfig:
+  zone: testZone
+  environment: testEnvironment
+  namespace: testNamespace
+validNamespacesKey: validNamespaces
+`
+	var cfg NamespaceValidatorConfiguration
+	require.NoError(t, yaml.Unmarshal([]byte(cfgStr), &cfg))
+	require.NoError(t, gvalidator.Validate(cfg))
+
+	kvStore := mem.NewStore()
+	initNamespaces := &commonpb.StringArrayProto{
+		Values: []string{"foo", "bar", "baz"},
+	}
+	_, err := kvStore.SetIfNotExists("validNamespaces", initNamespaces)
+	require.NoError(t, err)
+
+	kvOpts := kv.NewOptions().
+		SetZone("testZone").
+		SetNamespace("testNamespace").
+		SetEnvironment("testEnvironment")
+
+	kvClient := client.NewMockClient(ctrl)
+	kvClient.EXPECT().Store(kvOpts).Return(kvStore, nil)
+
+	res, err := cfg.NewNamespaceValidator(kvClient)
+	require.NoError(t, err)
+	validator := res.(*validator)
+	require.Equal(t, kvStore, validator.kvStore)
+	require.Equal(t, "validNamespaces", validator.validNamespacesKey)
+	require.Equal(t, defaultInitWatchTimeout, validator.initWatchTimeout)
+	expectedValidNamespaces := map[string]struct{}{
+		"foo": struct{}{},
+		"bar": struct{}{},
+		"baz": struct{}{},
+	}
+	require.Equal(t, expectedValidNamespaces, validator.validNamespaces)
+}

--- a/rules/validator/namespace/kv/options.go
+++ b/rules/validator/namespace/kv/options.go
@@ -1,0 +1,133 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package kv
+
+import (
+	"time"
+
+	"github.com/m3db/m3cluster/kv"
+	"github.com/m3db/m3x/instrument"
+)
+
+const (
+	defaultInitWatchTimeout = 10 * time.Second
+)
+
+// NamespaceValidatorOptions provide a set of options for the KV-backed namespace validator.
+type NamespaceValidatorOptions interface {
+	// SetInstrumentOptions sets the instrument options.
+	SetInstrumentOptions(value instrument.Options) NamespaceValidatorOptions
+
+	// InstrumentOptions returns the instrument options.
+	InstrumentOptions() instrument.Options
+
+	// SetKVStore sets the KV store for namespace validation.
+	SetKVStore(value kv.Store) NamespaceValidatorOptions
+
+	// KVStore returns the KV store for namespace validation.
+	KVStore() kv.Store
+
+	// SetInitWatchTimeout sets the initial watch timeout.
+	SetInitWatchTimeout(value time.Duration) NamespaceValidatorOptions
+
+	// InitWatchTimeout returns the initial watch timeout.
+	InitWatchTimeout() time.Duration
+
+	// SetValidNamespacesKey sets the KV key associated with valid namespaces.
+	SetValidNamespacesKey(value string) NamespaceValidatorOptions
+
+	// ValidNamespacesKey returns the KV key associated with valid namespaces.
+	ValidNamespacesKey() string
+
+	// SetDefaultValidNamespaces sets the default list of valid namespaces.
+	SetDefaultValidNamespaces(value []string) NamespaceValidatorOptions
+
+	// DefaultValidNamespaces returns the default list of valid namespaces.
+	DefaultValidNamespaces() []string
+}
+
+type namespaceValidatorOptions struct {
+	instrumentOpts         instrument.Options
+	kvStore                kv.Store
+	initWatchTimeout       time.Duration
+	validNamespacesKey     string
+	defaultValidNamespaces []string
+}
+
+// NewNamespaceValidatorOptions create a new set of namespace validator options.
+func NewNamespaceValidatorOptions() NamespaceValidatorOptions {
+	return &namespaceValidatorOptions{
+		instrumentOpts:   instrument.NewOptions(),
+		initWatchTimeout: defaultInitWatchTimeout,
+	}
+}
+
+func (o *namespaceValidatorOptions) SetInstrumentOptions(value instrument.Options) NamespaceValidatorOptions {
+	opts := *o
+	opts.instrumentOpts = value
+	return &opts
+}
+
+func (o *namespaceValidatorOptions) InstrumentOptions() instrument.Options {
+	return o.instrumentOpts
+}
+
+func (o *namespaceValidatorOptions) SetKVStore(value kv.Store) NamespaceValidatorOptions {
+	opts := *o
+	opts.kvStore = value
+	return &opts
+}
+
+func (o *namespaceValidatorOptions) KVStore() kv.Store {
+	return o.kvStore
+}
+
+func (o *namespaceValidatorOptions) SetInitWatchTimeout(value time.Duration) NamespaceValidatorOptions {
+	opts := *o
+	opts.initWatchTimeout = value
+	return &opts
+}
+
+func (o *namespaceValidatorOptions) InitWatchTimeout() time.Duration {
+	return o.initWatchTimeout
+}
+
+func (o *namespaceValidatorOptions) SetValidNamespacesKey(value string) NamespaceValidatorOptions {
+	opts := *o
+	opts.validNamespacesKey = value
+	return &opts
+}
+
+func (o *namespaceValidatorOptions) ValidNamespacesKey() string {
+	return o.validNamespacesKey
+}
+
+func (o *namespaceValidatorOptions) SetDefaultValidNamespaces(value []string) NamespaceValidatorOptions {
+	cloned := make([]string, len(value))
+	copy(cloned, value)
+	opts := *o
+	opts.defaultValidNamespaces = cloned
+	return &opts
+}
+
+func (o *namespaceValidatorOptions) DefaultValidNamespaces() []string {
+	return o.defaultValidNamespaces
+}

--- a/rules/validator/namespace/kv/validator.go
+++ b/rules/validator/namespace/kv/validator.go
@@ -1,0 +1,152 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package kv
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/m3db/m3cluster/kv"
+	kvutil "github.com/m3db/m3cluster/kv/util"
+	"github.com/m3db/m3metrics/rules/validator/namespace"
+	"github.com/m3db/m3x/log"
+)
+
+var (
+	errValidatorClosed = errors.New("validator is closed")
+)
+
+type validator struct {
+	sync.RWMutex
+
+	opts               NamespaceValidatorOptions
+	logger             log.Logger
+	kvStore            kv.Store
+	validNamespacesKey string
+	initWatchTimeout   time.Duration
+
+	closed          bool
+	doneCh          chan struct{}
+	wg              sync.WaitGroup
+	validNamespaces map[string]struct{}
+}
+
+// NewNamespaceValidator creates a new namespace validator.
+func NewNamespaceValidator(opts NamespaceValidatorOptions) (namespace.Validator, error) {
+	v := &validator{
+		opts:               opts,
+		logger:             opts.InstrumentOptions().Logger(),
+		kvStore:            opts.KVStore(),
+		validNamespacesKey: opts.ValidNamespacesKey(),
+		initWatchTimeout:   opts.InitWatchTimeout(),
+		doneCh:             make(chan struct{}),
+		validNamespaces:    toStringSet(opts.DefaultValidNamespaces()),
+	}
+	if err := v.watchRuntimeConfig(); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+// Validate validates whether a given namespace is valid.
+func (v *validator) Validate(ns string) error {
+	v.RLock()
+	defer v.RUnlock()
+
+	if v.closed {
+		return errValidatorClosed
+	}
+	if _, exists := v.validNamespaces[ns]; !exists {
+		return fmt.Errorf("%s is not a valid namespace", ns)
+	}
+	return nil
+}
+
+func (v *validator) Close() {
+	v.Lock()
+	if v.closed {
+		v.Unlock()
+		return
+	}
+	v.closed = true
+	close(v.doneCh)
+	v.Unlock()
+
+	// NB: Must wait outside the lock to avoid a circular dependency
+	// between the goroutine closing the validator and the goroutine
+	// processing updates.
+	v.wg.Wait()
+}
+
+func (v *validator) watchRuntimeConfig() error {
+	watch, err := v.kvStore.Watch(v.validNamespacesKey)
+	if err != nil {
+		return err
+	}
+	kvOpts := kvutil.NewOptions().SetLogger(v.logger)
+	select {
+	case <-watch.C():
+		v.processUpdate(watch.Get(), kvOpts)
+	case <-time.After(v.initWatchTimeout):
+		v.logger.WithFields(
+			log.NewField("key", v.validNamespacesKey),
+			log.NewField("timeout", v.initWatchTimeout),
+			log.NewField("default", v.opts.DefaultValidNamespaces()),
+		).Warnf("timed out waiting for initial valid namespaces")
+	}
+
+	v.wg.Add(1)
+	go func() {
+		defer v.wg.Done()
+
+		for {
+			select {
+			case <-watch.C():
+				v.processUpdate(watch.Get(), kvOpts)
+			case <-v.doneCh:
+				return
+			}
+		}
+	}()
+	return nil
+}
+
+func (v *validator) processUpdate(value kv.Value, opts kvutil.Options) {
+	strs, err := kvutil.StringArrayFromValue(value, v.validNamespacesKey, v.opts.DefaultValidNamespaces(), opts)
+	if err != nil {
+		// kvutil already logged the error.
+		return
+	}
+	m := toStringSet(strs)
+	v.Lock()
+	v.validNamespaces = m
+	v.Unlock()
+}
+
+func toStringSet(strs []string) map[string]struct{} {
+	m := make(map[string]struct{}, len(strs))
+	for _, s := range strs {
+		m[s] = struct{}{}
+	}
+	return m
+}

--- a/rules/validator/namespace/kv/validator_test.go
+++ b/rules/validator/namespace/kv/validator_test.go
@@ -1,0 +1,184 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package kv
+
+import (
+	"testing"
+	"time"
+
+	"github.com/m3db/m3cluster/generated/proto/commonpb"
+	"github.com/m3db/m3cluster/kv"
+	"github.com/m3db/m3cluster/kv/mem"
+
+	"github.com/fortytw2/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testValidNamespacesKey = "validNamespaces"
+)
+
+var (
+	testNamespaces1 = []string{"foo", "bar", "baz"}
+	testNamespaces2 = []string{"blah", "invalid"}
+)
+
+func TestValidatorInitTimeoutWithUpdate(t *testing.T) {
+	defer leaktest.Check(t)()
+
+	store := mem.NewStore()
+	v := testValidator(t, store)
+
+	// Timed out getting initial value and by default
+	// no namespace is valid.
+	for _, ns := range testNamespaces1 {
+		require.Error(t, v.Validate(ns))
+	}
+	for _, ns := range testNamespaces2 {
+		require.Error(t, v.Validate(ns))
+	}
+
+	// Set valid namespaces in KV and wait for changes to be processed.
+	nss := &commonpb.StringArrayProto{Values: testNamespaces1}
+	_, err := store.Set(testValidNamespacesKey, nss)
+	require.NoError(t, err)
+	for {
+		v.RLock()
+		currValidNamespaces := v.validNamespaces
+		v.RUnlock()
+		if len(currValidNamespaces) == len(testNamespaces1) {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// Now validating the valid namespaces should be ok and validating
+	// invalid namespaces should return an error.
+	for _, ns := range testNamespaces1 {
+		require.NoError(t, v.Validate(ns))
+	}
+	for _, ns := range testNamespaces2 {
+		require.Error(t, v.Validate(ns))
+	}
+
+	// Close the validator.
+	require.False(t, v.closed)
+	v.Close()
+	require.True(t, v.closed)
+
+	// Validating after the validator is closed results in an error.
+	for _, ns := range testNamespaces1 {
+		require.Equal(t, errValidatorClosed, v.Validate(ns))
+	}
+	for _, ns := range testNamespaces2 {
+		require.Equal(t, errValidatorClosed, v.Validate(ns))
+	}
+}
+
+func TestValidatorWithUpdateAndDeletion(t *testing.T) {
+	defer leaktest.Check(t)()
+
+	// Set valid namespaces in KV and wait for changes to be processed.
+	store := mem.NewStore()
+	nss := &commonpb.StringArrayProto{Values: testNamespaces1}
+	_, err := store.Set(testValidNamespacesKey, nss)
+	require.NoError(t, err)
+
+	// Assert that the validator has successfully received the list
+	// of valid namespaces from KV.
+	v := testValidator(t, store)
+	for _, ns := range testNamespaces1 {
+		require.NoError(t, v.Validate(ns))
+	}
+	for _, ns := range testNamespaces2 {
+		require.Error(t, v.Validate(ns))
+	}
+
+	// Change valid namespaces in KV and wait for changes to be processed.
+	nss = &commonpb.StringArrayProto{Values: testNamespaces2}
+	_, err = store.Set(testValidNamespacesKey, nss)
+	require.NoError(t, err)
+	for {
+		v.RLock()
+		currValidNamespaces := v.validNamespaces
+		v.RUnlock()
+		if len(currValidNamespaces) == len(testNamespaces2) {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// Now validating the valid namespaces should be ok and validating
+	// invalid namespaces should return an error.
+	for _, ns := range testNamespaces1 {
+		require.Error(t, v.Validate(ns))
+	}
+	for _, ns := range testNamespaces2 {
+		require.NoError(t, v.Validate(ns))
+	}
+
+	// Delete the valid namespaces key.
+	_, err = store.Delete(testValidNamespacesKey)
+	require.NoError(t, err)
+	for {
+		v.RLock()
+		currValidNamespaces := v.validNamespaces
+		v.RUnlock()
+		if len(currValidNamespaces) == 0 {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// No namespaces are valid by default after the key is deleted.
+	for _, ns := range testNamespaces1 {
+		require.Error(t, v.Validate(ns))
+	}
+	for _, ns := range testNamespaces2 {
+		require.Error(t, v.Validate(ns))
+	}
+
+	// Close the validator.
+	require.False(t, v.closed)
+	v.Close()
+	require.True(t, v.closed)
+
+	// Validating after the validator is closed results in an error.
+	for _, ns := range testNamespaces1 {
+		require.Equal(t, errValidatorClosed, v.Validate(ns))
+	}
+	for _, ns := range testNamespaces2 {
+		require.Equal(t, errValidatorClosed, v.Validate(ns))
+	}
+}
+
+func testValidatorOptions(store kv.Store) NamespaceValidatorOptions {
+	return NewNamespaceValidatorOptions().
+		SetInitWatchTimeout(100 * time.Millisecond).
+		SetKVStore(store).
+		SetValidNamespacesKey(testValidNamespacesKey)
+}
+
+func testValidator(t *testing.T, store kv.Store) *validator {
+	v, err := NewNamespaceValidator(testValidatorOptions(store))
+	require.NoError(t, err)
+	return v.(*validator)
+}

--- a/rules/validator/namespace/static/config.go
+++ b/rules/validator/namespace/static/config.go
@@ -18,16 +18,18 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package rules
+package static
 
-// Validator validates a ruleset.
-type Validator interface {
-	// Validate validates a ruleset.
-	Validate(rs RuleSet) error
+import (
+	"github.com/m3db/m3metrics/rules/validator/namespace"
+)
 
-	// ValidateSnapshot validates a ruleset snapshot.
-	ValidateSnapshot(snapshot *RuleSetSnapshot) error
+// NamespaceValidatorConfiguration configures a static namespace validator.
+type NamespaceValidatorConfiguration struct {
+	ValidationResult ValidationResult `yaml:"validationResult"`
+}
 
-	// Close closes the validator.
-	Close()
+// NewNamespaceValidator creates a new namespace validator.
+func (c *NamespaceValidatorConfiguration) NewNamespaceValidator() namespace.Validator {
+	return NewNamespaceValidator(c.ValidationResult)
 }

--- a/rules/validator/namespace/static/validator.go
+++ b/rules/validator/namespace/static/validator.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package static
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/m3db/m3metrics/rules/validator/namespace"
+)
+
+// ValidationResult is the validation result.
+type ValidationResult string
+
+// A list of supported validation result.
+const (
+	Invalid ValidationResult = "invalid"
+	Valid   ValidationResult = "valid"
+)
+
+var (
+	validValidationResults = []ValidationResult{
+		Invalid,
+		Valid,
+	}
+)
+
+// UnmarshalYAML unmarshals YAML object into a validation result.
+func (t *ValidationResult) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var str string
+	if err := unmarshal(&str); err != nil {
+		return err
+	}
+	validResults := make([]string, 0, len(validValidationResults))
+	for _, valid := range validValidationResults {
+		if str == string(valid) {
+			*t = valid
+			return nil
+		}
+		validResults = append(validResults, string(valid))
+	}
+	return fmt.Errorf("invalid validation result '%s' valid results are: %s",
+		str, strings.Join(validResults, ", "))
+}
+
+type validator struct {
+	validationResult ValidationResult
+}
+
+// NewNamespaceValidator creates a new static namespace validator.
+func NewNamespaceValidator(res ValidationResult) namespace.Validator {
+	return &validator{validationResult: res}
+}
+
+func (v *validator) Validate(ns string) error {
+	switch v.validationResult {
+	case Invalid:
+		return fmt.Errorf("static validator returns invalid for %s", ns)
+	default:
+		return nil
+	}
+}
+
+func (v *validator) Close() {}

--- a/rules/validator/namespace/static/validator_test.go
+++ b/rules/validator/namespace/static/validator_test.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package static
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	yaml "gopkg.in/yaml.v2"
+)
+
+func TestValidationResultUnmarshalYAML(t *testing.T) {
+	inputs := []string{
+		"invalid",
+		"valid",
+	}
+
+	for _, input := range inputs {
+		var res ValidationResult
+		require.NoError(t, yaml.Unmarshal([]byte(input), &res))
+		require.Equal(t, string(res), input)
+	}
+}
+
+func TestValidationResultUnmarshalYAMLError(t *testing.T) {
+	inputs := []string{
+		"foo",
+		"blah",
+	}
+	for _, input := range inputs {
+		var res ValidationResult
+		require.Error(t, yaml.Unmarshal([]byte(input), &res))
+	}
+}
+
+func TestValidatorAlwaysValid(t *testing.T) {
+	cfgStr := `
+validationResult: valid
+`
+	var cfg NamespaceValidatorConfiguration
+	require.NoError(t, yaml.Unmarshal([]byte(cfgStr), &cfg))
+	validator := cfg.NewNamespaceValidator()
+
+	inputs := []string{
+		"foo",
+		"bar",
+		"baz",
+	}
+	for _, input := range inputs {
+		require.NoError(t, validator.Validate(input))
+	}
+}
+
+func TestValidatorAlwaysInvalid(t *testing.T) {
+	cfgStr := `
+validationResult: invalid
+`
+	var cfg NamespaceValidatorConfiguration
+	require.NoError(t, yaml.Unmarshal([]byte(cfgStr), &cfg))
+	validator := cfg.NewNamespaceValidator()
+
+	inputs := []string{
+		"foo",
+		"bar",
+		"baz",
+	}
+	for _, input := range inputs {
+		require.Error(t, validator.Validate(input))
+	}
+}

--- a/rules/validator/namespace/validator.go
+++ b/rules/validator/namespace/validator.go
@@ -18,16 +18,13 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package rules
+package namespace
 
-// Validator validates a ruleset.
+// Validator validates namespaces.
 type Validator interface {
-	// Validate validates a ruleset.
-	Validate(rs RuleSet) error
+	// Validate validates whether a given namespace is valid.
+	Validate(ns string) error
 
-	// ValidateSnapshot validates a ruleset snapshot.
-	ValidateSnapshot(snapshot *RuleSetSnapshot) error
-
-	// Close closes the validator.
+	// Close closes the namespace validator.
 	Close()
 }


### PR DESCRIPTION
cc @jeromefroe @cw9 

This PR adds namespace validation logic to validate the namespace associated with a ruleset to prevent invalid namespaces from being persisted.