### PR TITLE
Allow marshaling and unmarshaling versioned metadatas as JSON

### DIFF
--- a/aggregation/id.go
+++ b/aggregation/id.go
@@ -21,6 +21,7 @@
 package aggregation
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/m3db/m3metrics/generated/proto/aggregationpb"
@@ -60,21 +61,6 @@ func NewIDFromProto(input []aggregationpb.AggregationType) (ID, error) {
 	return id, nil
 }
 
-// CompressTypes compresses a list of aggregation types to an ID.
-func CompressTypes(aggTypes ...Type) (ID, error) {
-	return NewIDCompressor().Compress(aggTypes)
-}
-
-// MustCompressTypes compresses a list of aggregation types to
-// an ID, it panics if an error was encountered.
-func MustCompressTypes(aggTypes ...Type) ID {
-	res, err := CompressTypes(aggTypes...)
-	if err != nil {
-		panic(err)
-	}
-	return res
-}
-
 // IsDefault checks if the ID is the default aggregation type.
 func (id ID) IsDefault() bool {
 	return id == DefaultID
@@ -100,13 +86,36 @@ func (id ID) Types() (Types, error) {
 	return NewIDDecompressor().Decompress(id)
 }
 
-// String for debugging.
+// String is a string representation of the ID.
 func (id ID) String() string {
 	aggTypes, err := id.Types()
 	if err != nil {
 		return fmt.Sprintf("[invalid ID: %v]", err)
 	}
 	return aggTypes.String()
+}
+
+// MarshalJSON returns the JSON encoding of an ID.
+func (id ID) MarshalJSON() ([]byte, error) {
+	aggTypes, err := id.Types()
+	if err != nil {
+		return nil, fmt.Errorf("invalid aggregation id %v: %v", id, err)
+	}
+	return json.Marshal(aggTypes)
+}
+
+// UnmarshalJSON unmarshals JSON-encoded data into an ID.
+func (id *ID) UnmarshalJSON(data []byte) error {
+	var aggTypes Types
+	if err := json.Unmarshal(data, &aggTypes); err != nil {
+		return err
+	}
+	tid, err := CompressTypes(aggTypes...)
+	if err != nil {
+		return fmt.Errorf("invalid aggregation types %v: %v", aggTypes, err)
+	}
+	*id = tid
+	return nil
 }
 
 // ToProto converts the aggregation id to a protobuf message in place.
@@ -125,4 +134,19 @@ func (id *ID) FromProto(pb aggregationpb.AggregationID) error {
 	}
 	(*id)[0] = pb.Id
 	return nil
+}
+
+// CompressTypes compresses a list of aggregation types to an ID.
+func CompressTypes(aggTypes ...Type) (ID, error) {
+	return NewIDCompressor().Compress(aggTypes)
+}
+
+// MustCompressTypes compresses a list of aggregation types to
+// an ID, it panics if an error was encountered.
+func MustCompressTypes(aggTypes ...Type) ID {
+	res, err := CompressTypes(aggTypes...)
+	if err != nil {
+		panic(err)
+	}
+	return res
 }

