### PR TITLE
Validate object type during decoding

### DIFF
--- a/protocol/msgpack/base_iterator.go
+++ b/protocol/msgpack/base_iterator.go
@@ -210,7 +210,15 @@ func (it *baseIterator) decodeVersion() int {
 }
 
 func (it *baseIterator) decodeObjectType() objectType {
-	return objectType(it.decodeVarint())
+	ot := objectType(it.decodeVarint())
+	if it.decodeErr != nil {
+		return unknownType
+	}
+	if !ot.isValid() {
+		it.decodeErr = fmt.Errorf("invalid object type %v", ot)
+		return unknownType
+	}
+	return ot
 }
 
 func (it *baseIterator) decodeNumObjectFields() int {

--- a/protocol/msgpack/schema.go
+++ b/protocol/msgpack/schema.go
@@ -68,7 +68,7 @@ const (
 	rawMetricWithStoragePolicyAndEncodeTimeType
 
 	// Total number of object types.
-	numObjectTypes = iota
+	numObjectTypes = iota - 1
 )
 
 const (
@@ -94,6 +94,10 @@ const (
 	numLongAggregationIDFields                       = 2
 	numPolicyFields                                  = 2
 )
+
+func (ot objectType) isValid() bool {
+	return ot > unknownType && ot <= numObjectTypes
+}
 
 // NB(xichen): use a slice instead of a map to avoid lookup overhead.
 var numObjectFields []int

--- a/protocol/msgpack/schema_test.go
+++ b/protocol/msgpack/schema_test.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package msgpack
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestObjectTypeIsValid(t *testing.T) {
+	inputs := []objectType{
+		rootObjectType,
+		counterWithPoliciesListType,
+		batchTimerWithPoliciesListType,
+		gaugeWithPoliciesListType,
+		rawMetricWithStoragePolicyType,
+		counterType,
+		batchTimerType,
+		gaugeType,
+		metricType,
+		defaultPoliciesListType,
+		customPoliciesListType,
+		stagedPoliciesType,
+		storagePolicyType,
+		knownResolutionType,
+		unknownResolutionType,
+		knownRetentionType,
+		unknownRetentionType,
+		defaultAggregationID,
+		shortAggregationID,
+		longAggregationID,
+		policyType,
+		rawMetricWithStoragePolicyAndEncodeTimeType,
+	}
+
+	for _, input := range inputs {
+		require.True(t, input.isValid())
+	}
+}
+
+func TestObjectTypeIsValidInvalidType(t *testing.T) {
+	inputs := []objectType{
+		unknownType,
+		numObjectTypes + 1,
+	}
+
+	for _, input := range inputs {
+		require.False(t, input.isValid())
+	}
+}


### PR DESCRIPTION
cc @cw9 @jeromefroe @prateek 

This PR validates the object type during decoding to return an error on invalid object types that may be caused by network packet corruptions.