### PR TITLE
Validate filter during snapshot construction

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package validator
+package errors
 
 // RuleConflictError is returned when a rule modification is made that would
 // result in a conflict with the existing set of rules in the ruleset.
@@ -28,7 +28,7 @@ type RuleConflictError string
 func NewRuleConflictError(str string) error { return RuleConflictError(str) }
 func (e RuleConflictError) Error() string   { return string(e) }
 
-// ValidationError is returned when validation failed for a ruleset.
+// ValidationError is returned when validation failed.
 type ValidationError string
 
 // NewValidationError creates a new validation error.

--- a/filters/tags_filter.go
+++ b/filters/tags_filter.go
@@ -256,3 +256,20 @@ func (f *tagsFilter) Matches(id []byte) bool {
 
 	return currIdx == len(f.tagFilters)
 }
+
+// ValidateTagsFilter validates whether a given string is a valid tags filter,
+// returning the filter values if the string is a valid tags filter expression,
+// and the error otherwise.
+func ValidateTagsFilter(str string) (TagFilterValueMap, error) {
+	filterValues, err := ParseTagFilterValueMap(str)
+	if err != nil {
+		return nil, fmt.Errorf("tags filter %s is malformed: %v", str, err)
+	}
+	for name, value := range filterValues {
+		// Validating the filter value by actually constructing the filter.
+		if _, err := NewFilterFromFilterValue(value); err != nil {
+			return nil, fmt.Errorf("tags filter %s contains invalid filter pattern %s for tag %s: %v", str, value.Pattern, name, err)
+		}
+	}
+	return filterValues, nil
+}

--- a/filters/tags_filter.go
+++ b/filters/tags_filter.go
@@ -26,6 +26,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/m3db/m3metrics/errors"
 	"github.com/m3db/m3metrics/metric/id"
 )
 
