### PR TITLE
Return a typed error when rules store value not found.

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -42,3 +42,10 @@ type StaleDataError string
 // NewStaleDataError creates a new version mismatch error.
 func NewStaleDataError(str string) error { return StaleDataError(str) }
 func (e StaleDataError) Error() string   { return string(e) }
+
+// NotFoundError is returned when fetching value from rule store that does not exist.
+type NotFoundError string
+
+// NewNotFoundError creates a new not found error.
+func NewNotFoundError(str string) error { return NotFoundError(str) }
+func (e NotFoundError) Error() string   { return string(e) }

--- a/rules/store/kv/store_test.go
+++ b/rules/store/kv/store_test.go
@@ -393,6 +393,14 @@ func TestReadNamespaces(t *testing.T) {
 	require.NotNil(t, nss.Namespaces)
 }
 
+func TestReadNamespaceNotFound(t *testing.T) {
+	s := testStore()
+	defer s.Close()
+
+	_, err := s.ReadNamespaces()
+	require.IsType(t, merrors.NewNotFoundError(""), err)
+}
+
 func TestReadNamespacesError(t *testing.T) {
 	s := testStore()
 	defer s.Close()
@@ -413,6 +421,14 @@ func TestReadRuleSet(t *testing.T) {
 	rs, err := s.ReadRuleSet(testNamespace)
 	require.NoError(t, err)
 	require.NotNil(t, rs)
+}
+
+func TestReadRuleSetNotFound(t *testing.T) {
+	s := testStore()
+	defer s.Close()
+
+	_, err := s.ReadRuleSet(testNamespace)
+	require.IsType(t, merrors.NewNotFoundError(""), err)
 }
 
 func TestReadRuleSetError(t *testing.T) {
@@ -642,6 +658,6 @@ type mockValidator struct {
 	validateFn validateFn
 }
 
-func (v *mockValidator) Validate(rs rules.RuleSet) error                { return v.validateFn(rs) }
+func (v *mockValidator) Validate(rs rules.RuleSet) error              { return v.validateFn(rs) }
 func (v *mockValidator) ValidateSnapshot(snapshot view.RuleSet) error { return nil }
-func (v *mockValidator) Close()                                         {}
+func (v *mockValidator) Close()                                       {}


### PR DESCRIPTION
m3metrics has a number of typed errors that are returned so downstream applications can conditionally check them. When using the rules store a special type is now returned if the value is not found in KV. KV is the only implementation of the rules store currently.