### PR TITLE
Add a few auxiliary functions and type definitions

### DIFF
--- a/aggregation/id_compress_test.go
+++ b/aggregation/id_compress_test.go
@@ -73,3 +73,29 @@ func TestIDDecompressError(t *testing.T) {
 	_, err = decompressor.Decompress(max)
 	require.Error(t, err)
 }
+
+func TestIDMustDecompress(t *testing.T) {
+	compressor, decompressor := NewIDCompressor(), NewIDDecompressor()
+	inputs := []struct {
+		id          ID
+		shouldPanic bool
+	}{
+		{
+			id:          compressor.MustCompress([]Type{Last, Min, Max, Mean, Median, Count, Sum, SumSq}),
+			shouldPanic: false,
+		},
+		{
+			id:          [IDLen]uint64{1},
+			shouldPanic: true,
+		},
+	}
+
+	for _, input := range inputs {
+		if input.shouldPanic {
+			require.Panics(t, func() { decompressor.MustDecompress(input.id) })
+		} else {
+			require.NotPanics(t, func() { decompressor.MustDecompress(input.id) })
+		}
+	}
+
+}

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -27,8 +27,15 @@ import (
 )
 
 var (
-	// DefaultStagedMetadata represents a default staged metadata.
-	DefaultStagedMetadata StagedMetadata
+	// DefaultStagedMetadata is a default staged metadata.
+	DefaultStagedMetadata = StagedMetadata{
+		Metadata: Metadata{
+			Pipelines: []PipelineMetadata{PipelineMetadata{}},
+		},
+	}
+
+	// DefaultStagedMetadatas represents default staged metadatas.
+	DefaultStagedMetadatas = StagedMetadatas{DefaultStagedMetadata}
 )
 
 // PipelineMetadata contains pipeline metadata.

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -52,6 +52,10 @@ func TestStagedMetadatasIsDefault(t *testing.T) {
 			expected: true,
 		},
 		{
+			metadatas: DefaultStagedMetadatas,
+			expected:  true,
+		},
+		{
 			metadatas: StagedMetadatas{},
 			expected:  false,
 		},

--- a/metric/unaggregated/types.go
+++ b/metric/unaggregated/types.go
@@ -23,6 +23,8 @@ package unaggregated
 import (
 	"fmt"
 
+	"github.com/m3db/m3metrics/metadata"
+
 	"github.com/m3db/m3metrics/metric/id"
 	"github.com/m3db/m3metrics/policy"
 	"github.com/m3db/m3x/pool"
@@ -86,6 +88,24 @@ type BatchTimerWithPoliciesList struct {
 type GaugeWithPoliciesList struct {
 	Gauge
 	policy.PoliciesList
+}
+
+// CounterWithMetadatas is a counter with applicable metadatas.
+type CounterWithMetadatas struct {
+	Counter
+	metadata.StagedMetadatas
+}
+
+// BatchTimerWithMetadatas is a batch timer with applicable metadatas.
+type BatchTimerWithMetadatas struct {
+	BatchTimer
+	metadata.StagedMetadatas
+}
+
+// GaugeWithMetadatas is a gauge with applicable metadatas.
+type GaugeWithMetadatas struct {
+	Gauge
+	metadata.StagedMetadatas
 }
 
 // MetricUnion is a union of different types of metrics, only one of which is valid

--- a/metric/unaggregated/types.go
+++ b/metric/unaggregated/types.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 
 	"github.com/m3db/m3metrics/metadata"
-
 	"github.com/m3db/m3metrics/metric/id"
 	"github.com/m3db/m3metrics/policy"
 	"github.com/m3db/m3x/pool"


### PR DESCRIPTION
cc @cw9 @jeromefroe

This PR adds a few auxiliary functions and type definitions including `MustDecompress`, `DefaultStagedMetadata(s)` and `{Counter/Timer/Gauge}WithMetadatas`.