### PR TITLE
Unmarshal aggregation types from YAML as lists

### DIFF
--- a/aggregation/type.go
+++ b/aggregation/type.go
@@ -272,22 +272,6 @@ func NewTypesFromProto(input []aggregationpb.AggregationType) (Types, error) {
 	return res, nil
 }
 
-// UnmarshalYAML unmarshals aggregation types from a string.
-// TODO(xichen): look into whether it's possible to unmarshal it as an array to be more consistent.
-func (aggTypes *Types) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var str string
-	if err := unmarshal(&str); err != nil {
-		return err
-	}
-
-	parsed, err := ParseTypes(str)
-	if err != nil {
-		return err
-	}
-	*aggTypes = parsed
-	return nil
-}
-
 // Contains checks if the given type is contained in the aggregation types.
 func (aggTypes Types) Contains(aggType Type) bool {
 	for _, at := range aggTypes {

--- a/aggregation/type_config_test.go
+++ b/aggregation/type_config_test.go
@@ -31,8 +31,11 @@ import (
 
 func TestTypesConfiguration(t *testing.T) {
 	str := `
-defaultGaugeAggregationTypes: Max
-defaultTimerAggregationTypes: P50,P99,P9999
+defaultGaugeAggregationTypes: [Max]
+defaultTimerAggregationTypes:
+  - P50
+  - P99
+  - P9999
 counterTransformFnType: empty
 timerTransformFnType: suffix
 gaugeTransformFnType: empty
@@ -56,8 +59,11 @@ gaugeTransformFnType: empty
 
 func TestTypesConfigurationNoTransformFnType(t *testing.T) {
 	str := `
-defaultGaugeAggregationTypes: Max
-defaultTimerAggregationTypes: P50,P99,P9999
+defaultGaugeAggregationTypes: [Max]
+defaultTimerAggregationTypes:
+  - P50
+  - P99
+  - P9999
 `
 
 	var cfg TypesConfiguration
@@ -75,8 +81,11 @@ defaultTimerAggregationTypes: P50,P99,P9999
 
 func TestTypesConfigurationError(t *testing.T) {
 	str := `
-defaultGaugeAggregationTypes: Max
-defaultTimerAggregationTypes: P50,P99,P9999
+defaultGaugeAggregationTypes: [Max]
+defaultTimerAggregationTypes:
+  - P50
+  - P99
+  - P9999
 timerTransformFnType: bla
 `
 

--- a/aggregation/type_test.go
+++ b/aggregation/type_test.go
@@ -21,6 +21,7 @@
 package aggregation
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/m3db/m3x/pool"
@@ -79,6 +80,91 @@ func TestTypesIsDefault(t *testing.T) {
 	require.False(t, Types{Max}.IsDefault())
 }
 
+func TestTypesMarshalJSON(t *testing.T) {
+	inputs := []struct {
+		types       Types
+		expected    string
+		expectedErr bool
+	}{
+		{
+			types:    Types{},
+			expected: `[]`,
+		},
+		{
+			types:    Types{Min},
+			expected: `["Min"]`,
+		},
+		{
+			expected: `["Mean","Max","P99","P9999"]`,
+			types:    Types{Mean, Max, P99, P9999},
+		},
+		{
+			types:       Types{Type(1000)},
+			expectedErr: true,
+		},
+	}
+	for _, input := range inputs {
+		b, err := json.Marshal(input.types)
+		if input.expectedErr {
+			require.Error(t, err)
+			continue
+		}
+		require.NoError(t, err)
+		require.Equal(t, input.expected, string(b))
+	}
+}
+
+func TestTypesUnMarshalJSON(t *testing.T) {
+	inputs := []struct {
+		str         string
+		expected    Types
+		expectedErr bool
+	}{
+		{
+			str:      `[]`,
+			expected: Types{},
+		},
+		{
+			str:      `["Min"]`,
+			expected: Types{Min},
+		},
+		{
+			str:      `["Mean","Max","P99","P9999"]`,
+			expected: Types{Mean, Max, P99, P9999},
+		},
+		{
+			str:         `[P100]`,
+			expectedErr: true,
+		},
+	}
+	for _, input := range inputs {
+		var aggTypes Types
+		err := json.Unmarshal([]byte(input.str), &aggTypes)
+		if input.expectedErr {
+			require.Error(t, err)
+			continue
+		}
+		require.NoError(t, err)
+		require.Equal(t, input.expected, aggTypes)
+	}
+}
+
+func TestTypesMarshalJSONRoundTrip(t *testing.T) {
+	inputs := []Types{
+		{},
+		{Min},
+		{Mean, Max, P99, P9999},
+	}
+
+	for _, input := range inputs {
+		b, err := json.Marshal(input)
+		require.NoError(t, err)
+		var aggTypes Types
+		require.NoError(t, json.Unmarshal(b, &aggTypes))
+		require.Equal(t, input, aggTypes)
+	}
+}
+
 func TestTypesUnmarshalYAML(t *testing.T) {
 	inputs := []struct {
 		str         string
@@ -86,19 +172,23 @@ func TestTypesUnmarshalYAML(t *testing.T) {
 		expectedErr bool
 	}{
 		{
-			str:      "Min",
+			str:      "",
+			expected: Types(nil),
+		},
+		{
+			str:      "[Min]",
 			expected: Types{Min},
 		},
 		{
-			str:      "Mean,Max,P99,P9999",
+			str:      "[Mean,Max,P99,P9999]",
 			expected: Types{Mean, Max, P99, P9999},
 		},
 		{
-			str:         "Min,Max,P99,P9999,P100",
+			str:         "[Min,Max,P99,P9999,P100]",
 			expectedErr: true,
 		},
 		{
-			str:         "Min,Max,P99,P9999,P100",
+			str:         "[Min,Max,P99,P9999,P100]",
 			expectedErr: true,
 		},
 		{

--- a/aggregation/type_test.go
+++ b/aggregation/type_test.go
@@ -95,8 +95,8 @@ func TestTypesMarshalJSON(t *testing.T) {
 			expected: `["Min"]`,
 		},
 		{
-			expected: `["Mean","Max","P99","P9999"]`,
 			types:    Types{Mean, Max, P99, P9999},
+			expected: `["Mean","Max","P99","P9999"]`,
 		},
 		{
 			types:       Types{Type(1000)},

--- a/pipeline/type_test.go
+++ b/pipeline/type_test.go
@@ -277,6 +277,7 @@ func TestOpUnionMarshalJSONError(t *testing.T) {
 	_, err := json.Marshal(op)
 	require.Error(t, err)
 }
+
 func TestOpUnionMarshalJSONRoundtrip(t *testing.T) {
 	ops := []OpUnion{
 		{
@@ -394,7 +395,9 @@ func TestPipelineUnmarshalYAML(t *testing.T) {
     tags:
       - tag1
       - tag2
-    aggregation: Min,Max
+    aggregation:
+      - Min
+      - Max
 - rollup:
     newName: testRollup2
     tags:


### PR DESCRIPTION
cc @jskelcy @cw9 

This PR unmarshals aggregation types from YAML as lists.