### PR TITLE
Add ApplyChanges function to mutable ruleset interface

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -20,13 +20,13 @@
 
 package errors
 
-// RuleConflictError is returned when a rule modification is made that would
+// InvalidInputError is returned when a rule modification is made that would
 // result in a conflict with the existing set of rules in the ruleset.
-type RuleConflictError string
+type InvalidInputError string
 
-// NewRuleConflictError creates a new rule conflict error.
-func NewRuleConflictError(str string) error { return RuleConflictError(str) }
-func (e RuleConflictError) Error() string   { return string(e) }
+// NewInvalidInputError creates a new rule conflict error.
+func NewInvalidInputError(str string) error { return InvalidInputError(str) }
+func (e InvalidInputError) Error() string   { return string(e) }
 
 // ValidationError is returned when validation failed.
 type ValidationError string
@@ -42,11 +42,3 @@ type StaleDataError string
 // NewStaleDataError creates a new version mismatch error.
 func NewStaleDataError(str string) error { return StaleDataError(str) }
 func (e StaleDataError) Error() string   { return string(e) }
-
-// InvalidChangeError is returned when a change is applied to a ruleset,
-// mapping rule, or rollup rule that is invalid.
-type InvalidChangeError string
-
-// NewInvalidChangeError careats a new invalid change error.
-func NewInvalidChangeError(str string) error { return InvalidChangeError(str) }
-func (e InvalidChangeError) Error() string   { return string(e) }

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -35,10 +35,18 @@ type ValidationError string
 func NewValidationError(str string) error { return ValidationError(str) }
 func (e ValidationError) Error() string   { return string(e) }
 
-// StaleDataError is returned when a rule modification is attempted but the
-// underlying data has changed and the change is no longer valid.
+// StaleDataError is returned when a rule modification can not be completed
+// because rule meta data is no longer valid.
 type StaleDataError string
 
 // NewStaleDataError creates a new version mismatch error.
 func NewStaleDataError(str string) error { return StaleDataError(str) }
 func (e StaleDataError) Error() string   { return string(e) }
+
+// InvalidChangeError is returned when a change is applied to a ruleset,
+// mapping rule, or rollup rule that is invalide.
+type InvalidChangeError string
+
+// NewInvalidChangeError careats a new invalid change error.
+func NewInvalidChangeError(str string) error { return InvalidChangeError(str) }
+func (e InvalidChangeError) Error() string   { return string(e) }

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -20,11 +20,11 @@
 
 package errors
 
-// InvalidInputError is returned when a rule modification is made that would
-// result in a conflict with the existing set of rules in the ruleset.
+// InvalidInputError is returned when a rule or rule change is applied which
+// is invalid.
 type InvalidInputError string
 
-// NewInvalidInputError creates a new rule conflict error.
+// NewInvalidInputError creates a new invalid input error.
 func NewInvalidInputError(str string) error { return InvalidInputError(str) }
 func (e InvalidInputError) Error() string   { return string(e) }
 

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -36,7 +36,7 @@ func NewValidationError(str string) error { return ValidationError(str) }
 func (e ValidationError) Error() string   { return string(e) }
 
 // StaleDataError is returned when a rule modification can not be completed
-// because rule meta data is no longer valid.
+// because rule metadata is no longer valid.
 type StaleDataError string
 
 // NewStaleDataError creates a new version mismatch error.
@@ -44,7 +44,7 @@ func NewStaleDataError(str string) error { return StaleDataError(str) }
 func (e StaleDataError) Error() string   { return string(e) }
 
 // InvalidChangeError is returned when a change is applied to a ruleset,
-// mapping rule, or rollup rule that is invalide.
+// mapping rule, or rollup rule that is invalid.
 type InvalidChangeError string
 
 // NewInvalidChangeError careats a new invalid change error.

--- a/rules/mapping.go
+++ b/rules/mapping.go
@@ -290,7 +290,7 @@ func (mc *mappingRule) markTombstoned(meta UpdateMetadata) error {
 	}
 
 	if mc.Tombstoned() {
-		return merrors.NewRuleConflictError(fmt.Sprintf("%s is already tombstoned", n))
+		return merrors.NewInvalidInputError(fmt.Sprintf("%s is already tombstoned", n))
 	}
 	if len(mc.snapshots) == 0 {
 		return errNoRuleSnapshots
@@ -316,7 +316,7 @@ func (mc *mappingRule) revive(
 		return err
 	}
 	if !mc.Tombstoned() {
-		return merrors.NewRuleConflictError(fmt.Sprintf("%s is not tombstoned", n))
+		return merrors.NewInvalidInputError(fmt.Sprintf("%s is not tombstoned", n))
 	}
 	return mc.addSnapshot(name, rawFilter, policies, meta)
 }