--- a/aggregation/id.go
+++ b/aggregation/id.go
@@ -118,6 +118,20 @@ func (id *ID) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// UnmarshalYAML unmarshals YAML-encoded data into an ID.
+func (id *ID) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var aggTypes Types
+	if err := unmarshal(&aggTypes); err != nil {
+		return err
+	}
+	tid, err := CompressTypes(aggTypes...)
+	if err != nil {
+		return fmt.Errorf("invalid aggregation types %v: %v", aggTypes, err)
+	}
+	*id = tid
+	return nil
+}
+
 // ToProto converts the aggregation id to a protobuf message in place.
 func (id ID) ToProto(pb *aggregationpb.AggregationID) error {
 	if IDLen != 1 {

--- a/aggregation/id_test.go
+++ b/aggregation/id_test.go
@@ -21,6 +21,7 @@
 package aggregation
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/m3db/m3metrics/generated/proto/aggregationpb"
@@ -53,4 +54,43 @@ func TestIDRoundTrip(t *testing.T) {
 	require.NoError(t, testID.ToProto(&pb))
 	require.NoError(t, res.FromProto(pb))
 	require.Equal(t, testID, res)
+}
+
+func TestIDMarshalJSON(t *testing.T) {
+	inputs := []struct {
+		id       ID
+		expected string
+	}{
+		{id: DefaultID, expected: `null`},
+		{id: testID, expected: `["Last","Min"]`},
+	}
+	for _, input := range inputs {
+		b, err := json.Marshal(input.id)
+		require.NoError(t, err)
+		require.Equal(t, input.expected, string(b))
+	}
+}
+
+func TestIDMarshalJSONError(t *testing.T) {
+	inputs := []ID{
+		ID{1234235235},
+	}
+	for _, input := range inputs {
+		_, err := json.Marshal(input)
+		require.Error(t, err)
+	}
+}
+
+func TestIDMarshalJSONRoundtrip(t *testing.T) {
+	inputs := []ID{
+		DefaultID,
+		testID,
+	}
+	for _, input := range inputs {
+		b, err := json.Marshal(input)
+		require.NoError(t, err)
+		var res ID
+		require.NoError(t, json.Unmarshal(b, &res))
+		require.Equal(t, input, res)
+	}
 }

--- a/aggregation/type.go
+++ b/aggregation/type.go
@@ -273,6 +273,7 @@ func NewTypesFromProto(input []aggregationpb.AggregationType) (Types, error) {
 }
 
 // UnmarshalYAML unmarshals aggregation types from a string.
+// TODO(xichen): look into whether it's possible to unmarshal it as an array to be more consistent.
 func (aggTypes *Types) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var str string
 	if err := unmarshal(&str); err != nil {

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -43,9 +43,6 @@ var (
 
 	// DefaultStagedMetadatas represents default staged metadatas.
 	DefaultStagedMetadatas = StagedMetadatas{DefaultStagedMetadata}
-
-	// DefaultVersionedStagedMetadatas represents default versioned staged metadatas.
-	DefaultVersionedStagedMetadatas = VersionedStagedMetadatas{StagedMetadatas: DefaultStagedMetadatas}
 )
 
 // PipelineMetadata contains pipeline metadata.

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -48,13 +48,13 @@ var (
 // PipelineMetadata contains pipeline metadata.
 type PipelineMetadata struct {
 	// List of aggregation types.
-	AggregationID aggregation.ID
+	AggregationID aggregation.ID `json:"aggregation"`
 
 	// List of storage policies.
-	StoragePolicies policy.StoragePolicies
+	StoragePolicies policy.StoragePolicies `json:"storagePolicies"`
 
 	// Pipeline operations.
-	Pipeline applied.Pipeline
+	Pipeline applied.Pipeline `json:"-"` // NB: not needed for JSON marshaling for now.
 }
 
 // Equal returns true if two pipeline metadata are considered equal.
@@ -117,7 +117,7 @@ func (m *PipelineMetadata) FromProto(pb metricpb.PipelineMetadata) error {
 
 // Metadata represents the metadata associated with a metric.
 type Metadata struct {
-	Pipelines []PipelineMetadata
+	Pipelines []PipelineMetadata `json:"pipelines"`
 }
 
 // IsDefault returns whether this is the default metadata.
@@ -210,13 +210,13 @@ func (m *ForwardMetadata) FromProto(pb metricpb.ForwardMetadata) error {
 
 // StagedMetadata represents metadata with a staged cutover time.
 type StagedMetadata struct {
-	Metadata
+	Metadata `json:"metadata"`
 
 	// Cutover is when the metadata is applicable.
-	CutoverNanos int64
+	CutoverNanos int64 `json:"cutoverNanos"`
 
 	// Tombstoned determines whether the associated metric has been tombstoned.
-	Tombstoned bool
+	Tombstoned bool `json:"tombstoned"`
 }
 
 // IsDefault returns whether this is a default staged metadata.
@@ -282,4 +282,10 @@ func (sms *StagedMetadatas) FromProto(pb metricpb.StagedMetadatas) error {
 		}
 	}
 	return nil
+}
+
+// VersionedStagedMetadatas is a versioned staged metadatas.
+type VersionedStagedMetadatas struct {
+	Version         int             `json:"version"`
+	StagedMetadatas StagedMetadatas `json:"stagedMetadatas"`
 }

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -67,7 +67,7 @@ func (m PipelineMetadata) Equal(other PipelineMetadata) bool {
 // IsDefault returns whether this is the default standard pipeline metadata.
 func (m PipelineMetadata) IsDefault() bool {
 	return m.AggregationID.IsDefault() &&
-		policy.IsDefaultStoragePolicies(m.StoragePolicies) &&
+		m.StoragePolicies.IsDefault() &&
 		m.Pipeline.IsEmpty()
 }
 

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -43,6 +43,9 @@ var (
 
 	// DefaultStagedMetadatas represents default staged metadatas.
 	DefaultStagedMetadatas = StagedMetadatas{DefaultStagedMetadata}
+
+	// DefaultVersionedStagedMetadatas represents default versioned staged metadatas.
+	DefaultVersionedStagedMetadatas = VersionedStagedMetadatas{StagedMetadatas: DefaultStagedMetadatas}
 )
 
 // PipelineMetadata contains pipeline metadata.

--- a/pipeline/type_test.go
+++ b/pipeline/type_test.go
@@ -261,7 +261,7 @@ func TestOpUnionMarshalJSON(t *testing.T) {
 					AggregationID: aggregation.DefaultID,
 				},
 			},
-			expected: `{"rollup":{"newName":"testRollup","tags":["tag1","tag2"]}}`,
+			expected: `{"rollup":{"newName":"testRollup","tags":["tag1","tag2"],"aggregation":null}}`,
 		},
 	}
 
@@ -277,7 +277,6 @@ func TestOpUnionMarshalJSONError(t *testing.T) {
 	_, err := json.Marshal(op)
 	require.Error(t, err)
 }
-
 func TestOpUnionMarshalJSONRoundtrip(t *testing.T) {
 	ops := []OpUnion{
 		{
@@ -348,7 +347,7 @@ func TestPipelineMarshalJSON(t *testing.T) {
 	expected := `[{"aggregation":"Sum"},` +
 		`{"transformation":"PerSecond"},` +
 		`{"rollup":{"newName":"testRollup","tags":["tag1","tag2"],"aggregation":["Min","Max"]}},` +
-		`{"rollup":{"newName":"testRollup","tags":["tag1","tag2"]}}]`
+		`{"rollup":{"newName":"testRollup","tags":["tag1","tag2"],"aggregation":null}}]`
 	require.Equal(t, expected, string(b))
 }
 

--- a/policy/storage_policy.go
+++ b/policy/storage_policy.go
@@ -241,11 +241,9 @@ func (sp StoragePolicies) Clone() StoragePolicies {
 	return cloned
 }
 
-// IsDefaultStoragePolicies returns whether a list of storage policies are considered
+// IsDefault returns whether a list of storage policies are considered
 // as default storage policies.
-func IsDefaultStoragePolicies(storagePolicies StoragePolicies) bool {
-	return len(storagePolicies) == 0
-}
+func (sp StoragePolicies) IsDefault() bool { return len(sp) == 0 }
 
 // ByResolutionAscRetentionDesc implements the sort.Sort interface that enables sorting
 // storage policies by resolution in ascending order and then by retention in descending


### PR DESCRIPTION
cc @cw9 @jeromefroe 

This PR adds the `VersionedMetadatas` struct and ability to marshal and unmarshal it in JSON format.