### PR TITLE
Closing migration iterator should close inner iterators

### DIFF
--- a/encoding/migration/unaggregated_iterator.go
+++ b/encoding/migration/unaggregated_iterator.go
@@ -119,6 +119,10 @@ func (it *unaggregatedIterator) Close() {
 		return
 	}
 	it.closed = true
+	it.msgpackIt.Close()
+	it.msgpackIt = nil
+	it.protobufIt.Close()
+	it.protobufIt = nil
 	it.msg = encoding.UnaggregatedMessageUnion{}
 	it.err = nil
 }

--- a/encoding/migration/unaggregated_iterator_test.go
+++ b/encoding/migration/unaggregated_iterator_test.go
@@ -813,7 +813,6 @@ func TestUnaggregatedIteratorNextOnClose(t *testing.T) {
 	require.False(t, it.Next())
 	require.True(t, iterator.closed)
 	require.Equal(t, encoding.UnaggregatedMessageUnion{}, iterator.msg)
-	require.Nil(t, it.Err())
 
 	// Verify that closing a second time is a no op.
 	it.Close()

--- a/encoding/migration/unaggregated_iterator_test.go
+++ b/encoding/migration/unaggregated_iterator_test.go
@@ -818,3 +818,25 @@ func TestUnaggregatedIteratorNextOnClose(t *testing.T) {
 	// Verify that closing a second time is a no op.
 	it.Close()
 }
+
+func TestUnaggregatedIteratorClose(t *testing.T) {
+	it := NewUnaggregatedIterator(
+		nil,
+		msgpack.NewUnaggregatedIteratorOptions(),
+		protobuf.NewUnaggregatedOptions(),
+	)
+	require.False(t, it.(*unaggregatedIterator).closed)
+	require.NotNil(t, it.(*unaggregatedIterator).msgpackIt)
+	require.NotNil(t, it.(*unaggregatedIterator).protobufIt)
+
+	it.Close()
+	require.True(t, it.(*unaggregatedIterator).closed)
+	require.Nil(t, it.(*unaggregatedIterator).msgpackIt)
+	require.Nil(t, it.(*unaggregatedIterator).protobufIt)
+
+	// Verify that closing a second time is a no op.
+	it.Close()
+	require.True(t, it.(*unaggregatedIterator).closed)
+	require.Nil(t, it.(*unaggregatedIterator).msgpackIt)
+	require.Nil(t, it.(*unaggregatedIterator).protobufIt)
+}


### PR DESCRIPTION
cc @cw9 @jeromefroe 

This PR ensures that closing a migration iterator will close the inner iterators.

