### PR TITLE
Add metric and pipeline metadata

### DIFF
--- a/aggregation/id.go
+++ b/aggregation/id.go
@@ -36,6 +36,11 @@ const (
 	idBitMask  = 63
 )
 
+var (
+	// DefaultID is a default ID.
+	DefaultID ID
+)
+
 // ID represents a compressed view of Types.
 type ID [IDLen]uint64
 

--- a/aggregation/type.go
+++ b/aggregation/type.go
@@ -74,9 +74,6 @@ var (
 	// DefaultTypes is a default list of aggregation types.
 	DefaultTypes Types
 
-	// DefaultID is a default ID.
-	DefaultID ID
-
 	// ValidTypes is the list of all the valid aggregation types.
 	ValidTypes = map[Type]struct{}{
 		Last:   emptyStruct,

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -131,6 +131,11 @@ type StagedMetadata struct {
 	Tombstoned bool
 }
 
+// IsDefault returns whether this is a default staged metadata.
+func (sm StagedMetadata) IsDefault() bool {
+	return sm.CutoverNanos == 0 && !sm.Tombstoned && sm.Metadata.IsDefault()
+}
+
 // StagedMetadatas contains a list of staged metadatas.
 type StagedMetadatas []StagedMetadata
 

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -1,0 +1,140 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package metadata
+
+import (
+	"github.com/m3db/m3metrics/aggregation"
+	"github.com/m3db/m3metrics/op/applied"
+	"github.com/m3db/m3metrics/policy"
+)
+
+var (
+	// DefaultStagedMetadata represents a default staged metadata.
+	DefaultStagedMetadata StagedMetadata
+)
+
+// PipelineType describes the type of a pipeline.
+type PipelineType int
+
+// A list of supported pipeline types.
+const (
+	// A standard pipeline is a full pipeline that has not been processed.
+	// The first step of a standard pipeline is always an aggregation step.
+	// Metrics associated with a standard pipeline are raw, unaggregated metrics.
+	StandardType PipelineType = iota
+
+	// A forwarding pipeline is a sub-pipeline whose previous steps have
+	// been processed. There are no aggregation steps in a forwarding pipeline.
+	// Metrics associated with a forwarding pipeline are produced from
+	// previous steps of the same forwarding pipeline.
+	ForwardingType
+)
+
+// AggregationMetadata dictates how metrics should be aggregated.
+type AggregationMetadata struct {
+	// List of aggregation types.
+	AggregationID aggregation.ID
+
+	// List of storage policies.
+	StoragePolicies []policy.StoragePolicy
+}
+
+// IsDefault returns whether this is the default aggregation metadata.
+func (m AggregationMetadata) IsDefault() bool {
+	return m.AggregationID.IsDefault() && policy.IsDefaultStoragePolicies(m.StoragePolicies)
+}
+
+// StandardPipelineMetadata contains standard pipeline metadata.
+type StandardPipelineMetadata struct {
+	AggregationMetadata
+	applied.Pipeline
+}
+
+// IsDefault returns whether this is the default standard pipeline metadata.
+func (sm StandardPipelineMetadata) IsDefault() bool {
+	return sm.AggregationMetadata.IsDefault() && sm.Pipeline.IsEmpty()
+}
+
+// ForwardingPipelineMetadata contains forwarding pipeline metadata.
+type ForwardingPipelineMetadata struct {
+	applied.Pipeline
+}
+
+// IsDefault returns whether this is the default forwarding pipeline metadata.
+func (fm ForwardingPipelineMetadata) IsDefault() bool {
+	return fm.Pipeline.IsEmpty()
+}
+
+// PipelineMetadataUnion is a union of different pipeline metadatas.
+type PipelineMetadataUnion struct {
+	Type       PipelineType
+	Standard   []StandardPipelineMetadata
+	Forwarding ForwardingPipelineMetadata
+}
+
+// IsDefault returns whether this is the default pipeline metadata.
+func (pu PipelineMetadataUnion) IsDefault() bool {
+	return (pu.Type == StandardType && len(pu.Standard) == 0) ||
+		(pu.Type == ForwardingType && pu.Forwarding.IsDefault())
+}
+
+// Metadata represents the metadata associated with a metric.
+type Metadata struct {
+	AggregationMetadata
+
+	Pipeline PipelineMetadataUnion
+}
+
+// IsDefault returns whether this is the default metadata.
+func (m Metadata) IsDefault() bool {
+	return m.AggregationMetadata.IsDefault() && m.Pipeline.IsDefault()
+}
+
+// ForwardMetadata represents the metadata information associated with forwarded metrics.
+type ForwardMetadata struct {
+	// List of aggregation types.
+	AggregationID aggregation.ID
+
+	// Storage policy.
+	StoragePolicy policy.StoragePolicy
+
+	// Pipeline of operations that may be applied to the metric.
+	Pipeline applied.Pipeline
+}
+
+// StagedMetadata represents metadata with a staged cutover time.
+type StagedMetadata struct {
+	Metadata
+
+	// Cutover is when the metadata is applicable.
+	CutoverNanos int64
+
+	// Tombstoned determines whether the associated metric has been tombstoned.
+	Tombstoned bool
+}
+
+// StagedMetadatas contains a list of staged metadatas.
+type StagedMetadatas []StagedMetadata
+
+// IsDefault determines whether the list of staged metadata is a default list.
+func (sms StagedMetadatas) IsDefault() bool {
+	return len(sms) == 1 && sms[0].IsDefault()
+}

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -1,0 +1,245 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package metadata
+
+import (
+	"testing"
+	"time"
+
+	"github.com/m3db/m3metrics/aggregation"
+	"github.com/m3db/m3metrics/op"
+	"github.com/m3db/m3metrics/op/applied"
+	"github.com/m3db/m3metrics/policy"
+	xtime "github.com/m3db/m3x/time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStagedMetadatasIsDefault(t *testing.T) {
+	inputs := []struct {
+		metadatas StagedMetadatas
+		expected  bool
+	}{
+		{
+			metadatas: StagedMetadatas{
+				{
+					Metadata: Metadata{
+						Pipeline: PipelineMetadataUnion{
+							Type:     StandardType,
+							Standard: nil,
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			metadatas: StagedMetadatas{
+				{
+					Metadata: Metadata{
+						Pipeline: PipelineMetadataUnion{
+							Type:       ForwardingType,
+							Forwarding: ForwardingPipelineMetadata{},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			metadatas: StagedMetadatas{},
+			expected:  false,
+		},
+		{
+			metadatas: StagedMetadatas{
+				{
+					CutoverNanos: 1234,
+					Metadata: Metadata{
+						Pipeline: PipelineMetadataUnion{
+							Type:     StandardType,
+							Standard: nil,
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			metadatas: StagedMetadatas{
+				{
+					Tombstoned: true,
+					Metadata: Metadata{
+						Pipeline: PipelineMetadataUnion{
+							Type:     StandardType,
+							Standard: nil,
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			metadatas: StagedMetadatas{
+				{
+					Metadata: Metadata{
+						AggregationMetadata: AggregationMetadata{
+							AggregationID: aggregation.MustCompressTypes(aggregation.Sum),
+						},
+						Pipeline: PipelineMetadataUnion{
+							Type:     StandardType,
+							Standard: nil,
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			metadatas: StagedMetadatas{
+				{
+					Metadata: Metadata{
+						AggregationMetadata: AggregationMetadata{
+							StoragePolicies: []policy.StoragePolicy{
+								policy.NewStoragePolicy(time.Second, xtime.Second, time.Hour),
+							},
+						},
+						Pipeline: PipelineMetadataUnion{
+							Type:     StandardType,
+							Standard: nil,
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			metadatas: StagedMetadatas{
+				{
+					Metadata: Metadata{
+						Pipeline: PipelineMetadataUnion{
+							Type: StandardType,
+							Standard: []StandardPipelineMetadata{
+								{
+									AggregationMetadata: AggregationMetadata{
+										AggregationID: aggregation.MustCompressTypes(aggregation.Sum),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			metadatas: StagedMetadatas{
+				{
+					Metadata: Metadata{
+						Pipeline: PipelineMetadataUnion{
+							Type: StandardType,
+							Standard: []StandardPipelineMetadata{
+								{
+									AggregationMetadata: AggregationMetadata{
+										StoragePolicies: []policy.StoragePolicy{
+											policy.NewStoragePolicy(time.Second, xtime.Second, time.Hour),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			metadatas: StagedMetadatas{
+				{
+					Metadata: Metadata{
+						Pipeline: PipelineMetadataUnion{
+							Type: StandardType,
+							Standard: []StandardPipelineMetadata{
+								{
+									Pipeline: applied.Pipeline{
+										Operations: []applied.Union{
+											{
+												Type:   op.RollupType,
+												Rollup: applied.Rollup{ID: []byte("foo")},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			metadatas: StagedMetadatas{
+				{
+					Metadata: Metadata{
+						Pipeline: PipelineMetadataUnion{
+							Type: ForwardingType,
+							Forwarding: ForwardingPipelineMetadata{
+								Pipeline: applied.Pipeline{
+									Operations: []applied.Union{
+										{
+											Type:   op.RollupType,
+											Rollup: applied.Rollup{ID: []byte("foo")},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			metadatas: StagedMetadatas{
+				{
+					Metadata: Metadata{
+						Pipeline: PipelineMetadataUnion{
+							Type:     StandardType,
+							Standard: nil,
+						},
+					},
+				},
+				{
+					Metadata: Metadata{
+						Pipeline: PipelineMetadataUnion{
+							Type:       ForwardingType,
+							Forwarding: ForwardingPipelineMetadata{},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, input := range inputs {
+		require.Equal(t, input.expected, input.metadatas.IsDefault())
+	}
+}

--- a/op/applied/type.go
+++ b/op/applied/type.go
@@ -1,0 +1,152 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package applied
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/m3db/m3metrics/aggregation"
+	"github.com/m3db/m3metrics/op"
+)
+
+var (
+	// DefaultPipeline is a default pipeline.
+	DefaultPipeline Pipeline
+)
+
+// Rollup captures the rollup metadata after the operation is applied against a metric ID.
+type Rollup struct {
+	// Metric ID generated as a result of the rollup.
+	ID []byte
+	// Type of aggregations performed within each unique dimension combination.
+	AggregationID aggregation.ID
+}
+
+// Equal determines whether two rollup operations are equal.
+func (op Rollup) Equal(other Rollup) bool {
+	return op.AggregationID == other.AggregationID && bytes.Equal(op.ID, other.ID)
+}
+
+// Clone clones the rollup operation.
+func (op Rollup) Clone() Rollup {
+	idClone := make([]byte, len(op.ID))
+	copy(idClone, op.ID)
+	return Rollup{ID: idClone, AggregationID: op.AggregationID}
+}
+
+func (op Rollup) String() string {
+	return fmt.Sprintf("{id: %s, aggregation: %v}", op.ID, op.AggregationID)
+}
+
+// Union is a union of different types of operation.
+type Union struct {
+	Type           op.Type
+	Transformation op.Transformation
+	Rollup         Rollup
+}
+
+// Equal determines whether two operation unions are equal.
+func (u Union) Equal(other Union) bool {
+	if u.Type != other.Type {
+		return false
+	}
+	switch u.Type {
+	case op.TransformationType:
+		return u.Transformation.Equal(other.Transformation)
+	case op.RollupType:
+		return u.Rollup.Equal(other.Rollup)
+	}
+	return true
+}
+
+// Clone clones an operation union.
+func (u Union) Clone() Union {
+	clone := Union{Type: u.Type}
+	switch u.Type {
+	case op.TransformationType:
+		clone.Transformation = u.Transformation.Clone()
+	case op.RollupType:
+		clone.Rollup = u.Rollup.Clone()
+	}
+	return clone
+}
+
+func (u Union) String() string {
+	var b bytes.Buffer
+	b.WriteString("{")
+	switch u.Type {
+	case op.TransformationType:
+		fmt.Fprintf(&b, "transformation: %s", u.Transformation.String())
+	case op.RollupType:
+		fmt.Fprintf(&b, "rollup: %s", u.Rollup.String())
+	default:
+		fmt.Fprintf(&b, "unknown op type: %v", u.Type)
+	}
+	b.WriteString("}")
+	return b.String()
+}
+
+// Pipeline is a pipeline of operations.
+type Pipeline struct {
+	// a list of pipeline operations.
+	Operations []Union
+}
+
+// IsEmpty determines whether a pipeline is empty.
+func (p Pipeline) IsEmpty() bool {
+	return len(p.Operations) == 0
+}
+
+// Equal determines whether two pipelines are equal.
+func (p Pipeline) Equal(other Pipeline) bool {
+	if len(p.Operations) != len(other.Operations) {
+		return false
+	}
+	for i := 0; i < len(p.Operations); i++ {
+		if !p.Operations[i].Equal(other.Operations[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// Clone clones the pipeline.
+func (p Pipeline) Clone() Pipeline {
+	clone := make([]Union, len(p.Operations))
+	for i, op := range p.Operations {
+		clone[i] = op.Clone()
+	}
+	return Pipeline{Operations: clone}
+}
+
+func (p Pipeline) String() string {
+	var b bytes.Buffer
+	b.WriteString("{operations: [")
+	for i, op := range p.Operations {
+		b.WriteString(op.String())
+		if i < len(p.Operations)-1 {
+			b.WriteString(", ")
+		}
+	}
+	b.WriteString("]}")
+	return b.String()
+}

--- a/op/applied/type_test.go
+++ b/op/applied/type_test.go
@@ -342,7 +342,7 @@ func TestPipelineString(t *testing.T) {
 					},
 				},
 			},
-			expected: "{operations: [{transformation: PerSecond}, {rollup: {name: foo, aggregation: Sum}}]}",
+			expected: "{operations: [{transformation: PerSecond}, {rollup: {id: foo, aggregation: Sum}}]}",
 		},
 		{
 			p: Pipeline{

--- a/op/applied/type_test.go
+++ b/op/applied/type_test.go
@@ -1,0 +1,362 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package applied
+
+import (
+	"testing"
+
+	"github.com/m3db/m3metrics/aggregation"
+	"github.com/m3db/m3metrics/op"
+	"github.com/m3db/m3metrics/transformation"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPipelineEqual(t *testing.T) {
+	inputs := []struct {
+		p1       Pipeline
+		p2       Pipeline
+		expected bool
+	}{
+		{
+			p1:       Pipeline{},
+			p2:       Pipeline{},
+			expected: true,
+		},
+		{
+			p1: Pipeline{
+				Operations: []Union{
+					{
+						Type: op.TransformationType,
+						Transformation: op.Transformation{
+							Type: transformation.Absolute,
+						},
+					},
+					{
+						Type: op.RollupType,
+						Rollup: Rollup{
+							ID:            []byte("foo"),
+							AggregationID: aggregation.MustCompressTypes(aggregation.Last, aggregation.Sum),
+						},
+					},
+					{
+						Type: op.TransformationType,
+						Transformation: op.Transformation{
+							Type: transformation.PerSecond,
+						},
+					},
+					{
+						Type: op.RollupType,
+						Rollup: Rollup{
+							ID:            []byte("bar"),
+							AggregationID: aggregation.MustCompressTypes(aggregation.P99),
+						},
+					},
+				},
+			},
+			p2: Pipeline{
+				Operations: []Union{
+					{
+						Type: op.TransformationType,
+						Transformation: op.Transformation{
+							Type: transformation.Absolute,
+						},
+					},
+					{
+						Type: op.RollupType,
+						Rollup: Rollup{
+							ID:            []byte("foo"),
+							AggregationID: aggregation.MustCompressTypes(aggregation.Last, aggregation.Sum),
+						},
+					},
+					{
+						Type: op.TransformationType,
+						Transformation: op.Transformation{
+							Type: transformation.PerSecond,
+						},
+					},
+					{
+						Type: op.RollupType,
+						Rollup: Rollup{
+							ID:            []byte("bar"),
+							AggregationID: aggregation.MustCompressTypes(aggregation.P99),
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			p1: Pipeline{},
+			p2: Pipeline{
+				Operations: []Union{
+					{
+						Type: op.TransformationType,
+						Transformation: op.Transformation{
+							Type: transformation.Absolute,
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			p1: Pipeline{
+				Operations: []Union{
+					{
+						Type: op.TransformationType,
+						Transformation: op.Transformation{
+							Type: transformation.PerSecond,
+						},
+					},
+				},
+			},
+			p2: Pipeline{
+				Operations: []Union{
+					{
+						Type: op.TransformationType,
+						Transformation: op.Transformation{
+							Type: transformation.PerSecond,
+						},
+					},
+					{
+						Type: op.RollupType,
+						Rollup: Rollup{
+							ID:            []byte("foo"),
+							AggregationID: aggregation.MustCompressTypes(aggregation.P99),
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			p1: Pipeline{
+				Operations: []Union{
+					{
+						Type: op.TransformationType,
+						Transformation: op.Transformation{
+							Type: transformation.PerSecond,
+						},
+					},
+				},
+			},
+			p2: Pipeline{
+				Operations: []Union{
+					{
+						Type: op.RollupType,
+						Rollup: Rollup{
+							ID:            []byte("foo"),
+							AggregationID: aggregation.MustCompressTypes(aggregation.P99),
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			p1: Pipeline{
+				Operations: []Union{
+					{
+						Type: op.TransformationType,
+						Transformation: op.Transformation{
+							Type: transformation.PerSecond,
+						},
+					},
+				},
+			},
+			p2: Pipeline{
+				Operations: []Union{
+					{
+						Type: op.TransformationType,
+						Transformation: op.Transformation{
+							Type: transformation.Absolute,
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			p1: Pipeline{
+				Operations: []Union{
+					{
+						Type: op.RollupType,
+						Rollup: Rollup{
+							ID:            []byte("foo"),
+							AggregationID: aggregation.MustCompressTypes(aggregation.P99),
+						},
+					},
+				},
+			},
+			p2: Pipeline{
+				Operations: []Union{
+					{
+						Type: op.RollupType,
+						Rollup: Rollup{
+							ID:            []byte("bar"),
+							AggregationID: aggregation.MustCompressTypes(aggregation.P99),
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			p1: Pipeline{
+				Operations: []Union{
+					{
+						Type: op.RollupType,
+						Rollup: Rollup{
+							ID:            []byte("foo"),
+							AggregationID: aggregation.MustCompressTypes(aggregation.P99),
+						},
+					},
+				},
+			},
+			p2: Pipeline{
+				Operations: []Union{
+					{
+						Type: op.RollupType,
+						Rollup: Rollup{
+							ID:            []byte("foo"),
+							AggregationID: aggregation.MustCompressTypes(aggregation.Sum),
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, input := range inputs {
+		require.Equal(t, input.expected, input.p1.Equal(input.p2))
+		require.Equal(t, input.expected, input.p2.Equal(input.p1))
+	}
+}
+
+func TestPipelineCloneEmptyPipeline(t *testing.T) {
+	p1 := Pipeline{}
+	require.True(t, p1.IsEmpty())
+
+	p2 := p1.Clone()
+	require.True(t, p1.Equal(p2))
+
+	p2.Operations = append(p2.Operations, Union{
+		Type: op.RollupType,
+		Rollup: Rollup{
+			ID:            []byte("foo"),
+			AggregationID: aggregation.MustCompressTypes(aggregation.P99),
+		},
+	})
+	require.False(t, p1.Equal(p2))
+	require.True(t, p1.IsEmpty())
+}
+
+func TestPipelineCloneMultiLevelPipeline(t *testing.T) {
+	p1 := Pipeline{
+		Operations: []Union{
+			{
+				Type: op.TransformationType,
+				Transformation: op.Transformation{
+					Type: transformation.Absolute,
+				},
+			},
+			{
+				Type: op.RollupType,
+				Rollup: Rollup{
+					ID:            []byte("foo"),
+					AggregationID: aggregation.MustCompressTypes(aggregation.Last, aggregation.Sum),
+				},
+			},
+			{
+				Type: op.TransformationType,
+				Transformation: op.Transformation{
+					Type: transformation.PerSecond,
+				},
+			},
+			{
+				Type: op.RollupType,
+				Rollup: Rollup{
+					ID:            []byte("bar"),
+					AggregationID: aggregation.MustCompressTypes(aggregation.P99),
+				},
+			},
+		},
+	}
+	p2 := p1.Clone()
+	p3 := p2.Clone()
+	require.True(t, p1.Equal(p2))
+	require.True(t, p1.Equal(p3))
+
+	// Mutate the operations of a cloned pipeline.
+	p2.Operations[0].Transformation.Type = transformation.PerSecond
+	p2.Operations[1].Rollup.ID[0] = 'z'
+	p2.Operations[3].Rollup.AggregationID = aggregation.MustCompressTypes(aggregation.Count)
+
+	// Verify the mutations do not affect the source pipeline or other clones.
+	require.False(t, p1.Equal(p2))
+	require.False(t, p2.Equal(p3))
+	require.True(t, p1.Equal(p3))
+	require.Equal(t, transformation.Absolute, p1.Operations[0].Transformation.Type)
+	require.Equal(t, []byte("foo"), p1.Operations[1].Rollup.ID)
+	require.Equal(t, aggregation.MustCompressTypes(aggregation.P99), p1.Operations[3].Rollup.AggregationID)
+}
+
+func TestPipelineString(t *testing.T) {
+	inputs := []struct {
+		p        Pipeline
+		expected string
+	}{
+		{
+			p: Pipeline{
+				Operations: []Union{
+					{
+						Type:           op.TransformationType,
+						Transformation: op.Transformation{Type: transformation.PerSecond},
+					},
+					{
+						Type: op.RollupType,
+						Rollup: Rollup{
+							ID:            []byte("foo"),
+							AggregationID: aggregation.MustCompressTypes(aggregation.Sum),
+						},
+					},
+				},
+			},
+			expected: "{operations: [{transformation: PerSecond}, {rollup: {name: foo, aggregation: Sum}}]}",
+		},
+		{
+			p: Pipeline{
+				Operations: []Union{
+					{
+						Type: op.Type(10),
+					},
+				},
+			},
+			expected: "{operations: [{unknown op type: Type(10)}]}",
+		},
+	}
+
+	for _, input := range inputs {
+		require.Equal(t, input.expected, input.p.String())
+	}
+}

--- a/op/type.go
+++ b/op/type.go
@@ -45,6 +45,11 @@ type Aggregation struct {
 	Type aggregation.Type
 }
 
+// Equal determines whether two aggregation operations are equal.
+func (op Aggregation) Equal(other Aggregation) bool {
+	return op.Type == other.Type
+}
+
 func (op Aggregation) String() string {
 	return op.Type.String()
 }
@@ -53,6 +58,16 @@ func (op Aggregation) String() string {
 type Transformation struct {
 	// Type of transformation performed.
 	Type transformation.Type
+}
+
+// Equal determines whether two transformation operations are equal.
+func (op Transformation) Equal(other Transformation) bool {
+	return op.Type == other.Type
+}
+
+// Clone clones the transformation operation.
+func (op Transformation) Clone() Transformation {
+	return op
 }
 
 func (op Transformation) String() string {

--- a/op/type_test.go
+++ b/op/type_test.go
@@ -29,6 +29,62 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestAggregationEqual(t *testing.T) {
+	inputs := []struct {
+		a1       Aggregation
+		a2       Aggregation
+		expected bool
+	}{
+		{
+			a1:       Aggregation{aggregation.Count},
+			a2:       Aggregation{aggregation.Count},
+			expected: true,
+		},
+		{
+			a1:       Aggregation{aggregation.Count},
+			a2:       Aggregation{aggregation.Sum},
+			expected: false,
+		},
+	}
+
+	for _, input := range inputs {
+		require.Equal(t, input.expected, input.a1.Equal(input.a2))
+		require.Equal(t, input.expected, input.a2.Equal(input.a1))
+	}
+}
+
+func TestTransformationEqual(t *testing.T) {
+	inputs := []struct {
+		a1       Transformation
+		a2       Transformation
+		expected bool
+	}{
+		{
+			a1:       Transformation{transformation.Absolute},
+			a2:       Transformation{transformation.Absolute},
+			expected: true,
+		},
+		{
+			a1:       Transformation{transformation.Absolute},
+			a2:       Transformation{transformation.PerSecond},
+			expected: false,
+		},
+	}
+
+	for _, input := range inputs {
+		require.Equal(t, input.expected, input.a1.Equal(input.a2))
+		require.Equal(t, input.expected, input.a2.Equal(input.a1))
+	}
+}
+
+func TestTransformationClone(t *testing.T) {
+	source := Transformation{transformation.Absolute}
+	clone := source.Clone()
+	require.Equal(t, source, clone)
+	clone.Type = transformation.PerSecond
+	require.Equal(t, transformation.Absolute, source.Type)
+}
+
 func TestPipelineString(t *testing.T) {
 	inputs := []struct {
 		p        Pipeline

--- a/policy/storage_policy.go
+++ b/policy/storage_policy.go
@@ -148,3 +148,9 @@ func MustParseStoragePolicy(str string) StoragePolicy {
 	}
 	return sp
 }
+
+// IsDefaultStoragePolicies returns whether a list of storage policies are considered
+// as default storage policies.
+func IsDefaultStoragePolicies(policies []StoragePolicy) bool {
+	return len(policies) == 0
+}


### PR DESCRIPTION
cc @cw9 

This PR adds metric and pipeline metadata so we can send metadata alongside metrics to downstream services.