### PR TITLE
Fix type conversion errors

### DIFF
--- a/rules/models/rollup.go
+++ b/rules/models/rollup.go
@@ -50,12 +50,20 @@ type RollupRuleViews map[string][]*RollupRuleView
 
 // NewRollupTarget takes a RollupTargetView and returns the equivalent RollupTarget.
 func NewRollupTarget(t RollupTargetView) RollupTarget {
-	return RollupTarget(t)
+	return RollupTarget{
+		Name:     t.Name,
+		Tags:     t.Tags,
+		Policies: t.Policies,
+	}
 }
 
 // ToRollupTargetView returns the equivalent ToRollupTargetView.
 func (t RollupTarget) ToRollupTargetView() RollupTargetView {
-	return RollupTargetView(t)
+	return RollupTargetView{
+		Name:     t.Name,
+		Tags:     t.Tags,
+		Policies: t.Policies,
+	}
 }
 
 // Sort sorts the policies inside the rollup target.


### PR DESCRIPTION
cc @cw9 @jskelcy 

This PR fixes the metalint errors when converting between a rollup target and a rollup target view.