--- a/rules/mapping.go
+++ b/rules/mapping.go
@@ -290,7 +290,7 @@ func (mc *mappingRule) markTombstoned(meta UpdateMetadata) error {
 	}
 
 	if mc.Tombstoned() {
-		return fmt.Errorf("%s is already tombstoned", n)
+		return merrors.NewRuleConflictError(fmt.Sprintf("%s is already tombstoned", n))
 	}
 	if len(mc.snapshots) == 0 {
 		return errNoRuleSnapshots

--- a/rules/rollup.go
+++ b/rules/rollup.go
@@ -442,7 +442,7 @@ func (rc *rollupRule) markTombstoned(meta UpdateMetadata) error {
 	}
 
 	if rc.Tombstoned() {
-		return merrors.NewRuleConflictError(fmt.Sprintf("%s is already tombstoned", n))
+		return merrors.NewInvalidInputError(fmt.Sprintf("%s is already tombstoned", n))
 	}
 
 	if len(rc.snapshots) == 0 {
@@ -470,7 +470,7 @@ func (rc *rollupRule) revive(
 		return err
 	}
 	if !rc.Tombstoned() {
-		return merrors.NewRuleConflictError(fmt.Sprintf("%s is not tombstoned", n))
+		return merrors.NewInvalidInputError(fmt.Sprintf("%s is not tombstoned", n))
 	}
 	return rc.addSnapshot(name, rawFilter, targets, meta)
 }

--- a/rules/rollup.go
+++ b/rules/rollup.go
@@ -442,7 +442,7 @@ func (rc *rollupRule) markTombstoned(meta UpdateMetadata) error {
 	}
 
 	if rc.Tombstoned() {
-		return fmt.Errorf("%s is already tombstoned", n)
+		return merrors.NewRuleConflictError(fmt.Sprintf("%s is already tombstoned", n))
 	}
 
 	if len(rc.snapshots) == 0 {

--- a/rules/ruleset.go
+++ b/rules/ruleset.go
@@ -52,9 +52,9 @@ var (
 	errRuleSetNotTombstoned = errors.New("ruleset is not tombstoned")
 	errRuleNotFound         = errors.New("rule not found")
 	errNoRuleSnapshots      = errors.New("rule has no snapshots")
-	errUnknownOpType        = merrors.NewInvalidInputError("changes must contain an op")
 	ruleActionErrorFmt      = "cannot %s rule %s"
 	ruleSetActionErrorFmt   = "cannot %s ruleset %s"
+	unknownOpTypeFmt        = "unknown op type %v, op"
 )
 
 // Matcher matches metrics against rules to determine applicable policies.
@@ -919,7 +919,7 @@ func (rs *ruleSet) applyMappingRuleChanges(mrChanges []changes.MappingRuleChange
 				return err
 			}
 		default:
-			return errUnknownOpType
+			return merrors.NewInvalidInputError(fmt.Sprintf(unknownOpTypeFmt, mrChange.Op))
 		}
 	}
 
@@ -944,7 +944,7 @@ func (rs *ruleSet) applyRollupRuleChanges(rrChanges []changes.RollupRuleChange, 
 				return err
 			}
 		default:
-			return errUnknownOpType
+			return merrors.NewInvalidInputError(fmt.Sprintf(unknownOpTypeFmt, rrChange.Op))
 		}
 	}
 

--- a/rules/ruleset.go
+++ b/rules/ruleset.go
@@ -52,7 +52,7 @@ var (
 	errRuleSetNotTombstoned = errors.New("ruleset is not tombstoned")
 	errRuleNotFound         = errors.New("rule not found")
 	errNoRuleSnapshots      = errors.New("rule has no snapshots")
-	errMissingOpInChanges   = merrors.NewInvalidInputError("changes must contain an op")
+	errUnknownOpType        = merrors.NewInvalidInputError("changes must contain an op")
 	ruleActionErrorFmt      = "cannot %s rule %s"
 	ruleSetActionErrorFmt   = "cannot %s ruleset %s"
 )
