### PR TITLE
Allow tombstoned rules to have empty targets and storage policies

### DIFF
--- a/rules/mapping.go
+++ b/rules/mapping.go
@@ -83,7 +83,7 @@ func newMappingRuleSnapshotFromProto(
 		if err != nil {
 			return nil, err
 		}
-	} else {
+	} else if !r.Tombstoned {
 		return nil, errNoStoragePoliciesInMappingRuleSnapshot
 	}
 	filterValues, err := filters.ParseTagFilterValueMap(r.Filter)
@@ -342,13 +342,13 @@ func (mc *mappingRule) markTombstoned(meta UpdateMetadata) error {
 	if len(mc.snapshots) == 0 {
 		return errNoRuleSnapshots
 	}
-	snapshot := *mc.snapshots[len(mc.snapshots)-1]
+	snapshot := mc.snapshots[len(mc.snapshots)-1].clone()
 	snapshot.tombstoned = true
 	snapshot.cutoverNanos = meta.cutoverNanos
-	snapshot.aggregationID = aggregation.DefaultID
-	snapshot.storagePolicies = nil
 	snapshot.lastUpdatedAtNanos = meta.updatedAtNanos
 	snapshot.lastUpdatedBy = meta.updatedBy
+	snapshot.aggregationID = aggregation.DefaultID
+	snapshot.storagePolicies = nil
 	mc.snapshots = append(mc.snapshots, &snapshot)
 	return nil
 }

--- a/rules/mapping_test.go
+++ b/rules/mapping_test.go
@@ -312,6 +312,32 @@ func TestNewMappingRuleSnapshotFromV2Proto(t *testing.T) {
 	}
 }
 
+func TestNewMappingRuleSnapshotFromProtoTombstoned(t *testing.T) {
+	filterOpts := testTagsFilterOptions()
+	input := &rulepb.MappingRuleSnapshot{
+		Name:               "foo",
+		Tombstoned:         true,
+		CutoverNanos:       12345,
+		Filter:             "tag1:value1 tag2:value2",
+		LastUpdatedAtNanos: 12345,
+		LastUpdatedBy:      "someone",
+	}
+	res, err := newMappingRuleSnapshotFromProto(input, filterOpts)
+	require.NoError(t, err)
+
+	expected := &mappingRuleSnapshot{
+		name:               "foo",
+		tombstoned:         true,
+		cutoverNanos:       12345,
+		rawFilter:          "tag1:value1 tag2:value2",
+		aggregationID:      aggregation.DefaultID,
+		lastUpdatedAtNanos: 12345,
+		lastUpdatedBy:      "someone",
+	}
+	require.True(t, cmp.Equal(expected, res, testMappingRuleSnapshotCmpOpts...))
+	require.NotNil(t, res.filter)
+}
+
 func TestNewMappingRuleSnapshotNoStoragePolicies(t *testing.T) {
 	proto := &rulepb.MappingRuleSnapshot{}
 	_, err := newMappingRuleSnapshotFromProto(proto, testTagsFilterOptions())

--- a/rules/rollup.go
+++ b/rules/rollup.go
@@ -80,7 +80,7 @@ func newRollupRuleSnapshotFromProto(
 			}
 			targets = append(targets, target)
 		}
-	} else {
+	} else if !r.Tombstoned {
 		return nil, errNoRollupTargetsInRollupRuleSnapshot
 	}
 
@@ -341,12 +341,12 @@ func (rc *rollupRule) markTombstoned(meta UpdateMetadata) error {
 		return errNoRuleSnapshots
 	}
 
-	snapshot := *rc.snapshots[len(rc.snapshots)-1]
+	snapshot := rc.snapshots[len(rc.snapshots)-1].clone()
 	snapshot.tombstoned = true
 	snapshot.cutoverNanos = meta.cutoverNanos
-	snapshot.targets = nil
 	snapshot.lastUpdatedAtNanos = meta.updatedAtNanos
 	snapshot.lastUpdatedBy = meta.updatedBy
+	snapshot.targets = nil
 	rc.snapshots = append(rc.snapshots, &snapshot)
 	return nil
 }

--- a/rules/rollup_test.go
+++ b/rules/rollup_test.go
@@ -516,6 +516,31 @@ func TestNewRollupRuleSnapshotFromV2Proto(t *testing.T) {
 	}
 }
 
+func TestNewRollupRuleSnapshotFromProtoTombstoned(t *testing.T) {
+	filterOpts := testTagsFilterOptions()
+	input := &rulepb.RollupRuleSnapshot{
+		Name:               "foo",
+		Tombstoned:         true,
+		CutoverNanos:       12345,
+		LastUpdatedAtNanos: 12345,
+		LastUpdatedBy:      "someone",
+		Filter:             "tag1:value1 tag2:value2",
+	}
+	res, err := newRollupRuleSnapshotFromProto(input, filterOpts)
+	require.NoError(t, err)
+
+	expected := &rollupRuleSnapshot{
+		name:               "foo",
+		tombstoned:         true,
+		cutoverNanos:       12345,
+		rawFilter:          "tag1:value1 tag2:value2",
+		lastUpdatedAtNanos: 12345,
+		lastUpdatedBy:      "someone",
+	}
+	require.True(t, cmp.Equal(expected, res, testRollupRuleSnapshotCmpOpts...))
+	require.NotNil(t, res.filter)
+}
+
 func TestNewRollupRuleSnapshotNoRollupTargets(t *testing.T) {
 	proto := &rulepb.RollupRuleSnapshot{}
 	_, err := newRollupRuleSnapshotFromProto(proto, testTagsFilterOptions())


### PR DESCRIPTION
cc @cw9  @jeromefroe 

This PR allows tombstoned rules to have empty targets and storage policies.