### PR TITLE
add stale data error for conditional failures

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -34,3 +34,11 @@ type ValidationError string
 // NewValidationError creates a new validation error.
 func NewValidationError(str string) error { return ValidationError(str) }
 func (e ValidationError) Error() string   { return string(e) }
+
+// StaleDataError is returned when a rule is modified but the
+// underlying data has changed and the rquest is no longer valid.
+type StaleDataError string
+
+// NewStaleDataError creates a new version mismatch error.
+func NewStaleDataError(str string) error { return StaleDataError(str) }
+func (e StaleDataError) Error() string   { return string(e) }

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -35,8 +35,8 @@ type ValidationError string
 func NewValidationError(str string) error { return ValidationError(str) }
 func (e ValidationError) Error() string   { return string(e) }
 
-// StaleDataError is returned when a rule is modified but the
-// underlying data has changed and the rquest is no longer valid.
+// StaleDataError is returned when a rule modification is attempted but the
+// underlying data has changed and the change is no longer valid.
 type StaleDataError string
 
 // NewStaleDataError creates a new version mismatch error.

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 44753b05e871f26cdeb1f9f15ce521e22f97f10fce5ecd5e23c6226752618823
-updated: 2018-03-15T19:02:36.273816-04:00
+hash: 73198192e7735c85a966325a514d00e3c6d766a91d662f7485c2de0f1f8b6c99
+updated: 2018-03-29T17:18:11.995756545-04:00
 imports:
 - name: github.com/apache/thrift
   version: 9549b25c77587b29be4e0b5c258221a4ed85d37a
@@ -20,7 +20,7 @@ imports:
   subpackages:
   - proto
 - name: github.com/m3db/m3cluster
-  version: 53fc512c11e1ed03db2d65dac4c139a3c2ff2eda
+  version: ebb48b02b8cf382df42062179dc29ce6b1331180
   subpackages:
   - client
   - generated/proto/commonpb

--- a/glide.yaml
+++ b/glide.yaml
@@ -7,7 +7,7 @@ import:
   - time
 
 - package: github.com/m3db/m3cluster
-  version: 53fc512c11e1ed03db2d65dac4c139a3c2ff2eda
+  version: ebb48b02b8cf382df42062179dc29ce6b1331180
   subpackages:
   - kv
   - kv/mem

--- a/rules/store/kv/store.go
+++ b/rules/store/kv/store.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 
 	"github.com/m3db/m3cluster/kv"
+	merrors "github.com/m3db/m3metrics/errors"
 	"github.com/m3db/m3metrics/generated/proto/schema"
 	"github.com/m3db/m3metrics/rules"
 )
@@ -96,6 +97,11 @@ func (s *store) WriteRuleSet(rs rules.MutableRuleSet) error {
 	}
 	conditions, ops := []kv.Condition{rsCond}, []kv.Op{rsOp}
 	_, err = s.kvStore.Commit(conditions, ops)
+	if err != nil {
+		if err == kv.ErrConditionCheckFailed {
+			err = merrors.NewStaleDataError(err.Error())
+		}
+	}
 	return err
 }
 

--- a/rules/store/kv/store.go
+++ b/rules/store/kv/store.go
@@ -97,12 +97,7 @@ func (s *store) WriteRuleSet(rs rules.MutableRuleSet) error {
 	}
 	conditions, ops := []kv.Condition{rsCond}, []kv.Op{rsOp}
 	_, err = s.kvStore.Commit(conditions, ops)
-	switch err {
-	case kv.ErrConditionCheckFailed:
-		return merrors.NewStaleDataError(err.Error())
-	default:
-		return err
-	}
+	return wrapWriteError(err)
 }
 
 func (s *store) WriteAll(nss *rules.Namespaces, rs rules.MutableRuleSet) error {
@@ -130,7 +125,7 @@ func (s *store) WriteAll(nss *rules.Namespaces, rs rules.MutableRuleSet) error {
 	conditions = append(conditions, namespacesCond)
 	ops = append(ops, namespacesOp)
 	_, err = s.kvStore.Commit(conditions, ops)
-	return err
+	return wrapWriteError(err)
 }
 
 func (s *store) Close() {
@@ -181,4 +176,14 @@ func (s *store) namespacesTransaction(nss *rules.Namespaces) (kv.Condition, kv.O
 		SetValue(nss.Version())
 
 	return namespacesCond, kv.NewSetOp(namespacesKey, nssSchema), nil
+}
+
+func wrapWriteError(err error) error {
+	if err == kv.ErrConditionCheckFailed {
+		return merrors.NewStaleDataError(
+			fmt.Sprintf("stale write request: %s", err.Error()),
+		)
+	}
+
+	return err
 }

--- a/rules/store/kv/store.go
+++ b/rules/store/kv/store.go
@@ -97,12 +97,12 @@ func (s *store) WriteRuleSet(rs rules.MutableRuleSet) error {
 	}
 	conditions, ops := []kv.Condition{rsCond}, []kv.Op{rsOp}
 	_, err = s.kvStore.Commit(conditions, ops)
-	if err != nil {
-		if err == kv.ErrConditionCheckFailed {
-			err = merrors.NewStaleDataError(err.Error())
-		}
+	switch err {
+	case kv.ErrConditionCheckFailed:
+		return merrors.NewStaleDataError(err.Error())
+	default:
+		return err
 	}
-	return err
 }
 
 func (s *store) WriteAll(nss *rules.Namespaces, rs rules.MutableRuleSet) error {


### PR DESCRIPTION
This PR introduces a new common error type to `StaleDataError`. This is returned by the rule store when a `WriteRuleSet` call fails because of some conditional failure.