### PR TITLE
Add a few utility methods

### DIFF
--- a/encoding/protobuf/buffer.go
+++ b/encoding/protobuf/buffer.go
@@ -41,6 +41,9 @@ func NewBuffer(buf []byte, p pool.BytesPool) Buffer {
 // Bytes returns the raw byte slice.
 func (b *Buffer) Bytes() []byte { return b.buf }
 
+// Truncate truncates the raw byte slice.
+func (b *Buffer) Truncate(n int) { b.buf = b.buf[:n] }
+
 // Close closes the buffer.
 func (b *Buffer) Close() {
 	if b.closed {

--- a/encoding/protobuf/buffer_test.go
+++ b/encoding/protobuf/buffer_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBuffer(t *testing.T) {
+func TestBufferWithPool(t *testing.T) {
 	buckets := []pool.Bucket{
 		{Capacity: 16, Count: 1},
 	}
@@ -66,6 +66,17 @@ func TestBufferNilPool(t *testing.T) {
 	require.True(t, buf.closed)
 	require.Nil(t, buf.pool)
 	require.Nil(t, buf.buf)
+}
+
+func TestBufferTruncate(t *testing.T) {
+	data := []byte{1, 2, 3, 4}
+	buf := NewBuffer(data, nil)
+	require.Equal(t, data, buf.Bytes())
+
+	for i := len(data); i >= 0; i-- {
+		buf.Truncate(i)
+		require.Equal(t, data[:i], buf.Bytes())
+	}
 }
 
 func TestAllocate(t *testing.T) {

--- a/metric/unaggregated/types.go
+++ b/metric/unaggregated/types.go
@@ -67,6 +67,15 @@ type Counter struct {
 	Value int64
 }
 
+// ToUnion converts the counter to a metric union.
+func (c Counter) ToUnion() MetricUnion {
+	return MetricUnion{
+		Type:       CounterType,
+		ID:         c.ID,
+		CounterVal: c.Value,
+	}
+}
+
 // ToProto converts the counter to a protobuf message in place.
 func (c Counter) ToProto(pb *metricpb.Counter) {
 	pb.Id = c.ID
@@ -85,6 +94,15 @@ type BatchTimer struct {
 	Values []float64
 }
 
+// ToUnion converts the batch timer to a metric union.
+func (t BatchTimer) ToUnion() MetricUnion {
+	return MetricUnion{
+		Type:          BatchTimerType,
+		ID:            t.ID,
+		BatchTimerVal: t.Values,
+	}
+}
+
 // ToProto converts the batch timer to a protobuf message in place.
 func (t BatchTimer) ToProto(pb *metricpb.BatchTimer) {
 	pb.Id = t.ID
@@ -101,6 +119,15 @@ func (t *BatchTimer) FromProto(pb metricpb.BatchTimer) {
 type Gauge struct {
 	ID    id.RawID
 	Value float64
+}
+
+// ToUnion converts the gauge to a metric union.
+func (g Gauge) ToUnion() MetricUnion {
+	return MetricUnion{
+		Type:     GaugeType,
+		ID:       g.ID,
+		GaugeVal: g.Value,
+	}
 }
 
 // ToProto converts the gauge to a protobuf message in place.

--- a/metric/unaggregated/types_test.go
+++ b/metric/unaggregated/types_test.go
@@ -45,13 +45,28 @@ var (
 		ID:    []byte("testCounter"),
 		Value: 1234,
 	}
+	testCounterUnion = MetricUnion{
+		Type:       CounterType,
+		ID:         []byte("testCounter"),
+		CounterVal: 1234,
+	}
 	testBatchTimer = BatchTimer{
 		ID:     []byte("testBatchTimer"),
 		Values: []float64{4.78, -2384, 0.0, 3145, 9999},
 	}
+	testBatchTimerUnion = MetricUnion{
+		Type:          BatchTimerType,
+		ID:            []byte("testBatchTimer"),
+		BatchTimerVal: []float64{4.78, -2384, 0.0, 3145, 9999},
+	}
 	testGauge = Gauge{
 		ID:    []byte("testGauge"),
 		Value: 45.28,
+	}
+	testGaugeUnion = MetricUnion{
+		Type:     GaugeType,
+		ID:       []byte("testGauge"),
+		GaugeVal: 45.28,
 	}
 	testMetadatas = metadata.StagedMetadatas{
 		{
@@ -286,6 +301,10 @@ var (
 	}
 )
 
+func TestCounterToUnion(t *testing.T) {
+	require.Equal(t, testCounterUnion, testCounter.ToUnion())
+}
+
 func TestCounterToProto(t *testing.T) {
 	var pb metricpb.Counter
 	testCounter.ToProto(&pb)
@@ -308,6 +327,10 @@ func TestCounterRoundTrip(t *testing.T) {
 	require.Equal(t, testCounter, c)
 }
 
+func TestBatchTimerToUnion(t *testing.T) {
+	require.Equal(t, testBatchTimerUnion, testBatchTimer.ToUnion())
+}
+
 func TestBatchTimerToProto(t *testing.T) {
 	var pb metricpb.BatchTimer
 	testBatchTimer.ToProto(&pb)
@@ -328,6 +351,10 @@ func TestBatchTimerRoundTrip(t *testing.T) {
 	testBatchTimer.ToProto(&pb)
 	c.FromProto(pb)
 	require.Equal(t, testBatchTimer, c)
+}
+
+func TestGaugeToUnion(t *testing.T) {
+	require.Equal(t, testGaugeUnion, testGauge.ToUnion())
 }
 
 func TestGaugeToProto(t *testing.T) {


### PR DESCRIPTION
cc @jeromefroe @cw9 

This PR adds a few utility methods:
- Add `Truncate` to `Buffer` and `Encoder` types.
- Add `ToUnion` to the `Counter/BatchTimer/Gauge` types.