@@ -263,12 +264,12 @@ func (f *tagsFilter) Matches(id []byte) bool {
 func ValidateTagsFilter(str string) (TagFilterValueMap, error) {
 	filterValues, err := ParseTagFilterValueMap(str)
 	if err != nil {
-		return nil, fmt.Errorf("tags filter %s is malformed: %v", str, err)
+		return nil, errors.NewValidationError(fmt.Sprintf("tags filter %s is malformed: %v", str, err))
 	}
 	for name, value := range filterValues {
 		// Validating the filter value by actually constructing the filter.
 		if _, err := NewFilterFromFilterValue(value); err != nil {
-			return nil, fmt.Errorf("tags filter %s contains invalid filter pattern %s for tag %s: %v", str, value.Pattern, name, err)
+			return nil, errors.NewValidationError(fmt.Sprintf("tags filter %s contains invalid filter pattern %s for tag %s: %v", str, value.Pattern, name, err))
 		}
 	}
 	return filterValues, nil

--- a/rules/mapping.go
+++ b/rules/mapping.go
@@ -82,10 +82,8 @@ func newMappingRuleSnapshot(
 	), nil
 }
 
-// nolint: unparam
 func newMappingRuleSnapshotFromFields(
 	name string,
-	tombstoned bool,
 	cutoverNanos int64,
 	rawFilter string,
 	policies []policy.Policy,
@@ -98,7 +96,7 @@ func newMappingRuleSnapshotFromFields(
 	}
 	return newMappingRuleSnapshotFromFieldsInternal(
 		name,
-		tombstoned,
+		false,
 		cutoverNanos,
 		rawFilter,
 		policies,
@@ -281,7 +279,6 @@ func (mc *mappingRule) addSnapshot(
 ) error {
 	snapshot, err := newMappingRuleSnapshotFromFields(
 		name,
-		false,
 		meta.cutoverNanos,
 		rawFilter,
 		policies,

--- a/rules/mapping.go
+++ b/rules/mapping.go
@@ -70,7 +70,7 @@ func newMappingRuleSnapshot(
 		return nil, err
 	}
 
-	return newMappingRuleSnapshotFromFields(
+	return newMappingRuleSnapshotFromFieldsInternal(
 		r.Name,
 		r.Tombstoned,
 		r.CutoverNanos,
@@ -83,6 +83,33 @@ func newMappingRuleSnapshot(
 }
 
 func newMappingRuleSnapshotFromFields(
+	name string,
+	tombstoned bool,
+	cutoverNanos int64,
+	rawFilter string,
+	policies []policy.Policy,
+	filter filters.Filter,
+	lastUpdatedAtNanos int64,
+	lastUpdatedBy string,
+) (*mappingRuleSnapshot, error) {
+	if _, err := filters.ValidateTagsFilter(rawFilter); err != nil {
+		return nil, err
+	}
+	return newMappingRuleSnapshotFromFieldsInternal(
+		name,
+		tombstoned,
+		cutoverNanos,
+		rawFilter,
+		policies,
+		filter,
+		lastUpdatedAtNanos,
+		lastUpdatedBy,
+	), nil
+}
+
+// newMappingRuleSnapshotFromFieldsInternal creates a new mapping rule snapshot
+// from various given fields assuming the filter has already been validated.
+func newMappingRuleSnapshotFromFieldsInternal(
 	name string,
 	tombstoned bool,
 	cutoverNanos int64,
@@ -251,7 +278,7 @@ func (mc *mappingRule) addSnapshot(
 	policies []policy.Policy,
 	meta UpdateMetadata,
 ) error {
-	snapshot := newMappingRuleSnapshotFromFields(
+	snapshot, err := newMappingRuleSnapshotFromFields(
 		name,
 		false,
 		meta.cutoverNanos,
@@ -261,6 +288,9 @@ func (mc *mappingRule) addSnapshot(
 		meta.updatedAtNanos,
 		meta.updatedBy,
 	)
+	if err != nil {
+		return err
+	}
 	mc.snapshots = append(mc.snapshots, snapshot)
 	return nil
 }

--- a/rules/mapping.go
+++ b/rules/mapping.go
@@ -82,6 +82,7 @@ func newMappingRuleSnapshot(
 	), nil
 }
 
+// nolint: unparam
 func newMappingRuleSnapshotFromFields(
 	name string,
 	tombstoned bool,

--- a/rules/rollup.go
+++ b/rules/rollup.go
@@ -203,6 +203,7 @@ func newRollupRuleSnapshot(
 	), nil
 }
 
+// nolint: unparam
 func newRollupRuleSnapshotFromFields(
 	name string,
 	tombstoned bool,

--- a/rules/rollup.go
+++ b/rules/rollup.go
@@ -203,10 +203,8 @@ func newRollupRuleSnapshot(
 	), nil
 }
 
-// nolint: unparam
 func newRollupRuleSnapshotFromFields(
 	name string,
-	tombstoned bool,
 	cutoverNanos int64,
 	rawFilter string,
 	targets []RollupTarget,
@@ -219,7 +217,7 @@ func newRollupRuleSnapshotFromFields(
 	}
 	return newRollupRuleSnapshotFromFieldsInternal(
 		name,
-		tombstoned,
+		false,
 		cutoverNanos,
 		rawFilter,
 		targets,
@@ -440,7 +438,6 @@ func (rc *rollupRule) addSnapshot(
 ) error {
 	snapshot, err := newRollupRuleSnapshotFromFields(
 		name,
-		false,
 		meta.cutoverNanos,
 		rawFilter,
 		rollupTargets,

--- a/rules/validator/validator.go
+++ b/rules/validator/validator.go
@@ -23,6 +23,7 @@ package validator
 import (
 	"fmt"
 
+	"github.com/m3db/m3metrics/errors"
 	"github.com/m3db/m3metrics/filters"
 	"github.com/m3db/m3metrics/metric"
 	"github.com/m3db/m3metrics/policy"
@@ -86,7 +87,7 @@ func (v *validator) validateMappingRules(mrv map[string]*rules.MappingRuleView) 
 	for _, view := range mrv {
 		// Validate that no rules with the same name exist.
 		if _, exists := namesSeen[view.Name]; exists {
-			return NewRuleConflictError(fmt.Sprintf("mapping rule %s already exists", view.Name))
+			return errors.NewRuleConflictError(fmt.Sprintf("mapping rule %s already exists", view.Name))
 		}
 		namesSeen[view.Name] = struct{}{}
 
@@ -121,7 +122,7 @@ func (v *validator) validateRollupRules(rrv map[string]*rules.RollupRuleView) er
 	for _, view := range rrv {
 		// Validate that no rules with the same name exist.
 		if _, exists := namesSeen[view.Name]; exists {
-			return NewRuleConflictError(fmt.Sprintf("rollup rule %s already exists", view.Name))
+			return errors.NewRuleConflictError(fmt.Sprintf("rollup rule %s already exists", view.Name))
 		}
 		namesSeen[view.Name] = struct{}{}
 
@@ -160,7 +161,7 @@ func (v *validator) validateRollupRules(rrv map[string]*rules.RollupRuleView) er
 			current := target.RollupTarget()
 			for _, seenTarget := range targetsSeen {
 				if current.SameTransform(seenTarget) {
-					return NewRuleConflictError(fmt.Sprintf("rollup target with name %s and tags %s already exists", current.Name, current.Tags))
+					return errors.NewRuleConflictError(fmt.Sprintf("rollup target with name %s and tags %s already exists", current.Name, current.Tags))
 				}
 			}
 			targetsSeen = append(targetsSeen, current)
@@ -283,11 +284,11 @@ func (v *validator) wrapError(err error) error {
 		return nil
 	}
 	switch err.(type) {
-	// Do not wrap error for these error types so caller can take actions based on the correct
-	// error type.
-	case RuleConflictError:
+	// Do not wrap error for these error types so caller can take actions
+	// based on the correct error type.
+	case errors.RuleConflictError, errors.ValidationError:
 		return err
 	default:
-		return NewValidationError(err.Error())
+		return errors.NewValidationError(err.Error())
 	}
 }

--- a/rules/validator/validator.go
+++ b/rules/validator/validator.go
@@ -171,19 +171,14 @@ func (v *validator) validateRollupRules(rrv map[string]*rules.RollupRuleView) er
 }
 
 func (v *validator) validateFilter(ruleName string, f string) (filters.TagFilterValueMap, error) {
-	filterValues, err := filters.ParseTagFilterValueMap(f)
+	filterValues, err := filters.ValidateTagsFilter(f)
 	if err != nil {
 		return nil, fmt.Errorf("rule %s has invalid rule filter %s: %v", ruleName, f, err)
 	}
-	for tag, filterValue := range filterValues {
+	for tag := range filterValues {
 		// Validating the filter tag name does not contain invalid chars.
 		if err := v.opts.CheckInvalidCharactersForTagName(tag); err != nil {
 			return nil, fmt.Errorf("rule %s has invalid rule filter %s: tag name %s contains invalid character, err: %v", ruleName, f, tag, err)
-		}
-
-		// Validating the filter expression by actually constructing the filter.
-		if _, err := filters.NewFilterFromFilterValue(filterValue); err != nil {
-			return nil, fmt.Errorf("rule %s has invalid rule filter %s: filter pattern for tag %s is invalid, err: %v", ruleName, f, tag, err)
 		}
 	}
 	return filterValues, nil

--- a/rules/validator/validator_test.go
+++ b/rules/validator/validator_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/m3db/m3cluster/generated/proto/commonpb"
 	"github.com/m3db/m3cluster/kv/mem"
+	"github.com/m3db/m3metrics/errors"
 	"github.com/m3db/m3metrics/filters"
 	"github.com/m3db/m3metrics/generated/proto/schema"
 	"github.com/m3db/m3metrics/metric"
@@ -91,7 +92,7 @@ func TestValidatorValidateDuplicateMappingRules(t *testing.T) {
 	validator := NewValidator(testValidatorOptions())
 	err := validator.Validate(ruleSet)
 	require.Error(t, err)
-	_, ok := err.(RuleConflictError)
+	_, ok := err.(errors.RuleConflictError)
 	require.True(t, ok)
 }
 
@@ -208,7 +209,7 @@ func TestValidatorValidateDuplicateRollupRules(t *testing.T) {
 	validator := NewValidator(testValidatorOptions())
 	err := validator.Validate(ruleSet)
 	require.Error(t, err)
-	_, ok := err.(RuleConflictError)
+	_, ok := err.(errors.RuleConflictError)
 	require.True(t, ok)
 }
 
@@ -382,7 +383,7 @@ func TestValidatorValidateRollupRuleConflictingTargets(t *testing.T) {
 	validator := NewValidator(opts)
 	err := validator.Validate(ruleSet)
 	require.Error(t, err)
-	_, ok := err.(RuleConflictError)
+	_, ok := err.(errors.RuleConflictError)
 	require.True(t, ok)
 }
 


### PR DESCRIPTION
cc @jeromefroe @cw9 

This PR adds filter validation when constructing mapping rule and rollup rule snapshots. This validation is currently done in the rules store right before persistence, so bad filter expression won't be detected till before the rule is persisted. By performing filter validation during construction, this can fail early when bad filter expression is detected.