@@ -919,7 +919,7 @@ func (rs *ruleSet) applyMappingRuleChanges(mrChanges []changes.MappingRuleChange
 				return err
 			}
 		default:
-			return errMissingOpInChanges
+			return errUnknownOpType
 		}
 	}
 
@@ -944,7 +944,7 @@ func (rs *ruleSet) applyRollupRuleChanges(rrChanges []changes.RollupRuleChange, 
 				return err
 			}
 		default:
-			return errMissingOpInChanges
+			return errUnknownOpType
 		}
 	}
 

--- a/rules/ruleset.go
+++ b/rules/ruleset.go
@@ -55,7 +55,7 @@ var (
 	ruleActionErrorFmt       = "cannot %s rule %s"
 	ruleIDNotFoundErrorFmt   = "no rule with id %v"
 	ruleSetActionErrorFmt    = "cannot %s ruleset %s"
-	unknownOpTypeFmt         = "unknown op type %v, op"
+	unknownOpTypeFmt         = "unknown op type %v"
 )
 
 // Matcher matches metrics against rules to determine applicable policies.

--- a/rules/ruleset.go
+++ b/rules/ruleset.go
@@ -48,13 +48,14 @@ const (
 )
 
 var (
-	errNilRuleSetSchema     = errors.New("nil rule set schema")
-	errRuleSetNotTombstoned = errors.New("ruleset is not tombstoned")
-	errRuleNotFound         = errors.New("rule not found")
-	errNoRuleSnapshots      = errors.New("rule has no snapshots")
-	ruleActionErrorFmt      = "cannot %s rule %s"
-	ruleSetActionErrorFmt   = "cannot %s ruleset %s"
-	unknownOpTypeFmt        = "unknown op type %v, op"
+	errNilRuleSetSchema      = errors.New("nil rule set schema")
+	errRuleSetNotTombstoned  = errors.New("ruleset is not tombstoned")
+	errRuleNotFound          = errors.New("rule not found")
+	errNoRuleSnapshots       = errors.New("rule has no snapshots")
+	ruleActionErrorFmt       = "cannot %s rule %s"
+	ruleIDNotFoundErrorFmt   = "no rule with id %v"
+	ruleSetActionErrorFmt    = "cannot %s ruleset %s"
+	unknownOpTypeFmt         = "unknown op type %v, op"
 )
 
 // Matcher matches metrics against rules to determine applicable policies.
