### PR TITLE
add mapping rule and rollup rule history structs

### DIFF
--- a/rules/models/mapping.go
+++ b/rules/models/mapping.go
@@ -101,12 +101,12 @@ func (a mappingRulesByNameAsc) Len() int           { return len(a) }
 func (a mappingRulesByNameAsc) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 func (a mappingRulesByNameAsc) Less(i, j int) bool { return a[i].Name < a[j].Name }
 
-// MappingRuleSnapshots is a common json serializable view of a mapping rule history
+// MappingRuleSnapshots contains a list of mapping rule snapshots.
 type MappingRuleSnapshots struct {
 	MappingRules []MappingRule `json:"mappingRules"`
 }
 
-// NewMappingRuleSnapshots returns a new mappingRuleHistory struct
+// NewMappingRuleSnapshots returns a new MappingRuleSnapshots object.
 func NewMappingRuleSnapshots(hist []*MappingRuleView) MappingRuleSnapshots {
 	mappingRules := make([]MappingRule, len(hist))
 	for i, view := range hist {

--- a/rules/models/mapping.go
+++ b/rules/models/mapping.go
@@ -100,3 +100,17 @@ type mappingRulesByNameAsc []MappingRule
 func (a mappingRulesByNameAsc) Len() int           { return len(a) }
 func (a mappingRulesByNameAsc) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 func (a mappingRulesByNameAsc) Less(i, j int) bool { return a[i].Name < a[j].Name }
+
+// MappingRuleHistory is a common json serializable view of a mapping rule history
+type MappingRuleHistory struct {
+	MappingRules []MappingRule `json:"mappingRules"`
+}
+
+// NewMappingRuleHistory returns a new mappingRuleHistory struct
+func NewMappingRuleHistory(hist []*MappingRuleView) MappingRuleHistory {
+	mappingRules := make([]MappingRule, len(hist))
+	for i, view := range hist {
+		mappingRules[i] = NewMappingRule(view)
+	}
+	return MappingRuleHistory{MappingRules: mappingRules}
+}

--- a/rules/models/mapping.go
+++ b/rules/models/mapping.go
@@ -101,16 +101,16 @@ func (a mappingRulesByNameAsc) Len() int           { return len(a) }
 func (a mappingRulesByNameAsc) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 func (a mappingRulesByNameAsc) Less(i, j int) bool { return a[i].Name < a[j].Name }
 
-// MappingRuleHistory is a common json serializable view of a mapping rule history
-type MappingRuleHistory struct {
+// MappingRuleSnapshots is a common json serializable view of a mapping rule history
+type MappingRuleSnapshots struct {
 	MappingRules []MappingRule `json:"mappingRules"`
 }
 
-// NewMappingRuleHistory returns a new mappingRuleHistory struct
-func NewMappingRuleHistory(hist []*MappingRuleView) MappingRuleHistory {
+// NewMappingRuleSnapshots returns a new mappingRuleHistory struct
+func NewMappingRuleSnapshots(hist []*MappingRuleView) MappingRuleSnapshots {
 	mappingRules := make([]MappingRule, len(hist))
 	for i, view := range hist {
 		mappingRules[i] = NewMappingRule(view)
 	}
-	return MappingRuleHistory{MappingRules: mappingRules}
+	return MappingRuleSnapshots{MappingRules: mappingRules}
 }

--- a/rules/models/mapping_test.go
+++ b/rules/models/mapping_test.go
@@ -167,7 +167,7 @@ func TestNewMappingRuleHistoryJSON(t *testing.T) {
 		testMappingRuleView(id, "name1"),
 		testMappingRuleView(id, "name2"),
 	}
-	expected := MappingRuleHistory{
+	expected := MappingRuleSnapshots{
 		MappingRules: []MappingRule{
 			{
 				ID:                  id,
@@ -189,7 +189,7 @@ func TestNewMappingRuleHistoryJSON(t *testing.T) {
 			},
 		},
 	}
-	require.EqualValues(t, expected, NewMappingRuleHistory(hist))
+	require.EqualValues(t, expected, NewMappingRuleSnapshots(hist))
 }
 
 // nolint:unparam

--- a/rules/models/mapping_test.go
+++ b/rules/models/mapping_test.go
@@ -161,6 +161,36 @@ func TestMappingRuleSort(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, expected, string(actual))
 }
+func TestNewMappingRuleHistoryJSON(t *testing.T) {
+	id := "id"
+	hist := []*MappingRuleView{
+		testMappingRuleView(id, "name1"),
+		testMappingRuleView(id, "name2"),
+	}
+	expected := MappingRuleHistory{
+		MappingRules: []MappingRule{
+			{
+				ID:                  id,
+				Name:                "name1",
+				Filter:              "filter",
+				Policies:            []policy.Policy{},
+				CutoverMillis:       0,
+				LastUpdatedBy:       "",
+				LastUpdatedAtMillis: 0,
+			},
+			{
+				ID:                  id,
+				Name:                "name2",
+				Filter:              "filter",
+				Policies:            []policy.Policy{},
+				CutoverMillis:       0,
+				LastUpdatedBy:       "",
+				LastUpdatedAtMillis: 0,
+			},
+		},
+	}
+	require.EqualValues(t, expected, NewMappingRuleHistory(hist))
+}
 
 // nolint:unparam
 func testMappingRuleView(id, name string) *MappingRuleView {

--- a/rules/models/rollup.go
+++ b/rules/models/rollup.go
@@ -226,12 +226,12 @@ func (a rollupRulesByNameAsc) Len() int           { return len(a) }
 func (a rollupRulesByNameAsc) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 func (a rollupRulesByNameAsc) Less(i, j int) bool { return a[i].Name < a[j].Name }
 
-// RollupRuleSnapshots is a common json serializable view of a rollup rule history
+// RollupRuleSnapshots contains a list of rollup rule snapshots.
 type RollupRuleSnapshots struct {
 	RollupRules []RollupRule `json:"rollupRules"`
 }
 
-// NewRollupRuleSnapshots returns a new RollupRuleHistory struct
+// NewRollupRuleSnapshots returns a new RollupRuleSnapshots object.
 func NewRollupRuleSnapshots(hist []*RollupRuleView) RollupRuleSnapshots {
 	rollupRules := make([]RollupRule, len(hist))
 	for i, view := range hist {

--- a/rules/models/rollup.go
+++ b/rules/models/rollup.go
@@ -225,3 +225,17 @@ type rollupRulesByNameAsc []RollupRule
 func (a rollupRulesByNameAsc) Len() int           { return len(a) }
 func (a rollupRulesByNameAsc) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 func (a rollupRulesByNameAsc) Less(i, j int) bool { return a[i].Name < a[j].Name }
+
+// RollupRuleHistory is a common json serializable view of a rollup rule history
+type RollupRuleHistory struct {
+	RollupRules []RollupRule `json:"rollupRules"`
+}
+
+// NewRollupRuleHistory returns a new RollupRuleHistory struct
+func NewRollupRuleHistory(hist []*RollupRuleView) RollupRuleHistory {
+	rollupRules := make([]RollupRule, len(hist))
+	for i, view := range hist {
+		rollupRules[i] = NewRollupRule(view)
+	}
+	return RollupRuleHistory{RollupRules: rollupRules}
+}

--- a/rules/models/rollup.go
+++ b/rules/models/rollup.go
@@ -226,16 +226,16 @@ func (a rollupRulesByNameAsc) Len() int           { return len(a) }
 func (a rollupRulesByNameAsc) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 func (a rollupRulesByNameAsc) Less(i, j int) bool { return a[i].Name < a[j].Name }
 
-// RollupRuleHistory is a common json serializable view of a rollup rule history
-type RollupRuleHistory struct {
+// RollupRuleSnapshots is a common json serializable view of a rollup rule history
+type RollupRuleSnapshots struct {
 	RollupRules []RollupRule `json:"rollupRules"`
 }
 
-// NewRollupRuleHistory returns a new RollupRuleHistory struct
-func NewRollupRuleHistory(hist []*RollupRuleView) RollupRuleHistory {
+// NewRollupRuleSnapshots returns a new RollupRuleHistory struct
+func NewRollupRuleSnapshots(hist []*RollupRuleView) RollupRuleSnapshots {
 	rollupRules := make([]RollupRule, len(hist))
 	for i, view := range hist {
 		rollupRules[i] = NewRollupRule(view)
 	}
-	return RollupRuleHistory{RollupRules: rollupRules}
+	return RollupRuleSnapshots{RollupRules: rollupRules}
 }

--- a/rules/models/rollup_test.go
+++ b/rules/models/rollup_test.go
@@ -607,7 +607,7 @@ func TestNewRollupRuleHistoryJSON(t *testing.T) {
 		testRollupRuleView(id, "name1", targets),
 		testRollupRuleView(id, "name2", targets),
 	}
-	expected := RollupRuleHistory{
+	expected := RollupRuleSnapshots{
 		RollupRules: []RollupRule{
 			{
 				ID:     id,
@@ -651,7 +651,7 @@ func TestNewRollupRuleHistoryJSON(t *testing.T) {
 			},
 		},
 	}
-	require.EqualValues(t, expected, NewRollupRuleHistory(hist))
+	require.EqualValues(t, expected, NewRollupRuleSnapshots(hist))
 }
 
 func testRollupTarget(name string) *RollupTarget {

--- a/rules/models/rollup_test.go
+++ b/rules/models/rollup_test.go
@@ -597,6 +597,63 @@ func TestRollupTargetSameTransform(t *testing.T) {
 	}
 }
 
+func TestNewRollupRuleHistoryJSON(t *testing.T) {
+	id := "id"
+	targets := []RollupTargetView{
+		*testRollupTargetView("target1"),
+		*testRollupTargetView("target2"),
+	}
+	hist := []*RollupRuleView{
+		testRollupRuleView(id, "name1", targets),
+		testRollupRuleView(id, "name2", targets),
+	}
+	expected := RollupRuleHistory{
+		RollupRules: []RollupRule{
+			{
+				ID:     id,
+				Name:   "name1",
+				Filter: "filter",
+				Targets: []RollupTarget{
+					{
+						Name:     "target1",
+						Tags:     []string{"tag"},
+						Policies: []policy.Policy{},
+					},
+					{
+						Name:     "target2",
+						Tags:     []string{"tag"},
+						Policies: []policy.Policy{},
+					},
+				},
+				CutoverMillis:       0,
+				LastUpdatedBy:       "",
+				LastUpdatedAtMillis: 0,
+			},
+			{
+				ID:     id,
+				Name:   "name2",
+				Filter: "filter",
+				Targets: []RollupTarget{
+					{
+						Name:     "target1",
+						Tags:     []string{"tag"},
+						Policies: []policy.Policy{},
+					},
+					{
+						Name:     "target2",
+						Tags:     []string{"tag"},
+						Policies: []policy.Policy{},
+					},
+				},
+				CutoverMillis:       0,
+				LastUpdatedBy:       "",
+				LastUpdatedAtMillis: 0,
+			},
+		},
+	}
+	require.EqualValues(t, expected, NewRollupRuleHistory(hist))
+}
+
 func testRollupTarget(name string) *RollupTarget {
 	return &RollupTarget{
 		Name:     name,


### PR DESCRIPTION
When a number of structs that were floating around the m3 repos were consolidated here these two were left out. Moving them here so they are easily accessible.