### PR TITLE
Add ability to disallow multiple aggregation types

### DIFF
--- a/matcher/config.go
+++ b/matcher/config.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/m3db/m3cluster/client"
 	"github.com/m3db/m3cluster/kv"
-	"github.com/m3db/m3metrics/aggregation"
 	"github.com/m3db/m3metrics/filters"
 	"github.com/m3db/m3metrics/matcher/cache"
 	"github.com/m3db/m3metrics/metric/id"
@@ -39,16 +38,15 @@ import (
 
 // Configuration is config used to create a Matcher.
 type Configuration struct {
-	InitWatchTimeout      time.Duration                  `yaml:"initWatchTimeout"`
-	RulesKVConfig         kv.OverrideConfiguration       `yaml:"rulesKVConfig"`
-	NamespacesKey         string                         `yaml:"namespacesKey" validate:"nonzero"`
-	RuleSetKeyFmt         string                         `yaml:"ruleSetKeyFmt" validate:"nonzero"`
-	NamespaceTag          string                         `yaml:"namespaceTag" validate:"nonzero"`
-	DefaultNamespace      string                         `yaml:"defaultNamespace" validate:"nonzero"`
-	NameTagKey            string                         `yaml:"nameTagKey" validate:"nonzero"`
-	MatchRangePast        *time.Duration                 `yaml:"matchRangePast"`
-	SortedTagIteratorPool pool.ObjectPoolConfiguration   `yaml:"sortedTagIteratorPool"`
-	AggregationTypes      aggregation.TypesConfiguration `yaml:"aggregationTypes"`
+	InitWatchTimeout      time.Duration                `yaml:"initWatchTimeout"`
+	RulesKVConfig         kv.OverrideConfiguration     `yaml:"rulesKVConfig"`
+	NamespacesKey         string                       `yaml:"namespacesKey" validate:"nonzero"`
+	RuleSetKeyFmt         string                       `yaml:"ruleSetKeyFmt" validate:"nonzero"`
+	NamespaceTag          string                       `yaml:"namespaceTag" validate:"nonzero"`
+	DefaultNamespace      string                       `yaml:"defaultNamespace" validate:"nonzero"`
+	NameTagKey            string                       `yaml:"nameTagKey" validate:"nonzero"`
+	MatchRangePast        *time.Duration               `yaml:"matchRangePast"`
+	SortedTagIteratorPool pool.ObjectPoolConfiguration `yaml:"sortedTagIteratorPool"`
 }
 
 // NewNamespaces creates a matcher.Namespaces.
@@ -120,15 +118,10 @@ func (cfg *Configuration) NewOptions(
 		return m3.IsRollupID(name, tags, sortedTagIteratorPool)
 	}
 
-	aggTypeOpts, err := cfg.AggregationTypes.NewOptions(instrumentOpts)
-	if err != nil {
-		return nil, err
-	}
 	ruleSetOpts := rules.NewOptions().
 		SetTagsFilterOptions(tagsFilterOptions).
 		SetNewRollupIDFn(m3.NewRollupID).
-		SetIsRollupIDFn(isRollupIDFn).
-		SetAggregationTypesOptions(aggTypeOpts)
+		SetIsRollupIDFn(isRollupIDFn)
 
 	// Configure ruleset key function.
 	ruleSetKeyFn := func(namespace []byte) string {

--- a/matcher/namespaces.go
+++ b/matcher/namespaces.go
@@ -58,7 +58,14 @@ type Namespaces interface {
 
 	// ReverseMatch reverse matches the matching policies for a given id in a given namespace
 	// between [fromNanos, toNanos), taking into account the metric type and aggregation type for the given id.
-	ReverseMatch(namespace, id []byte, fromNanos, toNanos int64, mt metric.Type, at aggregation.Type) rules.MatchResult
+	ReverseMatch(
+		namespace, id []byte,
+		fromNanos, toNanos int64,
+		mt metric.Type,
+		at aggregation.Type,
+		isMultiAggregationTypesAllowed bool,
+		aggTypesOpts aggregation.TypesOptions,
+	) rules.MatchResult
 
 	// Close closes the namespaces.
 	Close()
@@ -183,12 +190,14 @@ func (n *namespaces) ReverseMatch(
 	fromNanos, toNanos int64,
 	mt metric.Type,
 	at aggregation.Type,
+	isMultiAggregationTypesAllowed bool,
+	aggTypesOpts aggregation.TypesOptions,
 ) rules.MatchResult {
 	ruleSet, exists := n.ruleSet(namespace)
 	if !exists {
 		return rules.EmptyMatchResult
 	}
-	return ruleSet.ReverseMatch(id, fromNanos, toNanos, mt, at)
+	return ruleSet.ReverseMatch(id, fromNanos, toNanos, mt, at, isMultiAggregationTypesAllowed, aggTypesOpts)
 }
 
 func (n *namespaces) ruleSet(namespace []byte) (RuleSet, bool) {

--- a/matcher/ruleset.go
+++ b/matcher/ruleset.go
@@ -167,6 +167,8 @@ func (r *ruleSet) ReverseMatch(
 	fromNanos, toNanos int64,
 	mt metric.Type,
 	at aggregation.Type,
+	isMultiAggregationTypesAllowed bool,
+	aggTypesOpts aggregation.TypesOptions,
 ) rules.MatchResult {
 	callStart := r.nowFn()
 	r.RLock()
@@ -175,7 +177,7 @@ func (r *ruleSet) ReverseMatch(
 		r.metrics.nilMatcher.Inc(1)
 		return rules.EmptyMatchResult
 	}
-	res := r.matcher.ReverseMatch(id, fromNanos, toNanos, mt, at)
+	res := r.matcher.ReverseMatch(id, fromNanos, toNanos, mt, at, isMultiAggregationTypesAllowed, aggTypesOpts)
 	r.RUnlock()
 	r.metrics.match.ReportSuccess(r.nowFn().Sub(callStart))
 	return res

--- a/rules/active_ruleset_test.go
+++ b/rules/active_ruleset_test.go
@@ -57,7 +57,6 @@ func TestActiveRuleSetCutoverTimesWithMappingRules(t *testing.T) {
 		testTagsFilterOptions(),
 		mockNewID,
 		nil,
-		aggregation.NewTypesOptions(),
 	)
 	expectedCutovers := []int64{5000, 8000, 10000, 15000, 20000, 22000, 24000, 30000, 34000, 35000, 100000}
 	require.Equal(t, expectedCutovers, as.cutoverTimesAsc)
@@ -71,7 +70,6 @@ func TestActiveRuleSetCutoverTimesWithRollupRules(t *testing.T) {
 		testTagsFilterOptions(),
 		mockNewID,
 		nil,
-		aggregation.NewTypesOptions(),
 	)
 	expectedCutovers := []int64{10000, 15000, 20000, 22000, 24000, 30000, 34000, 35000, 38000, 90000, 100000, 120000}
 	require.Equal(t, expectedCutovers, as.cutoverTimesAsc)
@@ -85,7 +83,6 @@ func TestActiveRuleSetCutoverTimesWithMappingRulesAndRollupRules(t *testing.T) {
 		testTagsFilterOptions(),
 		mockNewID,
 		nil,
-		aggregation.NewTypesOptions(),
 	)
 	expectedCutovers := []int64{5000, 8000, 10000, 15000, 20000, 22000, 24000, 30000, 34000, 35000, 38000, 90000, 100000, 120000}
 	require.Equal(t, expectedCutovers, as.cutoverTimesAsc)
@@ -496,7 +493,6 @@ func TestActiveRuleSetForwardMatchWithMappingRules(t *testing.T) {
 		testTagsFilterOptions(),
 		mockNewID,
 		nil,
-		aggregation.NewTypesOptions(),
 	)
 	for _, input := range inputs {
 		res := as.ForwardMatch(b(input.id), input.matchFrom, input.matchTo)
@@ -1265,7 +1261,6 @@ func TestActiveRuleSetForwardMatchWithRollupRules(t *testing.T) {
 		testTagsFilterOptions(),
 		mockNewID,
 		nil,
-		aggregation.NewTypesOptions(),
 	)
 	for _, input := range inputs {
 		res := as.ForwardMatch(b(input.id), input.matchFrom, input.matchTo)
@@ -2332,7 +2327,6 @@ func TestActiveRuleSetForwardMatchWithMappingRulesAndRollupRules(t *testing.T) {
 		testTagsFilterOptions(),
 		mockNewID,
 		nil,
-		aggregation.NewTypesOptions(),
 	)
 	for _, input := range inputs {
 		res := as.ForwardMatch(b(input.id), input.matchFrom, input.matchTo)
@@ -2746,6 +2740,8 @@ func TestActiveRuleSetReverseMatchWithMappingRulesForNonRollupID(t *testing.T) {
 		},
 	}
 
+	isMultiAggregationTypesAllowed := true
+	aggTypesOpts := aggregation.NewTypesOptions()
 	as := newActiveRuleSet(
 		0,
 		testMappingRules(t),
@@ -2753,10 +2749,9 @@ func TestActiveRuleSetReverseMatchWithMappingRulesForNonRollupID(t *testing.T) {
 		testTagsFilterOptions(),
 		mockNewID,
 		func([]byte, []byte) bool { return false },
-		aggregation.NewTypesOptions(),
 	)
 	for _, input := range inputs {
-		res := as.ReverseMatch(b(input.id), input.matchFrom, input.matchTo, input.metricType, input.aggregationType)
+		res := as.ReverseMatch(b(input.id), input.matchFrom, input.matchTo, input.metricType, input.aggregationType, isMultiAggregationTypesAllowed, aggTypesOpts)
 		require.Equal(t, input.expireAtNanos, res.expireAtNanos)
 		require.True(t, cmp.Equal(input.forExistingIDResult, res.ForExistingIDAt(0), testStagedMetadatasCmptOpts...))
 	}
@@ -2946,6 +2941,8 @@ func TestActiveRuleSetReverseMatchWithRollupRulesForRollupID(t *testing.T) {
 		},
 	}
 
+	isMultiAggregationTypesAllowed := true
+	aggTypesOpts := aggregation.NewTypesOptions()
 	as := newActiveRuleSet(
 		0,
 		nil,
@@ -2953,10 +2950,9 @@ func TestActiveRuleSetReverseMatchWithRollupRulesForRollupID(t *testing.T) {
 		testTagsFilterOptions(),
 		mockNewID,
 		func([]byte, []byte) bool { return true },
-		aggregation.NewTypesOptions(),
 	)
 	for _, input := range inputs {
-		res := as.ReverseMatch(b(input.id), input.matchFrom, input.matchTo, input.metricType, input.aggregationType)
+		res := as.ReverseMatch(b(input.id), input.matchFrom, input.matchTo, input.metricType, input.aggregationType, isMultiAggregationTypesAllowed, aggTypesOpts)
 		require.Equal(t, input.expireAtNanos, res.expireAtNanos)
 		require.Equal(t, input.forExistingIDResult, res.ForExistingIDAt(0))
 		require.Equal(t, 0, res.NumNewRollupIDs())

--- a/rules/options.go
+++ b/rules/options.go
@@ -21,7 +21,6 @@
 package rules
 
 import (
-	"github.com/m3db/m3metrics/aggregation"
 	"github.com/m3db/m3metrics/filters"
 	"github.com/m3db/m3metrics/metric/id"
 )
@@ -45,26 +44,17 @@ type Options interface {
 
 	// IsRollupIDFn returns the function that determines whether an id is a rollup id.
 	IsRollupIDFn() id.MatchIDFn
-
-	// SetAggregationTypesOptions sets the aggregation types options.
-	SetAggregationTypesOptions(v aggregation.TypesOptions) Options
-
-	// PolicyOptions returns the aggregation types options.
-	AggregationTypesOptions() aggregation.TypesOptions
 }
 
 type options struct {
 	tagsFilterOpts filters.TagsFilterOptions
 	newRollupIDFn  id.NewIDFn
 	isRollupIDFn   id.MatchIDFn
-	aggTypesOpts   aggregation.TypesOptions
 }
 
 // NewOptions creates a new set of options.
 func NewOptions() Options {
-	return &options{
-		aggTypesOpts: aggregation.NewTypesOptions(),
-	}
+	return &options{}
 }
 
 func (o *options) SetTagsFilterOptions(value filters.TagsFilterOptions) Options {
@@ -95,14 +85,4 @@ func (o *options) SetIsRollupIDFn(value id.MatchIDFn) Options {
 
 func (o *options) IsRollupIDFn() id.MatchIDFn {
 	return o.isRollupIDFn
-}
-
-func (o *options) SetAggregationTypesOptions(value aggregation.TypesOptions) Options {
-	opts := *o
-	opts.aggTypesOpts = value
-	return &opts
-}
-
-func (o *options) AggregationTypesOptions() aggregation.TypesOptions {
-	return o.aggTypesOpts
 }

--- a/rules/ruleset.go
+++ b/rules/ruleset.go
@@ -28,7 +28,6 @@ import (
 	"time"
 
 	"github.com/m3db/m3cluster/kv"
-	"github.com/m3db/m3metrics/aggregation"
 	merrors "github.com/m3db/m3metrics/errors"
 	"github.com/m3db/m3metrics/filters"
 	"github.com/m3db/m3metrics/generated/proto/rulepb"
@@ -146,7 +145,6 @@ type ruleSet struct {
 	tagsFilterOpts     filters.TagsFilterOptions
 	newRollupIDFn      metricID.NewIDFn
 	isRollupIDFn       metricID.MatchIDFn
-	aggTypesOpts       aggregation.TypesOptions
 }
 
 // NewRuleSetFromProto creates a new RuleSet from a proto object.
@@ -185,7 +183,6 @@ func NewRuleSetFromProto(version int, rs *rulepb.RuleSet, opts Options) (RuleSet
 		tagsFilterOpts:     tagsFilterOpts,
 		newRollupIDFn:      opts.NewRollupIDFn(),
 		isRollupIDFn:       opts.IsRollupIDFn(),
-		aggTypesOpts:       opts.AggregationTypesOptions(),
 	}, nil
 }
 
@@ -198,7 +195,6 @@ func NewEmptyRuleSet(namespaceName string, meta UpdateMetadata) MutableRuleSet {
 		tombstoned:   false,
 		mappingRules: make([]*mappingRule, 0),
 		rollupRules:  make([]*rollupRule, 0),
-		aggTypesOpts: aggregation.NewTypesOptions(),
 	}
 	rs.updateMetadata(meta)
 	return rs
@@ -230,7 +226,6 @@ func (rs *ruleSet) ActiveSet(timeNanos int64) Matcher {
 		rs.tagsFilterOpts,
 		rs.newRollupIDFn,
 		rs.isRollupIDFn,
-		rs.aggTypesOpts,
 	)
 }
 
@@ -343,7 +338,6 @@ func (rs *ruleSet) Clone() MutableRuleSet {
 		tagsFilterOpts:     rs.tagsFilterOpts,
 		newRollupIDFn:      rs.newRollupIDFn,
 		isRollupIDFn:       rs.isRollupIDFn,
-		aggTypesOpts:       rs.aggTypesOpts,
 	}
 }
 

--- a/rules/ruleset_test.go
+++ b/rules/ruleset_test.go
@@ -200,7 +200,6 @@ func TestRuleSetActiveSet(t *testing.T) {
 			rs.tagsFilterOpts,
 			rs.newRollupIDFn,
 			rs.isRollupIDFn,
-			rs.aggTypesOpts,
 		)
 		require.True(t, cmp.Equal(expected, as, testActiveRuleSetCmpOpts...))
 	}

--- a/rules/validator/config.go
+++ b/rules/validator/config.go
@@ -133,7 +133,7 @@ type metricTypesValidationConfiguration struct {
 	Allowed []metric.Type `yaml:"allowed"`
 
 	// Metric types that support multiple aggregation types.
-	MultiAggregationTypesEnabledFor *[]metric.Type `yaml:"MultiAggregationTypesEnabledFor"`
+	MultiAggregationTypesEnabledFor *[]metric.Type `yaml:"multiAggregationTypesEnabledFor"`
 }
 
 // NewMetricTypesFn creates a new metric types fn from the given configuration.

--- a/rules/validator/config.go
+++ b/rules/validator/config.go
@@ -72,6 +72,9 @@ func (c Configuration) newValidatorOptions(
 		SetMetricTypesFn(c.MetricTypes.NewMetricTypesFn()).
 		SetTagNameInvalidChars(toRunes(c.TagNameInvalidChars)).
 		SetMetricNameInvalidChars(toRunes(c.MetricNameInvalidChars))
+	if c.MetricTypes.MultiAggregationTypesEnabledFor != nil {
+		opts = opts.SetMultiAggregationTypesEnabledFor(*c.MetricTypes.MultiAggregationTypesEnabledFor)
+	}
 	if c.Policies.DefaultAllowed.StoragePolicies != nil {
 		opts = opts.SetDefaultAllowedStoragePolicies(*c.Policies.DefaultAllowed.StoragePolicies)
 	}
@@ -128,6 +131,9 @@ type metricTypesValidationConfiguration struct {
 
 	// Allowed metric types.
 	Allowed []metric.Type `yaml:"allowed"`
+
+	// Metric types that support multiple aggregation types.
+	MultiAggregationTypesEnabledFor *[]metric.Type `yaml:"MultiAggregationTypesEnabledFor"`
 }
 
 // NewMetricTypesFn creates a new metric types fn from the given configuration.
@@ -171,8 +177,8 @@ type policiesOverrideConfiguration struct {
 // policiesConfiguration is the configuration for storage policies and aggregation types.
 type policiesConfiguration struct {
 	StoragePolicies               *[]policy.StoragePolicy `yaml:"storagePolicies"`
-	FirstLevelAggregationTypes    *[]aggregation.Type     `yaml:"firstLevelAggregationTypes"`
-	NonFirstLevelAggregationTypes *[]aggregation.Type     `yaml:"nonFirstLevelAggregationTypes"`
+	FirstLevelAggregationTypes    *aggregation.Types      `yaml:"firstLevelAggregationTypes"`
+	NonFirstLevelAggregationTypes *aggregation.Types      `yaml:"nonFirstLevelAggregationTypes"`
 }
 
 func toRunes(s string) []rune {

--- a/rules/validator/options.go
+++ b/rules/validator/options.go
@@ -158,6 +158,7 @@ type options struct {
 // NewOptions create a new set of validator options.
 func NewOptions() Options {
 	return &options{
+		multiAggregationTypesEnableFor:   map[metric.Type]struct{}{metric.TimerType: struct{}{}},
 		maxTransformationDerivativeOrder: defaultMaxTransformationDerivativeOrder,
 		maxRollupLevels:                  defaultMaxRollupLevels,
 		namespaceValidator:               static.NewNamespaceValidator(static.Valid),

--- a/rules/validator/options.go
+++ b/rules/validator/options.go
@@ -80,6 +80,10 @@ type Options interface {
 	// MetricTypesFn returns the metric types function.
 	MetricTypesFn() MetricTypesFn
 
+	// SetMultiAggregationTypesEnabledFor sets the list of metric types that support
+	// multiple aggregation types.
+	SetMultiAggregationTypesEnabledFor(value []metric.Type) Options
+
 	// SetRequiredRollupTags sets the list of required rollup tags.
 	SetRequiredRollupTags(value []string) Options
 
@@ -118,6 +122,9 @@ type Options interface {
 	// given metric type.
 	IsAllowedStoragePolicyFor(t metric.Type, p policy.StoragePolicy) bool
 
+	// IsMultiAggregationTypesEnabledFor checks if a metric type supports multiple aggregation types.
+	IsMultiAggregationTypesEnabledFor(t metric.Type) bool
+
 	// IsAllowedFirstLevelAggregationTypeFor determines whether a given aggregation type is allowed
 	// as the first-level aggregation for the given metric type.
 	IsAllowedFirstLevelAggregationTypeFor(t metric.Type, aggType aggregation.Type) bool
@@ -139,6 +146,7 @@ type options struct {
 	defaultAllowedFirstLevelAggregationTypes    map[aggregation.Type]struct{}
 	defaultAllowedNonFirstLevelAggregationTypes map[aggregation.Type]struct{}
 	metricTypesFn                               MetricTypesFn
+	multiAggregationTypesEnableFor              map[metric.Type]struct{}
 	requiredRollupTags                          []string
 	maxTransformationDerivativeOrder            int
 	maxRollupLevels                             int
@@ -211,6 +219,11 @@ func (o *options) MetricTypesFn() MetricTypesFn {
 	return o.metricTypesFn
 }
 
+func (o *options) SetMultiAggregationTypesEnabledFor(value []metric.Type) Options {
+	o.multiAggregationTypesEnableFor = toMetricTypeSet(value)
+	return o
+}
+
 func (o *options) SetRequiredRollupTags(value []string) Options {
 	requiredRollupTags := make([]string, len(value))
 	copy(requiredRollupTags, value)
@@ -275,6 +288,11 @@ func (o *options) IsAllowedStoragePolicyFor(t metric.Type, p policy.StoragePolic
 	return found
 }
 
+func (o *options) IsMultiAggregationTypesEnabledFor(t metric.Type) bool {
+	_, exists := o.multiAggregationTypesEnableFor[t]
+	return exists
+}
+
 func (o *options) IsAllowedFirstLevelAggregationTypeFor(t metric.Type, aggType aggregation.Type) bool {
 	if metadata, exists := o.metadatasByType[t]; exists {
 		_, found := metadata.allowedFirstLevelAggTypes[aggType]
@@ -316,6 +334,14 @@ func toAggregationTypeSet(aggTypes aggregation.Types) map[aggregation.Type]struc
 	m := make(map[aggregation.Type]struct{}, len(aggTypes))
 	for _, t := range aggTypes {
 		m[t] = struct{}{}
+	}
+	return m
+}
+
+func toMetricTypeSet(metricTypes []metric.Type) map[metric.Type]struct{} {
+	m := make(map[metric.Type]struct{}, len(metricTypes))
+	for _, mt := range metricTypes {
+		m[mt] = struct{}{}
 	}
 	return m
 }


### PR DESCRIPTION
cc @cw9 @jeromefroe 

This PR adds ability to disallow multiple aggregation types for certain metric types and for those metric types, do not filter the pipelines by aggregation types during reverse matching.