@@ -782,7 +783,7 @@ func (rs *ruleSet) AddMappingRule(mrv models.MappingRuleView, meta UpdateMetadat
 func (rs *ruleSet) UpdateMappingRule(mrv models.MappingRuleView, meta UpdateMetadata) error {
 	m, err := rs.getMappingRuleByID(mrv.ID)
 	if err != nil {
-		return xerrors.Wrap(err, fmt.Sprintf(ruleActionErrorFmt, "update", mrv.ID))
+		return merrors.NewInvalidInputError(fmt.Sprintf(ruleIDNotFoundErrorFmt, mrv.ID))
 	}
 	if err := m.addSnapshot(
 		mrv.Name,
@@ -799,7 +800,7 @@ func (rs *ruleSet) UpdateMappingRule(mrv models.MappingRuleView, meta UpdateMeta
 func (rs *ruleSet) DeleteMappingRule(id string, meta UpdateMetadata) error {
 	m, err := rs.getMappingRuleByID(id)
 	if err != nil {
-		return xerrors.Wrap(err, fmt.Sprintf(ruleActionErrorFmt, "delete", id))
+		return merrors.NewInvalidInputError(fmt.Sprintf(ruleIDNotFoundErrorFmt, id))
 	}
 
 	if err := m.markTombstoned(meta); err != nil {
@@ -842,7 +843,7 @@ func (rs *ruleSet) AddRollupRule(rrv models.RollupRuleView, meta UpdateMetadata)
 func (rs *ruleSet) UpdateRollupRule(rrv models.RollupRuleView, meta UpdateMetadata) error {
 	r, err := rs.getRollupRuleByID(rrv.ID)
 	if err != nil {
-		return xerrors.Wrap(err, fmt.Sprintf(ruleActionErrorFmt, "update", rrv.ID))
+		return merrors.NewInvalidInputError(fmt.Sprintf(ruleIDNotFoundErrorFmt, rrv.ID))
 	}
 	targets := newRollupTargetsFromView(rrv.Targets)
 	if err = r.addSnapshot(
@@ -860,7 +861,7 @@ func (rs *ruleSet) UpdateRollupRule(rrv models.RollupRuleView, meta UpdateMetada
 func (rs *ruleSet) DeleteRollupRule(id string, meta UpdateMetadata) error {
 	r, err := rs.getRollupRuleByID(id)
 	if err != nil {
-		return xerrors.Wrap(err, fmt.Sprintf(ruleActionErrorFmt, "delete", id))
+		return merrors.NewInvalidInputError(fmt.Sprintf(ruleIDNotFoundErrorFmt, id))
 	}
 
 	if err := r.markTombstoned(meta); err != nil {

--- a/rules/ruleset.go
+++ b/rules/ruleset.go
@@ -52,7 +52,7 @@ var (
 	errRuleSetNotTombstoned = errors.New("ruleset is not tombstoned")
 	errRuleNotFound         = errors.New("rule not found")
 	errNoRuleSnapshots      = errors.New("rule has no snapshots")
-	errMissingOpInChanges   = "changes must contain an op"
+	errMissingOpInChanges   = merrors.NewInvalidInputError("changes must contain an op")
 	ruleActionErrorFmt      = "cannot %s rule %s"
 	ruleSetActionErrorFmt   = "cannot %s ruleset %s"
 )
@@ -919,7 +919,7 @@ func (rs *ruleSet) applyMappingRuleChanges(mrChanges []changes.MappingRuleChange
 				return err
 			}
 		default:
-			return merrors.NewInvalidInputError(errMissingOpInChanges)
+			return errMissingOpInChanges
 		}
 	}
 
@@ -944,7 +944,7 @@ func (rs *ruleSet) applyRollupRuleChanges(rrChanges []changes.RollupRuleChange, 
 				return err
 			}
 		default:
-			return merrors.NewInvalidInputError(errMissingOpInChanges)
+			return errMissingOpInChanges
 		}
 	}
 

--- a/rules/ruleset_test.go
+++ b/rules/ruleset_test.go
@@ -3033,8 +3033,8 @@ func TestRuleSetClone(t *testing.T) {
 	require.NotEqual(t, rs.rollupRules, rsClone.rollupRules)
 }
 
-func TestApplyChangesToRuleSet(t *testing.T) {
-	mutable, _, helper, _ := initMutableTest()
+func TestApplyChanges(t *testing.T) {
+	mutable, rs, helper, _ := initMutableTest()
 	changes := changes.RuleSetChanges{}
 	ruleSetChangesWithAddOps(&changes, "rrID1", "mrID1")
 	ruleSetChangesWithUpdateOps(&changes, "rollupRule1", "mappingRule1")
@@ -3044,8 +3044,30 @@ func TestApplyChangesToRuleSet(t *testing.T) {
 		changes,
 		helper.NewUpdateMetadata(100, "validAuthor"),
 	)
-
 	require.NoError(t, err)
+
+	_, err = rs.getMappingRuleByName("mappingRuleAdd")
+	require.NoError(t, err)
+	_, err = rs.getRollupRuleByName("rollupRuleAdd")
+	require.NoError(t, err)
+
+	updatedMappingRule, err := rs.getMappingRuleByID("mappingRule1")
+	require.NoError(t, err)
+	name, err := updatedMappingRule.Name()
+	require.NoError(t, err)
+	require.Equal(t, name, "updatedMappingRule")
+	updatedRollupRule, err := rs.getRollupRuleByID("rollupRule1")
+	require.NoError(t, err)
+	name, err = updatedRollupRule.Name()
+	require.NoError(t, err)
+	require.Equal(t, name, "updatedRollupRule")
+
+	tombstonedMappingRule, err := rs.getMappingRuleByID("mappingRule3")
+	require.NoError(t, err)
+	require.True(t, tombstonedMappingRule.Tombstoned())
+	tombstonedRollupRule, err := rs.getRollupRuleByID("rollupRule3")
+	require.NoError(t, err)
+	require.True(t, tombstonedRollupRule.Tombstoned())
 }
 
 func TestApplyMappingRuleChangesAddFailure(t *testing.T) {

--- a/rules/ruleset_test.go
+++ b/rules/ruleset_test.go
@@ -2682,7 +2682,7 @@ func TestAddMappingRuleDup(t *testing.T) {
 	containedErr, ok := err.(xerrors.ContainedError)
 	require.True(t, ok)
 	err = containedErr.InnerError()
-	_, ok = err.(errors.RuleConflictError)
+	_, ok = err.(errors.InvalidInputError)
 	require.True(t, ok)
 }
 
@@ -2861,7 +2861,7 @@ func TestAddRollupRuleDup(t *testing.T) {
 	containedErr, ok := err.(xerrors.ContainedError)
 	require.True(t, ok)
 	err = containedErr.InnerError()
-	_, ok = err.(errors.RuleConflictError)
+	_, ok = err.(errors.InvalidInputError)
 	require.True(t, ok)
 }
 
@@ -3033,14 +3033,14 @@ func TestRuleSetClone(t *testing.T) {
 	require.NotEqual(t, rs.rollupRules, rsClone.rollupRules)
 }
 
-func TestApplyChanges(t *testing.T) {
+func TestApplyRuleSetChanges(t *testing.T) {
 	mutable, rs, helper, _ := initMutableTest()
 	changes := changes.RuleSetChanges{}
 	testRuleSetChangesWithAddOps(&changes, "rrID1", "mrID1")
 	testRuleSetChangesWithUpdateOps(&changes, "rollupRule1", "mappingRule1")
 	testRulesetChangesWithDeletes(&changes, "rollupRule3", "mappingRule3")
 
-	err := mutable.ApplyChanges(
+	err := mutable.ApplyRuleSetChanges(
 		changes,
 		helper.NewUpdateMetadata(100, "validAuthor"),
 	)
@@ -3085,7 +3085,7 @@ func TestApplyMappingRuleChangesAddFailure(t *testing.T) {
 	containedErr, ok := err.(xerrors.ContainedError)
 	require.True(t, ok)
 	err = containedErr.InnerError()
-	_, ok = err.(errors.RuleConflictError)
+	_, ok = err.(errors.InvalidInputError)
 	require.True(t, ok)
 }
 
@@ -3104,7 +3104,7 @@ func TestApplyRollupRuleChangesAddFailure(t *testing.T) {
 	containedErr, ok := err.(xerrors.ContainedError)
 	require.True(t, ok)
 	err = containedErr.InnerError()
-	_, ok = err.(errors.RuleConflictError)
+	_, ok = err.(errors.InvalidInputError)
 	require.True(t, ok)
 }
 
@@ -3128,7 +3128,7 @@ func TestApplyMappingRuleChangesDeleteFailure(t *testing.T) {
 	containedErr, ok := err.(xerrors.ContainedError)
 	require.True(t, ok)
 	err = containedErr.InnerError()
-	_, ok = err.(errors.RuleConflictError)
+	_, ok = err.(errors.InvalidInputError)
 	require.True(t, ok)
 }
 
@@ -3152,7 +3152,7 @@ func TestApplyRollupRuleChangesDeleteFailure(t *testing.T) {
 	containedErr, ok := err.(xerrors.ContainedError)
 	require.True(t, ok)
 	err = containedErr.InnerError()
-	_, ok = err.(errors.RuleConflictError)
+	_, ok = err.(errors.InvalidInputError)
 	require.True(t, ok)
 }
 
@@ -3203,7 +3203,7 @@ func TestApplyRollupRuleWithInvalidOp(t *testing.T) {
 		helper.NewUpdateMetadata(100, "validAuthor"),
 	)
 	require.Error(t, err)
-	require.IsType(t, errors.NewInvalidChangeError(""), err)
+	require.IsType(t, errors.NewInvalidInputError(""), err)
 }
 
 func TestApplyMappingRuleWithInvalidOp(t *testing.T) {
@@ -3219,7 +3219,7 @@ func TestApplyMappingRuleWithInvalidOp(t *testing.T) {
 		helper.NewUpdateMetadata(100, "validAuthor"),
 	)
 	require.Error(t, err)
-	require.IsType(t, errors.NewInvalidChangeError(""), err)
+	require.IsType(t, errors.NewInvalidInputError(""), err)
 }
 
 func testRuleSetChangesWithAddOps(rsc *changes.RuleSetChanges, rrIDToAdd, mrIDToAdd string) {

--- a/rules/ruleset_test.go
+++ b/rules/ruleset_test.go
@@ -3036,9 +3036,9 @@ func TestRuleSetClone(t *testing.T) {
 func TestApplyChanges(t *testing.T) {
 	mutable, rs, helper, _ := initMutableTest()
 	changes := changes.RuleSetChanges{}
-	ruleSetChangesWithAddOps(&changes, "rrID1", "mrID1")
-	ruleSetChangesWithUpdateOps(&changes, "rollupRule1", "mappingRule1")
-	rulesetChangesWithDeletes(&changes, "rollupRule3", "mappingRule3")
+	testRuleSetChangesWithAddOps(&changes, "rrID1", "mrID1")
+	testRuleSetChangesWithUpdateOps(&changes, "rollupRule1", "mappingRule1")
+	testRulesetChangesWithDeletes(&changes, "rollupRule3", "mappingRule3")
 
 	err := mutable.ApplyChanges(
 		changes,
@@ -3073,7 +3073,7 @@ func TestApplyChanges(t *testing.T) {
 func TestApplyMappingRuleChangesAddFailure(t *testing.T) {
 	_, rs, helper, _ := initMutableTest()
 	changes := changes.RuleSetChanges{}
-	ruleSetChangesWithAddOps(&changes, "", "mappingRule1")
+	testRuleSetChangesWithAddOps(&changes, "", "mappingRule1")
 	changes.MappingRuleChanges[0].RuleData.Name = "mappingRule1.snapshot3"
 
 	err := rs.applyMappingRuleChanges(
@@ -3092,7 +3092,7 @@ func TestApplyMappingRuleChangesAddFailure(t *testing.T) {
 func TestApplyRollupRuleChangesAddFailure(t *testing.T) {
 	_, rs, helper, _ := initMutableTest()
 	changes := changes.RuleSetChanges{}
-	ruleSetChangesWithAddOps(&changes, "rollupRule1", "")
+	testRuleSetChangesWithAddOps(&changes, "rollupRule1", "")
 	changes.RollupRuleChanges[0].RuleData.Name = "rollupRule1.snapshot3"
 
 	err := rs.applyRollupRuleChanges(
@@ -3111,7 +3111,7 @@ func TestApplyRollupRuleChangesAddFailure(t *testing.T) {
 func TestApplyMappingRuleChangesDeleteFailure(t *testing.T) {
 	_, rs, helper, _ := initMutableTest()
 	changes := changes.RuleSetChanges{}
-	rulesetChangesWithDeletes(&changes, "", "mappingRule1")
+	testRulesetChangesWithDeletes(&changes, "", "mappingRule1")
 
 	err := rs.DeleteMappingRule(
 		"mappingRule1",
@@ -3135,7 +3135,7 @@ func TestApplyMappingRuleChangesDeleteFailure(t *testing.T) {
 func TestApplyRollupRuleChangesDeleteFailure(t *testing.T) {
 	_, rs, helper, _ := initMutableTest()
 	changes := changes.RuleSetChanges{}
-	rulesetChangesWithDeletes(&changes, "rollupRule1", "")
+	testRulesetChangesWithDeletes(&changes, "rollupRule1", "")
 
 	err := rs.DeleteRollupRule(
 		"rollupRule1",
@@ -3159,7 +3159,7 @@ func TestApplyRollupRuleChangesDeleteFailure(t *testing.T) {
 func TestApplyMappingRuleChangesUpdateFailure(t *testing.T) {
 	_, rs, helper, _ := initMutableTest()
 	changes := changes.RuleSetChanges{}
-	ruleSetChangesWithUpdateOps(&changes, "", "invalideMappingRule")
+	testRuleSetChangesWithUpdateOps(&changes, "", "invalideMappingRule")
 
 	err := rs.applyMappingRuleChanges(
 		changes.MappingRuleChanges,
@@ -3176,7 +3176,7 @@ func TestApplyMappingRuleChangesUpdateFailure(t *testing.T) {
 func TestApplyRollupRuleChangesUpdateFailure(t *testing.T) {
 	_, rs, helper, _ := initMutableTest()
 	changes := changes.RuleSetChanges{}
-	ruleSetChangesWithUpdateOps(&changes, "invalidRollupRule", "")
+	testRuleSetChangesWithUpdateOps(&changes, "invalidRollupRule", "")
 
 	err := rs.applyRollupRuleChanges(
 		changes.RollupRuleChanges,
@@ -3222,7 +3222,7 @@ func TestApplyMappingRuleWithInvalidOp(t *testing.T) {
 	require.IsType(t, errors.NewInvalidChangeError(""), err)
 }
 
-func ruleSetChangesWithAddOps(rsc *changes.RuleSetChanges, rrIDToAdd, mrIDToAdd string) {
+func testRuleSetChangesWithAddOps(rsc *changes.RuleSetChanges, rrIDToAdd, mrIDToAdd string) {
 	if rrIDToAdd != "" {
 		rsc.RollupRuleChanges = append(
 			rsc.RollupRuleChanges,
@@ -3250,13 +3250,13 @@ func ruleSetChangesWithAddOps(rsc *changes.RuleSetChanges, rrIDToAdd, mrIDToAdd 
 	}
 }
 
-func ruleSetChangesWithUpdateOps(rsc *changes.RuleSetChanges, rrIDToUpdate, mrIDToUpdate string) {
+func testRuleSetChangesWithUpdateOps(rsc *changes.RuleSetChanges, rrIDToUpdate, mrIDToUpdate string) {
 	if rrIDToUpdate != "" {
 		rsc.RollupRuleChanges = append(
 			rsc.RollupRuleChanges,
 			changes.RollupRuleChange{
 				Op:     changes.ChangeOp,
-				RuleID: ptr(rrIDToUpdate),
+				RuleID: &rrIDToUpdate,
 				RuleData: &models.RollupRule{
 					ID:   rrIDToUpdate,
 					Name: "updatedRollupRule",
@@ -3270,7 +3270,7 @@ func ruleSetChangesWithUpdateOps(rsc *changes.RuleSetChanges, rrIDToUpdate, mrID
 			rsc.MappingRuleChanges,
 			changes.MappingRuleChange{
 				Op:     changes.ChangeOp,
-				RuleID: ptr(mrIDToUpdate),
+				RuleID: &mrIDToUpdate,
 				RuleData: &models.MappingRule{
 					ID:   mrIDToUpdate,
 					Name: "updatedMappingRule",
@@ -3280,13 +3280,13 @@ func ruleSetChangesWithUpdateOps(rsc *changes.RuleSetChanges, rrIDToUpdate, mrID
 	}
 }
 
-func rulesetChangesWithDeletes(rsc *changes.RuleSetChanges, rrIDToDelete, mrIDToDelete string) {
+func testRulesetChangesWithDeletes(rsc *changes.RuleSetChanges, rrIDToDelete, mrIDToDelete string) {
 	if rrIDToDelete != "" {
 		rsc.RollupRuleChanges = append(
 			rsc.RollupRuleChanges,
 			changes.RollupRuleChange{
 				Op:     changes.DeleteOp,
-				RuleID: ptr(rrIDToDelete),
+				RuleID: &rrIDToDelete,
 			},
 		)
 	}
@@ -3296,14 +3296,10 @@ func rulesetChangesWithDeletes(rsc *changes.RuleSetChanges, rrIDToDelete, mrIDTo
 			rsc.MappingRuleChanges,
 			changes.MappingRuleChange{
 				Op:     changes.DeleteOp,
-				RuleID: ptr(mrIDToDelete),
+				RuleID: &mrIDToDelete,
 			},
 		)
 	}
-}
-
-func ptr(s string) *string {
-	return &s
 }
 
 type testMappingsData struct {

--- a/rules/ruleset_test.go
+++ b/rules/ruleset_test.go
@@ -3165,12 +3165,8 @@ func TestApplyMappingRuleChangesUpdateFailure(t *testing.T) {
 		changes.MappingRuleChanges,
 		helper.NewUpdateMetadata(100, "validAuthor"),
 	)
-
 	require.Error(t, err)
-	containedErr, ok := err.(xerrors.ContainedError)
-	require.True(t, ok)
-	err = containedErr.InnerError()
-	require.Equal(t, errRuleNotFound, err)
+	require.IsType(t, errors.NewInvalidInputError(""), err)
 }
 
 func TestApplyRollupRuleChangesUpdateFailure(t *testing.T) {
@@ -3182,12 +3178,8 @@ func TestApplyRollupRuleChangesUpdateFailure(t *testing.T) {
 		changes.RollupRuleChanges,
 		helper.NewUpdateMetadata(100, "validAuthor"),
 	)
-
 	require.Error(t, err)
-	containedErr, ok := err.(xerrors.ContainedError)
-	require.True(t, ok)
-	err = containedErr.InnerError()
-	require.Equal(t, errRuleNotFound, err)
+	require.IsType(t, errors.NewInvalidInputError(""), err)
 }
 
 func TestApplyRollupRuleWithInvalidOp(t *testing.T) {

--- a/rules/validator/validator.go
+++ b/rules/validator/validator.go
@@ -88,7 +88,7 @@ func (v *validator) validateMappingRules(mrv map[string]*models.MappingRuleView)
 	for _, view := range mrv {
 		// Validate that no rules with the same name exist.
 		if _, exists := namesSeen[view.Name]; exists {
-			return errors.NewRuleConflictError(fmt.Sprintf("mapping rule '%s' already exists", view.Name))
+			return errors.NewInvalidInputError(fmt.Sprintf("mapping rule '%s' already exists", view.Name))
 		}
 		namesSeen[view.Name] = struct{}{}
 
@@ -123,7 +123,7 @@ func (v *validator) validateRollupRules(rrv map[string]*models.RollupRuleView) e
 	for _, view := range rrv {
 		// Validate that no rules with the same name exist.
 		if _, exists := namesSeen[view.Name]; exists {
-			return errors.NewRuleConflictError(fmt.Sprintf("rollup rule '%s' already exists", view.Name))
+			return errors.NewInvalidInputError(fmt.Sprintf("rollup rule '%s' already exists", view.Name))
 		}
 		namesSeen[view.Name] = struct{}{}
 
@@ -161,7 +161,7 @@ func (v *validator) validateRollupRules(rrv map[string]*models.RollupRuleView) e
 			// Validate that there are no conflicting rollup targets.
 			for _, seenTarget := range targetsSeen {
 				if target.SameTransform(seenTarget) {
-					return errors.NewRuleConflictError(fmt.Sprintf("rollup target with name '%s' and tags '%s' already exists", target.Name, target.Tags))
+					return errors.NewInvalidInputError(fmt.Sprintf("rollup target with name '%s' and tags '%s' already exists", target.Name, target.Tags))
 				}
 			}
 			targetsSeen = append(targetsSeen, target)
@@ -286,7 +286,7 @@ func (v *validator) wrapError(err error) error {
 	switch err.(type) {
 	// Do not wrap error for these error types so caller can take actions
 	// based on the correct error type.
-	case errors.RuleConflictError, errors.ValidationError:
+	case errors.InvalidInputError, errors.ValidationError:
 		return err
 	default:
 		return errors.NewValidationError(err.Error())

--- a/rules/validator/validator_test.go
+++ b/rules/validator/validator_test.go
@@ -94,7 +94,7 @@ func TestValidatorValidateDuplicateMappingRules(t *testing.T) {
 	validator := NewValidator(testValidatorOptions())
 	err := validator.Validate(ruleSet)
 	require.Error(t, err)
-	_, ok := err.(errors.RuleConflictError)
+	_, ok := err.(errors.InvalidInputError)
 	require.True(t, ok)
 }
 
@@ -211,7 +211,7 @@ func TestValidatorValidateDuplicateRollupRules(t *testing.T) {
 	validator := NewValidator(testValidatorOptions())
 	err := validator.Validate(ruleSet)
 	require.Error(t, err)
-	_, ok := err.(errors.RuleConflictError)
+	_, ok := err.(errors.InvalidInputError)
 	require.True(t, ok)
 }
 
@@ -385,7 +385,7 @@ func TestValidatorValidateRollupRuleConflictingTargets(t *testing.T) {
 	validator := NewValidator(opts)
 	err := validator.Validate(ruleSet)
 	require.Error(t, err)
-	_, ok := err.(errors.RuleConflictError)
+	_, ok := err.(errors.InvalidInputError)
 	require.True(t, ok)
 }
 


### PR DESCRIPTION
We have previously introduced a `RuleSetChanges` struct. This PR adds a public method to the `MutableRuleSet` interface which takes a `RuleSetChanges` object as an argument and applies all the changes. 