### PR TITLE
perSecond returns empty datapoint for negative rate

### DIFF
--- a/transformation/binary.go
+++ b/transformation/binary.go
@@ -29,10 +29,19 @@ const (
 	nanosPerSecond = time.Second / time.Nanosecond
 )
 
+// perSecond computes the derivative between consecutive datapoints, taking into
+// account the time interval between the values.
+// * It skips NaN values.
+// * It assumes the timestamps are monotonically increasing, and values are non-decreasing.
+//   If either of the two conditions is not met, an empty datapoint is returned.
 func perSecond(prev, curr Datapoint) Datapoint {
 	if prev.TimeNanos >= curr.TimeNanos || math.IsNaN(prev.Value) || math.IsNaN(curr.Value) {
 		return emptyDatapoint
 	}
-	rate := (curr.Value - prev.Value) * float64(nanosPerSecond) / float64(curr.TimeNanos-prev.TimeNanos)
+	diff := curr.Value - prev.Value
+	if diff < 0 {
+		return emptyDatapoint
+	}
+	rate := diff * float64(nanosPerSecond) / float64(curr.TimeNanos-prev.TimeNanos)
 	return Datapoint{TimeNanos: curr.TimeNanos, Value: rate}
 }

--- a/transformation/binary_test.go
+++ b/transformation/binary_test.go
@@ -42,8 +42,8 @@ func TestPerSecond(t *testing.T) {
 		},
 		{
 			prev:     Datapoint{TimeNanos: time.Unix(1230, 0).UnixNano(), Value: 25},
-			curr:     Datapoint{TimeNanos: time.Unix(1240, 0).UnixNano(), Value: 20},
-			expected: Datapoint{TimeNanos: time.Unix(1240, 0).UnixNano(), Value: -0.5},
+			curr:     Datapoint{TimeNanos: time.Unix(1240, 0).UnixNano(), Value: 30},
+			expected: Datapoint{TimeNanos: time.Unix(1240, 0).UnixNano(), Value: 0.5},
 		},
 		{
 			prev:        Datapoint{TimeNanos: time.Unix(1230, 0).UnixNano(), Value: 25},
@@ -60,6 +60,12 @@ func TestPerSecond(t *testing.T) {
 		{
 			prev:        Datapoint{TimeNanos: time.Unix(1230, 0).UnixNano(), Value: 20},
 			curr:        Datapoint{TimeNanos: time.Unix(1240, 0).UnixNano(), Value: math.NaN()},
+			expectedNaN: true,
+			expected:    emptyDatapoint,
+		},
+		{
+			prev:        Datapoint{TimeNanos: time.Unix(1230, 0).UnixNano(), Value: 30},
+			curr:        Datapoint{TimeNanos: time.Unix(1240, 0).UnixNano(), Value: 20},
 			expectedNaN: true,
 			expected:    emptyDatapoint,
 		},


### PR DESCRIPTION
cc @jeromefroe @cw9 

This PR adds logic so that `perSecond` returns an empty datapoint if the computed derivative is negative. This is consistent with the graphite [perSecond](https://graphite.readthedocs.io/en/latest/functions.html#graphite.render.functions.perSecond) function semantics as well as `rate` function semantics in prometheus.